### PR TITLE
performance: use narrower read-only interface to page data 

### DIFF
--- a/src/fitnesse/components/ClassPathBuilder.java
+++ b/src/fitnesse/components/ClassPathBuilder.java
@@ -128,6 +128,6 @@ public class ClassPathBuilder extends InheritedItemBuilder {
   }
 
   protected List<String> getItemsFromPage(WikiPage page) {
-    return page.getData().getClasspaths();
+    return page.readPageData().getClasspaths();
   }
 }

--- a/src/fitnesse/responders/run/MultipleTestsRunner.java
+++ b/src/fitnesse/responders/run/MultipleTestsRunner.java
@@ -89,7 +89,7 @@ public class MultipleTestsRunner implements TestSystemListener, Stoppable {
   
   private boolean useManualStartForTestSystem() {
     if (isRemoteDebug) {
-      String useManualStart = page.getData().getVariable("MANUALLY_START_TEST_RUNNER_ON_DEBUG");
+      String useManualStart = page.readPageData().getVariable("MANUALLY_START_TEST_RUNNER_ON_DEBUG");
       return (useManualStart != null && useManualStart.toLowerCase().equals("true"));
     }
     return false;

--- a/src/fitnesse/responders/run/SuiteContentsFinder.java
+++ b/src/fitnesse/responders/run/SuiteContentsFinder.java
@@ -8,13 +8,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-import fitnesse.wiki.PageCrawler;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.PathParser;
-import fitnesse.wiki.VirtualCouplingExtension;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPageDummy;
-import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.*;
 
 public class SuiteContentsFinder {
 
@@ -58,6 +52,7 @@ public class SuiteContentsFinder {
 
   public LinkedList<WikiPage> getAllPagesToRunForThisSuite() {
     String content = pageToRun.getData().getHtml();
+    //todo perf: all pages html parsed here?
     if (SuiteSpecificationRunner.isASuiteSpecificationsPage(content)) {
       SuiteSpecificationRunner runner = new SuiteSpecificationRunner(wikiRootPage);
       if (runner.getPageListFromPageContent(content))
@@ -137,7 +132,7 @@ public class SuiteContentsFinder {
   }
 
   private void addXrefPages(List<WikiPage> pages, WikiPage thePage) {
-    PageData data = thePage.getData();
+    PageDataRead data = thePage.readPageData();
     List<String> pageReferences = data.getXrefPages();
     PageCrawler crawler = thePage.getPageCrawler();
     WikiPagePath testPagePath = crawler.getFullPath(thePage);

--- a/src/fitnesse/responders/run/TestSystem.java
+++ b/src/fitnesse/responders/run/TestSystem.java
@@ -4,6 +4,7 @@ package fitnesse.responders.run;
 
 import fitnesse.responders.PageFactory;
 import fitnesse.wiki.PageData;
+import fitnesse.wiki.PageDataRead;
 import fitnesse.wiki.WikiPage;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ public abstract class TestSystem implements TestSystemListener {
     return command;
   }
 
-  private static String getRemoteDebugCommandPattern(PageData pageData) {
+  private static String getRemoteDebugCommandPattern(PageDataRead pageData) {
     String testRunner = pageData.getVariable("REMOTE_DEBUG_COMMAND");
     if (testRunner == null) {
       testRunner = pageData.getVariable(PageData.COMMAND_PATTERN);
@@ -56,14 +57,14 @@ public abstract class TestSystem implements TestSystemListener {
     return testRunner;
   }
 
-  private static String getNormalCommandPattern(PageData pageData) {
+  private static String getNormalCommandPattern(PageDataRead pageData) {
     String testRunner = pageData.getVariable(PageData.COMMAND_PATTERN);
     if (testRunner == null)
       testRunner = DEFAULT_COMMAND_PATTERN;
     return testRunner;
   }
 
-  private static String getCommandPattern(PageData pageData, boolean isRemoteDebug) {
+  private static String getCommandPattern(PageDataRead pageData, boolean isRemoteDebug) {
     if (isRemoteDebug)
       return getRemoteDebugCommandPattern(pageData);
     else
@@ -92,14 +93,14 @@ public abstract class TestSystem implements TestSystemListener {
     return String.format("%s:%s", testSystemName, testRunner);
   }
 
-  private static String getTestSystem(PageData data) {
+  private static String getTestSystem(PageDataRead data) {
     String testSystemName = data.getVariable("TEST_SYSTEM");
     if (testSystemName == null)
       return "fit";
     return testSystemName;
   }
 
-  public static String getPathSeparator(PageData pageData) {
+  public static String getPathSeparator(PageDataRead pageData) {
     String separator = pageData.getVariable(PageData.PATH_SEPARATOR);
     if (separator == null)
       separator = (String) System.getProperties().get("path.separator");
@@ -127,7 +128,7 @@ public abstract class TestSystem implements TestSystemListener {
 
   public abstract void start() throws IOException;
 
-  private static String getTestRunner(PageData pageData, boolean isRemoteDebug) {
+  private static String getTestRunner(PageDataRead pageData, boolean isRemoteDebug) {
     if (isRemoteDebug)
       return getTestRunnerDebug(pageData);
     else
@@ -135,7 +136,7 @@ public abstract class TestSystem implements TestSystemListener {
   }
 
   
-  private static String getTestRunnerDebug(PageData data) {
+  private static String getTestRunnerDebug(PageDataRead data) {
     String program = data.getVariable("REMOTE_DEBUG_RUNNER");
     if (program == null) {
       program = getTestRunnerNormal(data);
@@ -146,14 +147,14 @@ public abstract class TestSystem implements TestSystemListener {
     return program;
   }
 
-  public static String getTestRunnerNormal(PageData data) {
+  public static String getTestRunnerNormal(PageDataRead data) {
     String program = data.getVariable(PageData.TEST_RUNNER);
     if (program == null)
       program = defaultTestRunner(data);
     return program;
   }
 
-  static String defaultTestRunner(PageData data) {
+  static String defaultTestRunner(PageDataRead data) {
     String testSystemType = getTestSystemType(getTestSystem(data));
     if ("slim".equalsIgnoreCase(testSystemType))
       return "fitnesse.slim.SlimService";
@@ -169,7 +170,7 @@ public abstract class TestSystem implements TestSystemListener {
 
   public abstract String runTestsAndGenerateHtml(PageData pageData) throws IOException, InterruptedException;
 
-  public static Descriptor getDescriptor(PageData data, PageFactory pageFactory, boolean isRemoteDebug) {
+  public static Descriptor getDescriptor(PageDataRead data, PageFactory pageFactory, boolean isRemoteDebug) {
     String testSystemName = getTestSystem(data);
     String testRunner = getTestRunner(data, isRemoteDebug);
     String commandPattern = getCommandPattern(data, isRemoteDebug);
@@ -178,7 +179,7 @@ public abstract class TestSystem implements TestSystemListener {
   }
 
   protected Map<String, String> createClasspathEnvironment(String classPath) {
-    String classpathProperty = page.getData().getVariable("CLASSPATH_PROPERTY");
+    String classpathProperty = page.readPageData().getVariable("CLASSPATH_PROPERTY");
     Map<String, String> environmentVariables = null;
     if (classpathProperty != null) {
       environmentVariables = Collections.singletonMap(classpathProperty, classPath);

--- a/src/fitnesse/responders/run/slimResponder/HtmlSlimTestSystem.java
+++ b/src/fitnesse/responders/run/slimResponder/HtmlSlimTestSystem.java
@@ -7,7 +7,7 @@ import fitnesse.slimTables.HtmlTableScanner;
 import fitnesse.slimTables.SlimTable;
 import fitnesse.slimTables.Table;
 import fitnesse.slimTables.TableScanner;
-import fitnesse.wiki.PageData;
+import fitnesse.wiki.PageDataRead;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wikitext.parser.Collapsible;
 import fitnesse.wikitext.parser.Symbol;
@@ -17,7 +17,7 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
     super(page, listener);
   }
 
-  protected TableScanner scanTheTables(PageData pageData) {
+  protected TableScanner scanTheTables(PageDataRead pageData) {
 
     Symbol syntaxTree = pageData.getSyntaxTree();
     Symbol preparsedScenarioLibrary = getPreparsedScenarioLibrary();

--- a/src/fitnesse/responders/run/slimResponder/SlimResponder.java
+++ b/src/fitnesse/responders/run/slimResponder/SlimResponder.java
@@ -18,12 +18,7 @@ import fitnesse.responders.run.TestSummary;
 import fitnesse.responders.run.TestSystem;
 import fitnesse.responders.run.TestSystemListener;
 import fitnesse.responders.templateUtilities.HtmlPage;
-import fitnesse.wiki.PageCrawler;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.PathParser;
-import fitnesse.wiki.VirtualEnabledPageCrawler;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.*;
 
 /*
 This responder is a test rig for SlimTestSystemTest, which makes sure that the SlimTestSystem works nicely with
@@ -95,7 +90,7 @@ public abstract class SlimResponder implements Responder, TestSystemListener {
     return slimOpen;
   }
 
-  public PageData getTestResults() {
+  public PageDataRead getTestResults() {
     return testSystem.getTestResults();
   }
 

--- a/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
+++ b/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
@@ -13,10 +13,7 @@ import fitnesse.slim.SlimServer;
 import fitnesse.slim.SlimService;
 import fitnesse.slimTables.*;
 import fitnesse.testutil.MockCommandRunner;
-import fitnesse.wiki.PageCrawlerImpl;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.*;
 import fitnesse.wikitext.parser.Parser;
 import fitnesse.wikitext.parser.Symbol;
 
@@ -48,7 +45,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
 
   protected List<Object> instructions;
   private boolean started;
-  protected PageData testResults;
+  protected PageDataRead testResults;
   protected TableScanner tableScanner;
   protected Map<String, Object> instructionResults;
   protected List<SlimTable> testTables = new ArrayList<SlimTable>();
@@ -101,7 +98,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
   }
 
   String getSlimFlags() {
-    String slimFlags = page.getData().getVariable("SLIM_FLAGS");
+    String slimFlags = page.readPageData().getVariable("SLIM_FLAGS");
     if (slimFlags == null)
       slimFlags = "";
     return slimFlags;
@@ -154,7 +151,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
   private int getSlimPortBase() {
     int base = 8085;
     try {
-      String slimPort = page.getData().getVariable("SLIM_PORT");
+      String slimPort = page.readPageData().getVariable("SLIM_PORT");
       if (slimPort != null) {
         int slimPortInt = Integer.parseInt(slimPort);
         base = slimPortInt;
@@ -177,7 +174,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
   }
 
   String determineSlimHost() {
-    String slimHost = page.getData().getVariable("SLIM_HOST");
+    String slimHost = page.readPageData().getVariable("SLIM_HOST");
     return slimHost == null ? "localhost" : slimHost;
   }
 
@@ -253,7 +250,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
     exceptions.resetForNewTest();
   }
 
-  private void checkForAndReportVersionMismatch(PageData pageData) {
+  private void checkForAndReportVersionMismatch(PageDataRead pageData) {
     double expectedVersionNumber = getExpectedSlimVersion(pageData);
     double serverVersionNumber = slimClient.getServerVersion();
     if (serverVersionNumber < expectedVersionNumber)
@@ -261,7 +258,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
         String.format("Expected V%s but was V%s", expectedVersionNumber, serverVersionNumber));
   }
 
-  private double getExpectedSlimVersion(PageData pageData) {
+  private double getExpectedSlimVersion(PageDataRead pageData) {
     double expectedVersionNumber = SlimClient.MINIMUM_REQUIRED_SLIM_VERSION;
     String pageSpecificSlimVersion = pageData.getVariable("SLIM_VERSION");
     if (pageSpecificSlimVersion != null) {
@@ -276,7 +273,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
 
   protected abstract String createHtmlResults(SlimTable startAfterTable, SlimTable lastWrittenTable);
 
-  String processAllTablesOnPage(PageData pageData) throws IOException {
+  String processAllTablesOnPage(PageDataRead pageData) throws IOException {
     tableScanner = scanTheTables(pageData);
     allTables = createSlimTables(tableScanner);
     testResults = pageData;
@@ -300,7 +297,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
     return htmlResults;
   }
 
-  protected abstract TableScanner scanTheTables(PageData pageData);
+  protected abstract TableScanner scanTheTables(PageDataRead pageData);
 
   private String processTablesAndGetHtml(List<SlimTable> tables, SlimTable startWithTable, SlimTable nextTable) throws IOException {
     expectations.clear();
@@ -365,7 +362,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
     return exceptionMessage;
   }
 
-  public PageData getTestResults() {
+  public PageDataRead getTestResults() {
     return testResults;
   }
 

--- a/src/fitnesse/testutil/MockExtendableWikiPage.java
+++ b/src/fitnesse/testutil/MockExtendableWikiPage.java
@@ -4,11 +4,7 @@ package fitnesse.testutil;
 
 import java.util.List;
 
-import fitnesse.wiki.ExtendableWikiPage;
-import fitnesse.wiki.Extension;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.VersionInfo;
-import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.*;
 
 public class MockExtendableWikiPage extends ExtendableWikiPage {
   private static final long serialVersionUID = 1L;
@@ -48,6 +44,8 @@ public class MockExtendableWikiPage extends ExtendableWikiPage {
   public PageData getData() {
     return null;
   }
+
+  public PageDataRead readPageData() { return getData(); }
 
   public PageData getDataVersion(String versionName) {
     return null;

--- a/src/fitnesse/wiki/CachingPage.java
+++ b/src/fitnesse/wiki/CachingPage.java
@@ -68,14 +68,25 @@ public abstract class CachingPage extends CommitingPage {
   }
 
   public PageData getData() {
+      RefreshCache();
+      return new PageData(getCachedData());
+  }
+
+  private void RefreshCache() {
     if (cachedDataExpired()) {
       PageData data = makePageData();
       setCachedData(data);
     }
-    return new PageData(getCachedData());
+  }
+
+  public PageDataRead readPageData() {
+    RefreshCache();
+    return getCachedData();
   }
 
   private boolean cachedDataExpired() {
+      //if (getCachedData() == null) System.out.println("cache null " + (getName() != null ? getName() : "?"));
+      //else if (cachedTime.elapsed() >= cacheTime) System.out.println("cache expired " + (getName() != null ? getName() : "?"));
     return getCachedData() == null || cachedTime.elapsed() >= cacheTime;
   }
 

--- a/src/fitnesse/wiki/FileSystemPage.java
+++ b/src/fitnesse/wiki/FileSystemPage.java
@@ -341,7 +341,7 @@ public class FileSystemPage extends CachingPage {
     }
 
     private String getCmSystemVariable() {
-      return getData().getVariable("CM_SYSTEM");
+      return readPageData().getVariable("CM_SYSTEM");
     }
   }
 }

--- a/src/fitnesse/wiki/InMemoryPage.java
+++ b/src/fitnesse/wiki/InMemoryPage.java
@@ -81,6 +81,10 @@ public class InMemoryPage extends CommitingPage {
     return new PageData(getDataVersion(currentVersionName));
   }
 
+  public PageDataRead readPageData() {
+      return getDataVersion(currentVersionName);
+  }
+
   public void doCommit(PageData newData) {
     newData.setWikiPage(this);
     newData.getProperties().setLastModificationTime(Clock.currentDate());

--- a/src/fitnesse/wiki/PageDataRead.java
+++ b/src/fitnesse/wiki/PageDataRead.java
@@ -1,0 +1,15 @@
+package fitnesse.wiki;
+
+import fitnesse.wikitext.parser.ParsingPage;
+import fitnesse.wikitext.parser.Symbol;
+import java.util.List;
+
+public interface PageDataRead {
+    String getHtml();
+    String getVariable(String name);
+    Symbol getSyntaxTree();
+    ParsingPage getParsingPage();
+    String translateToHtml(Symbol syntaxTree);
+    List<String> getClasspaths();
+    List<String> getXrefPages();
+}

--- a/src/fitnesse/wiki/SymbolicPage.java
+++ b/src/fitnesse/wiki/SymbolicPage.java
@@ -70,6 +70,8 @@ public class SymbolicPage extends BaseWikiPage {
     return data;
   }
 
+  public PageDataRead readPageData() { return getData(); }
+
   public PageData getDataVersion(String versionName) {
     PageData data = realPage.getDataVersion(versionName);
     data.setWikiPage(this);

--- a/src/fitnesse/wiki/VirtualCouplingPage.java
+++ b/src/fitnesse/wiki/VirtualCouplingPage.java
@@ -34,6 +34,8 @@ public class VirtualCouplingPage implements WikiPage {
     return hostPage.getData();
   }
 
+  public PageDataRead readPageData() { return getData(); }
+
   public int compareTo(Object o) {
     return 0;
   }

--- a/src/fitnesse/wiki/WikiPage.java
+++ b/src/fitnesse/wiki/WikiPage.java
@@ -27,6 +27,7 @@ public interface WikiPage extends Serializable, Comparable<Object> {
   String getName();
 
   PageData getData();
+  PageDataRead readPageData();
 
   PageData getDataVersion(String versionName);
 

--- a/src/fitnesse/wiki/WikiPageDummy.java
+++ b/src/fitnesse/wiki/WikiPageDummy.java
@@ -59,6 +59,8 @@ public class WikiPageDummy implements WikiPage {
     return pageData;
   }
 
+  public PageDataRead readPageData() { return getData(); }
+
   public VersionInfo commit(PageData data) {
     pageData = data;
     return new VersionInfo("mockVersionName", "mockAuthor", Clock.currentDate());

--- a/src/fitnesse/wikitext/parser/ParsingPage.java
+++ b/src/fitnesse/wikitext/parser/ParsingPage.java
@@ -7,6 +7,12 @@ import util.Maybe;
 import java.util.HashMap;
 
 public class ParsingPage {
+    private static SymbolProvider variableDefinitionSymbolProvider = new SymbolProvider(new SymbolType[] {
+        Literal.symbolType, new Define(), new Include(), SymbolType.CloseLiteral, Comment.symbolType, SymbolType.Whitespace,
+        SymbolType.Newline, Variable.symbolType, Preformat.symbolType,
+        SymbolType.ClosePreformat, SymbolType.Text
+    });
+
     private SourcePage page;
     private SourcePage namedPage;
     private HashMap<String, HashMap<String, Maybe<String>>> cache;
@@ -68,11 +74,6 @@ public class ParsingPage {
         return findVariable(page, name);
     }
 
-    public String findVariable(SourcePage page, String name, String defaultValue) {
-        Maybe<String> result = findVariable(page, name);
-        return result.isNothing() ? defaultValue : result.getValue();
-    }
-
     public void putVariable(SourcePage page, String name, Maybe<String> value) {
         String key = page.getFullName();
         if (!cache.containsKey(key)) cache.put(key, new HashMap<String, Maybe<String>>());
@@ -81,5 +82,9 @@ public class ParsingPage {
 
     public void putVariable(String name, String value) {
         putVariable(page, name, new Maybe<String>(value));
+    }
+
+    public String renderVariableValue(String variableValue) {
+        return new HtmlTranslator(null, this).translate(Parser.make(this, "", variableDefinitionSymbolProvider).parseWithParent(variableValue, null));
     }
 }


### PR DESCRIPTION
this lets the cached syntax tree be reused without reparsing
