### PR TITLE
#24 allow SymbolTypes to represent more than one paths. A new interface i

### DIFF
--- a/src/fitnesse/wikitext/parser/Path.java
+++ b/src/fitnesse/wikitext/parser/Path.java
@@ -3,10 +3,9 @@ package fitnesse.wikitext.parser;
 import util.Maybe;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.Arrays;
 
-public class Path extends SymbolType implements Rule, PathsCollector {
+public class Path extends SymbolType implements Rule, PathsProvider {
     public static final Path symbolType = new Path();
 
     public Path() {
@@ -16,10 +15,8 @@ public class Path extends SymbolType implements Rule, PathsCollector {
         htmlTranslation(new HtmlBuilder("span").body(0, "classpath: ").attribute("class", "meta").inline());
     }
 
-    public Collection<String> collectPaths(Translator translator,  Symbol symbol) {
-        List<String> paths = new ArrayList<String>();
-        paths.add(translator.translate(symbol.childAt(0)));
-        return paths;
+    public Collection<String> providePaths(Translator translator, Symbol symbol) {
+        return Arrays.asList(translator.translate(symbol.childAt(0)));
     }
 
     public Maybe<Symbol> parse(Symbol current, Parser parser) {

--- a/src/fitnesse/wikitext/parser/Paths.java
+++ b/src/fitnesse/wikitext/parser/Paths.java
@@ -20,11 +20,8 @@ public class Paths {
         public List<String> result = new ArrayList<String>();
 
         public boolean visit(Symbol node) {
-            if (node.getType() instanceof PathsCollector) {
-                result.addAll(((PathsCollector) node.getType()).collectPaths(translator, node));
-            } else if (node.isType(Path.symbolType)) {
-                // backward compatibility with external extensions
-                result.add(translator.translate(node.childAt(0)));
+            if (node.getType() instanceof PathsProvider) {
+                result.addAll(((PathsProvider) node.getType()).providePaths(translator, node));
             }
             return true;
         }

--- a/src/fitnesse/wikitext/parser/PathsProvider.java
+++ b/src/fitnesse/wikitext/parser/PathsProvider.java
@@ -7,12 +7,12 @@ import java.util.Collection;
  *
  * Useful in particular when one needs to generate a list of paths from a single symbol, with optional translation.
  */
-public interface PathsCollector {
+public interface PathsProvider {
     /**
      * Return the collection of paths represented by the given symbol
      * @param translator that optionally translates the symbols to a valid paths
      * @param symbol the symbol to collect the paths from
      * @return the collection of paths to be added to the classpath
      */
-    Collection<String> collectPaths(Translator translator, Symbol symbol);
+    Collection<String> providePaths(Translator translator, Symbol symbol);
 }


### PR DESCRIPTION
#24 allow SymbolTypes to represent more than one paths. A new interface is added for those SymbolTypes that want to generate more than one paths

This solves issue #24 for us. Please comment is this acceptable or not. 
