### PR TITLE
Handling of Converters exteded

### DIFF
--- a/src/fitnesse/slim/ConverterSupport.java
+++ b/src/fitnesse/slim/ConverterSupport.java
@@ -4,12 +4,13 @@ import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
 import java.util.List;
 
+import fitnesse.slim.converters.ConverterRegistry;
 import fitnesse.slim.converters.PropertyEditorConverter;
 
 class ConverterSupport {
 
   public static Converter getConverter(Class<?> k) {
-    Converter c = Slim.converters.get(k);
+    Converter c = ConverterRegistry.getConverterForClass(k);
     if (c != null)
       return c;
     PropertyEditor pe = PropertyEditorManager.findEditor(k);

--- a/src/fitnesse/slim/Slim.java
+++ b/src/fitnesse/slim/Slim.java
@@ -2,13 +2,5 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class Slim {
-  static Map<Class<?>, Converter> converters = new HashMap<Class<?>, Converter>();
-
-  public static void addConverter(Class<?> k, Converter converter) {
-    converters.put(k, converter);
-  }
 }

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -30,24 +30,6 @@ public class StatementExecutor implements StatementExecutorInterface {
   private String lastActor;
 
   public StatementExecutor() {
-    Slim.addConverter(void.class, new VoidConverter());
-    Slim.addConverter(String.class, new StringConverter());
-    Slim.addConverter(int.class, new IntConverter());
-    Slim.addConverter(double.class, new DoubleConverter());
-    Slim.addConverter(Integer.class, new IntConverter());
-    Slim.addConverter(Double.class, new DoubleConverter());
-    Slim.addConverter(char.class, new CharConverter());
-    Slim.addConverter(boolean.class, new BooleanConverter());
-    Slim.addConverter(Boolean.class, new BooleanConverter());
-    Slim.addConverter(Date.class, new DateConverter());
-    Slim.addConverter(List.class, new ListConverter());
-    Slim.addConverter(Integer[].class, new IntegerArrayConverter());
-    Slim.addConverter(int[].class, new IntegerArrayConverter());
-    Slim.addConverter(String[].class, new StringArrayConverter());
-    Slim.addConverter(boolean[].class, new BooleanArrayConverter());
-    Slim.addConverter(Boolean[].class, new BooleanArrayConverter());
-    Slim.addConverter(double[].class, new DoubleArrayConverter());
-    Slim.addConverter(Double[].class, new DoubleArrayConverter());
     PropertyEditorManager.registerEditor(Map.class, MapEditor.class);
 
     executorChain.add(new FixtureMethodExecutor(instances));

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -1,0 +1,47 @@
+package fitnesse.slim.converters;
+
+import fitnesse.slim.Converter;
+
+import java.util.*;
+
+public class ConverterRegistry {
+
+  static Map<Class<?>, Converter> converters = new HashMap<Class<?>, Converter>();
+
+  static {
+    addStandardConverters();
+  }
+
+  protected static void addStandardConverters() {
+    addConverter(void.class, new VoidConverter());
+    addConverter(String.class, new StringConverter());
+    addConverter(int.class, new IntConverter());
+    addConverter(double.class, new DoubleConverter());
+    addConverter(Integer.class, new IntConverter());
+    addConverter(Double.class, new DoubleConverter());
+    addConverter(char.class, new CharConverter());
+    addConverter(boolean.class, new BooleanConverter());
+    addConverter(Boolean.class, new BooleanConverter());
+    addConverter(Date.class, new DateConverter());
+    addConverter(List.class, new ListConverter());
+    addConverter(Integer[].class, new IntegerArrayConverter());
+    addConverter(int[].class, new IntegerArrayConverter());
+    addConverter(String[].class, new StringArrayConverter());
+    addConverter(boolean[].class, new BooleanArrayConverter());
+    addConverter(Boolean[].class, new BooleanArrayConverter());
+    addConverter(double[].class, new DoubleArrayConverter());
+    addConverter(Double[].class, new DoubleArrayConverter());
+  }
+
+  public static Converter getConverterForClass(Class<?> clazz) {
+    return converters.get(clazz);
+  }
+
+  public static void addConverter(Class<?> clazz, Converter converter) {
+    converters.put(clazz, converter);
+  }
+
+  public static Map<Class<?>, Converter> getConverters() {
+    return Collections.unmodifiableMap(converters);
+  }
+}

--- a/src/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/src/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -1,0 +1,41 @@
+package fitnesse.slim.converters;
+
+import fitnesse.slim.Converter;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+
+public class ConverterRegistryTest {
+
+  @Test
+  public void checkInitialisationSuccessful() {
+    Converter converter = ConverterRegistry.getConverterForClass(Date.class);
+    Date converted = (Date) converter.fromString("27-FEB-2012");
+    assertNotNull(converted);
+  }
+
+  @Test
+  public void useConverterFromCustomizing() {
+    ConverterRegistry.addConverter(CustomClass.class, new CustomConverter());
+
+    Converter converter = ConverterRegistry.getConverterForClass(CustomClass.class);
+    assertEquals("customConverter", converter.toString(new CustomClass()));
+  }
+
+  static class CustomClass {
+
+  }
+
+  static class CustomConverter implements Converter {
+
+    public String toString(Object o) {
+      return "customConverter";
+    }
+
+    public Object fromString(String arg) {
+      return "customConverter";
+    }
+  }
+}


### PR DESCRIPTION
Hello,

I changed the handling of converters to allow the customizer to choose which kind of converters are available.
We want to use JodaTime instanes seamlessly.
- To make this easier I created a CinverterRegistry where the customizing developer can easily set the needed Converter.
- I reduced the coupling between the StatementExecutor and the whole converter package

Hope you approve this. Thank you very much in advance.

Regards,
Marco
