### PR TITLE
Untitled

### DIFF
--- a/src/fitnesse/responders/run/formatters/SuiteExecutionReportFormatter.java
+++ b/src/fitnesse/responders/run/formatters/SuiteExecutionReportFormatter.java
@@ -60,6 +60,8 @@ public class SuiteExecutionReportFormatter extends BaseFormatter {
     referenceToCurrentTest.setRunTimeInMillis(timeMeasurement.elapsed());
     suiteExecutionReport.addPageHistoryReference(referenceToCurrentTest);
     suiteExecutionReport.tallyPageCounts(testSummary);
+	failCount+=testSummary.wrong;
+	failCount+=testSummary.exceptions; 
   }
 
   public List<SuiteExecutionReport.PageHistoryReference> getPageHistoryReferences() {

--- a/src/fitnesse/responders/run/formatters/SuiteExecutionReportFormatterTest.java
+++ b/src/fitnesse/responders/run/formatters/SuiteExecutionReportFormatterTest.java
@@ -54,4 +54,28 @@ public class SuiteExecutionReportFormatterTest {
     assertThat(formatter.suiteExecutionReport.getTotalRunTimeInMillis(), 
         is(totalTimeMeasurement.elapsed()));
   }
+  
+  @Test
+  public void testCompleteShouldSetFailedCount() throws Exception {
+    FitNesseContext context = mock(FitNesseContext.class);
+    WikiPage page = new WikiPageDummy("name", "content");
+    SuiteExecutionReportFormatter formatter = new SuiteExecutionReportFormatter(context, page);
+    
+    TimeMeasurement timeMeasurement = mock(TimeMeasurement.class);
+    when(timeMeasurement.startedAt()).thenReturn(65L);
+    when(timeMeasurement.elapsed()).thenReturn(2L);
+    formatter.newTestStarted(page, timeMeasurement);
+    
+    when(timeMeasurement.elapsed()).thenReturn(99L);
+    TestSummary testSummary = new TestSummary(4,2,7,3);
+    formatter.testComplete(page, testSummary, timeMeasurement);
+	
+	assertThat(formatter.failCount, is(5));
+	
+    formatter.allTestingComplete(timeMeasurement);
+	
+    assertThat(BaseFormatter.finalErrorCount, is(5));
+    
+  }
+
 }


### PR DESCRIPTION
Set failedCount in SuiteExecutionReportFormatter.testComplete so that when run suite test from ant
run suite test from ant it will return correct failed test count (and stop with "Build failed").
