### PR TITLE
Option for custom slim tables

### DIFF
--- a/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
+++ b/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
@@ -57,7 +57,7 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
   protected final Pattern exceptionMessagePattern = Pattern.compile("message:<<(.*)>>");
   private Map<String, ScenarioTable> scenarios = new HashMap<String, ScenarioTable>();
   protected List<SlimTable.Expectation> expectations = new ArrayList<SlimTable.Expectation>();
-  private SlimTableFactory slimTableFactory = new SlimTableFactory();
+  private SlimTableFactory slimTableFactory = SlimTableFactory.getInstance();
   private Symbol preparsedScenarioLibrary;
 
 

--- a/src/fitnesse/slimTables/AlternateSlimTableFactoryTest.java
+++ b/src/fitnesse/slimTables/AlternateSlimTableFactoryTest.java
@@ -1,0 +1,47 @@
+package fitnesse.slimTables;
+
+import fitnesse.responders.run.slimResponder.SlimTestContext;
+import org.junit.Before;
+
+import java.util.Map;
+
+public class AlternateSlimTableFactoryTest extends SlimTableFactoryTest {
+
+  @Before
+  public void moreSetUp() {
+    slimTableFactory = SlimTableFactory.getInstance(AlternateSlimTableFactory.class.getName());
+    map.put("alt:", AltTable.class);
+  }
+
+  public static class AlternateSlimTableFactory extends SlimTableFactory {
+    @Override
+    public SlimTable makeSlimTable(Table table, String tableId, SlimTestContext slimTestContext) {
+      String tableType = table.getCellContents(0, 0);
+      if (beginsWith(tableType, "alt:"))
+        return new AltTable(table, tableId, slimTestContext);
+      else
+        return super.makeSlimTable(table, tableId, slimTestContext);
+    }
+  }
+
+  private static class AltTable extends SlimTable {
+    public AltTable(Table table, String id, SlimTestContext testContext) {
+      super(table, id, testContext);
+    }
+
+    @Override
+    protected String getTableType() {
+      return "alt";
+    }
+
+    @Override
+    public void appendInstructions() {
+      throw new UnsupportedOperationException("This operation is not yet supported");
+    }
+
+    @Override
+    public void evaluateReturnValues(Map<String, Object> returnValues) throws Exception {
+      throw new UnsupportedOperationException("This operation is not yet supported");
+    }
+  }
+}

--- a/src/fitnesse/slimTables/SlimTableFactory.java
+++ b/src/fitnesse/slimTables/SlimTableFactory.java
@@ -5,14 +5,34 @@ import java.util.Map;
 
 import fitnesse.responders.run.slimResponder.SlimTestContext;
 import fitnesse.slimTables.SlimTable.Disgracer;
+import org.apache.commons.lang.StringUtils;
 
 public class SlimTableFactory {
+
+  public static SlimTableFactory getInstance() {
+    String defaultFactoryClass = SlimTableFactory.class.getName();
+    return getInstance(StringUtils.defaultIfEmpty(System.getProperty(defaultFactoryClass), defaultFactoryClass));
+  }
+
+  public static SlimTableFactory getInstance(String factoryClassName) {
+    try {
+      Class<SlimTableFactory> factoryClass = (Class<SlimTableFactory>) Class.forName(factoryClassName);
+      assert SlimTableFactory.class.isAssignableFrom(factoryClass);
+      return factoryClass.newInstance();
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("SlimTableFactory class not found: " + factoryClassName, e);
+    } catch (InstantiationException e) {
+      throw new IllegalArgumentException("Could not instantiate SlimTableFactory: " + factoryClassName, e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalArgumentException("Could not access constructor for SlimTableFactory: " + factoryClassName, e);
+    }
+  }
 
   private boolean doesNotHaveColon(String tableType) {
     return tableType.indexOf(":") == -1;
   }
 
-  private boolean beginsWith(String tableType, String typeCode) {
+  protected boolean beginsWith(String tableType, String typeCode) {
     return tableType.toUpperCase().startsWith(typeCode.toUpperCase());
   }
 

--- a/src/fitnesse/slimTables/SlimTableFactoryTest.java
+++ b/src/fitnesse/slimTables/SlimTableFactoryTest.java
@@ -16,15 +16,15 @@ import java.util.Set;
 
 @SuppressWarnings("unchecked")
 public class SlimTableFactoryTest {
-  private SlimTableFactory slimTableFactory;
+  protected SlimTableFactory slimTableFactory;
   private Table table;
-  private Map map;
+  protected Map<String, Class<? extends SlimTable>> map;
 
   @Before
   public void setUp() {
-    slimTableFactory = new SlimTableFactory();
+    slimTableFactory = SlimTableFactory.getInstance();
     table = mock(Table.class);
-    map = new HashMap();
+    map = new HashMap<String, Class<? extends SlimTable>>();
     map.put("dt:", DecisionTable.class);
     map.put("dT:", DecisionTable.class);
     map.put("decision:", DecisionTable.class);
@@ -41,12 +41,10 @@ public class SlimTableFactoryTest {
 
   @Test
   public void shouldCreateCorrectSlimTableForTablesType() {
-    Set entrySet = map.entrySet();
+    Set<Entry<String, Class<? extends SlimTable>>> entrySet = map.entrySet();
 
-    for (Iterator iterator = entrySet.iterator(); iterator.hasNext();) {
-      Map.Entry entry = (Entry) iterator.next();
-      assertThatTableTypeCreateSlimTableType((String) entry.getKey(), (Class) entry.getValue());
-
+    for (Entry<String, Class<? extends SlimTable>> entry : entrySet) {
+      assertThatTableTypeCreateSlimTableType(entry.getKey(), entry.getValue());
     }
   }
 


### PR DESCRIPTION
# Purpose

We created a few custom slim tables that are needed to tests parts of our project. These tables are only relevant for our project. This patch allows us to use our own custom tables.
# Usage

Run fitnesse with the `fitnesse.slimTables.SlimTableFactory` system property set to `YourCustomSlimTableFactory`.

Then, make the factory class something similar to the below.

```
public class YourCustomSlimTableFactory {
  public SlimTable makeSlimTable(Table table, String tableId, SlimTestContext slimTestContext) {
    String tableType = table.getCellContents(0, 0);
    if (beginsWith(tableType, "customTableFoo:")) {
      return new CustomTableFoo(table, tableId, slimTestContext)
    } else {
        return super.makeSlimTable(table, tableId, slimTestContext);
    }
  }
}
```

Then you can make a test like:

```
!|customTableFoo:|Some stuff|
|more|custom|stuff|
```
