### PR TITLE
maven pom.xml cleanups.

### DIFF
--- a/changeLog.txt
+++ b/changeLog.txt
@@ -1,3 +1,12 @@
+20110923 Dan Rollo
+ maven pom.xml cleanups:
+ * Remove unneeded default <groupId> tags.
+ * Add plugin <version> tags.
+ * Add explicit, platform independent UTF-8 file encoding via property: project.build.sourceEncoding
+ * Remove dependency on obsolete fitlibrary (the required classes are already in the source tree).
+ * Replace <system> dependency on json with the latest published json artifact.
+ * Remove unneeded ${basedir} from <sourceDirectory> tag value.
+
 20081128 UB
  * Added &debug flag to TestResponder url.  This forces the test to run ''inside'' the fitnesse process.  If you are running fitnesse in a debugger, you can breakpoint your fixtures.
  * Symbols can be java properties or environment variables.  Symbols first, env variables second, java properties third.

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <properties>
+    <!-- specify default text file encoding. Fixes warning:
+    [WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent! -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -58,34 +63,27 @@
       <version>1.6.2</version>
     </dependency>
     <dependency>
-      <groupId>org.fitnesse</groupId>
-      <artifactId>fitlibrary</artifactId>
-      <version>20080812</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>1.0</version>
-      <scope>system</scope>
-      <systemPath>${basedir}/lib/json.jar</systemPath>
+      <version>20090211</version>
     </dependency>
   </dependencies>
   <build>
-    <sourceDirectory>${basedir}/src</sourceDirectory>
+    <sourceDirectory>src</sourceDirectory>
     <outputDirectory>classes</outputDirectory>
     <testOutputDirectory>classes</testOutputDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.9</version>
         <configuration>
           <includes>
             <include>**/*Test.java</include>
@@ -93,8 +91,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
- Remove unneeded default <groupId> tags.
- Add plugin <version> tags.
- Add explicit, platform independent UTF-8 file encoding via property: project.build.sourceEncoding
- Remove dependency on obsolete fitlibrary (the required classes are already in the source tree).
- Replace <system> dependency on json with the latest published json artifact.
- Remove unneeded ${basedir} from <sourceDirectory> tag value.

I'm trying to help make it easier to do a new release of the fitnesse jar into the maven repo. Are there any other things I should focus on?
