### PR TITLE
Custom fixture loader ability

### DIFF
--- a/src/fit/FixtureLoaderInterface.java
+++ b/src/fit/FixtureLoaderInterface.java
@@ -1,0 +1,6 @@
+package fit;
+
+public interface FixtureLoaderInterface {
+  public Fixture disgraceThenLoad(String tableName) throws Throwable;
+  public void addPackageToPath(String name);
+}

--- a/src/fit/FixtureLoaderTest.java
+++ b/src/fit/FixtureLoaderTest.java
@@ -34,4 +34,56 @@ public class FixtureLoaderTest extends TestCase {
     Fixture fixture = fixtureLoader.disgraceThenLoad("the third");
     assertEquals("fit.TheThirdFixture", fixture.getClass().getName());
   }
+
+  public static class CustomFixtureLoader implements FixtureLoaderInterface {
+    @Override
+    public Fixture disgraceThenLoad(String tableName) throws Throwable {
+      return null;
+    }
+
+    @Override
+    public void addPackageToPath(String name) {
+    }
+  }
+
+  public void testCustomFixtureLoader() throws Throwable {
+/*
+    // Due to some error, couldn't manage to execute System.setProperty for unit tests
+
+    String oldFixtureLoader = System.getProperty(FixtureLoader.class.getName());
+
+    FixtureLoader.setInstance(null);
+    System.setProperty(FixtureLoader.class.getName(), null);
+    assertEquals(FixtureLoader.instance().getClass(), FixtureLoader.class);
+
+    FixtureLoader.setInstance(null);
+    System.setProperty(FixtureLoader.class.getName(), "");
+    assertEquals(FixtureLoader.instance().getClass(), FixtureLoader.class);
+
+    FixtureLoader.setInstance(null);
+    System.setProperty(FixtureLoader.class.getName(), "1_am_sure_there_is_no_class_with_this_name");
+    assertEquals(FixtureLoader.instance().getClass(), FixtureLoader.class);
+
+    FixtureLoader.setInstance(null);
+    System.setProperty(FixtureLoader.class.getName(), FixtureLoader.class.getName());
+    assertEquals(FixtureLoader.instance().getClass(), FixtureLoader.class);
+ 
+    FixtureLoader.setInstance(null);
+    System.setProperty(FixtureLoader.class.getName(), CustomFixtureLoader.class.getName());
+    assertEquals(FixtureLoader.instance().getClass(), CustomFixtureLoader.class);
+
+    System.setProperty(FixtureLoader.class.getName(), oldFixtureLoader);
+*/
+    FixtureLoader.setInstance(null);
+    assertEquals(FixtureLoader.instanceForClassName(null).getClass(), FixtureLoader.class);
+    FixtureLoader.setInstance(null);
+    assertEquals(FixtureLoader.instanceForClassName("").getClass(), FixtureLoader.class);
+    FixtureLoader.setInstance(null);
+    assertEquals(FixtureLoader.instanceForClassName("1_am_sure_there_is_no_class_with_this_name").getClass(), FixtureLoader.class);
+    FixtureLoader.setInstance(null);
+    assertEquals(FixtureLoader.instanceForClassName(FixtureLoader.class.getName()).getClass(), FixtureLoader.class);
+    FixtureLoader.setInstance(null);
+    assertEquals(FixtureLoader.instanceForClassName(CustomFixtureLoader.class.getName()).getClass(), CustomFixtureLoader.class);
+  }
+
 }


### PR DESCRIPTION
Fitnesse's way of creating the fixture instances can be customized with this change. Old way was creating instances in a fixed way, i.e. calling its no arg constructor, which wasn't suitable for utilizing frameworks such as Guice. Now an arbitrary fixture loader (a class which implements the newly added FixtureLoaderInterface) can be used by setting "fit.FixtureLoader" system property (e.g. with JVM parameter -Dfit,FixtureLoader=CustomFixtureLoaderClass). The original behavior is not affected with this change. If no arguments is set, Fitnesse uses the default fixture loader. I have done the change so that no other class in the repo is affected.

Need for this change has emerged, when we needed to use Guice framework in my company for its depencency injection and aspect oriented abilities. I will commit a Guice plugin in a short term.

Best Regards
Ugur Zongur
