### PR TITLE
Make MovePageResponder act nicely with symbolic links

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/TestMovePageWithSymlinks/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/TestMovePageWithSymlinks/content.txt
@@ -1,0 +1,29 @@
+!contents
+
+If a symlink is created on the to-be-moved page, the symlink should be moved.
+
+!*> local setup and scenario's
+| library |
+| page driver |
+
+!| scenario | create symlink on | pageName | with name | name | link to | linkedPage |
+| check | request page | @pageName?responder=symlink&linkName=@name&linkPath=@linkedPage | 303 |
+| show | content |
+| ensure | content contains | Location: @pageName?properties |
+
+!| scenario | move page | pageName | to | location |
+| check | request page | @pageName?responder=movePage&newLocation=@location | 303 |
+| show | content |
+| ensure | content contains | Location: @location.@pageName |
+*!
+
+!| script |
+| create page | ToBeMovedPage | with content | main page |
+| create page | NewLocation | with content | new location |
+| create page | SymlinkedPage | with content | symlink |
+| create symlink on | ToBeMovedPage | with name | TestPage | link to | SymlinkedPage |
+| ensure | page | ToBeMovedPage.TestPage | is a symbolic link |
+| move page | ToBeMovedPage | to | NewLocation |
+| reject | page | ToBeMovedPage | exists |
+| ensure | page | NewLocation.ToBeMovedPage | exists |
+| ensure | page | NewLocation.ToBeMovedPage.TestPage | is a symbolic link |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/TestMovePageWithSymlinks/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/TestMovePageWithSymlinks/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/content.txt
@@ -2,15 +2,4 @@
 
 The move responder is invoked with the ''movePage'' url.  This url has an argument named ''newPageLocation'' that holds the name of the new parent of the page.  Thus the url:{{{http://localhost/SomePage?responder=movePage&newLocation=NewPage}}} will move''!-SomePage-!'' beneath ''!-NewPage-!''
 
-^TestSimpleMove
-^TestMovePageWithSubPages
-^TestMovePageWithManyLevelsOfSubPages
-^TestMovePageWithExternalReference
-^TestMovePageWithRelativeInternalReference
-^TestMovePageWithAbsoluteInternalReference
-^TestCantMovePageBeneathSelf
-^TestMovePageThreeLevelsDown
-^TestReferencesOfChildOfMovedPageAreRenamed
-^TestMoveToNonExistentPage
-^TestMoveIncludedPage
-^TestMovePageInsideItself
+!contents -g

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteMoveResponder/properties.xml
@@ -2,13 +2,11 @@
 <properties>
 	<Edit/>
 	<Files/>
-	<Help></Help>
 	<Properties/>
 	<RecentChanges/>
 	<Refactor/>
 	<Search/>
 	<Suite/>
-	<Suites></Suites>
 	<Versions/>
 	<WhereUsed/>
 </properties>

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -2,15 +2,10 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.fixtures;
 
-import fitnesse.FitNesseExpediter;
-import fitnesse.authentication.OneUserAuthenticator;
-import fitnesse.http.MockRequest;
-import fitnesse.http.MockResponseSender;
-import fitnesse.responders.editing.EditResponder;
-import fitnesse.responders.run.formatters.XmlFormatter;
-import fitnesse.responders.testHistory.TestHistory;
-import fitnesse.testutil.MockSocket;
-import fitnesse.wiki.*;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
 import org.htmlparser.Node;
 import org.htmlparser.NodeFilter;
 import org.htmlparser.Parser;
@@ -23,10 +18,19 @@ import org.htmlparser.lexer.Page;
 import org.htmlparser.util.NodeList;
 import org.json.JSONObject;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Map;
+import fitnesse.FitNesseExpediter;
+import fitnesse.authentication.OneUserAuthenticator;
+import fitnesse.http.MockRequest;
+import fitnesse.http.MockResponseSender;
+import fitnesse.responders.editing.EditResponder;
+import fitnesse.responders.testHistory.TestHistory;
+import fitnesse.testutil.MockSocket;
+import fitnesse.wiki.PageCrawler;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.SymbolicPage;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPagePath;
 
 public class PageDriver {
   private PageCreator creator = new PageCreator();
@@ -86,6 +90,20 @@ public class PageDriver {
     WikiPage thePage = root.getPageCrawler().getPage(root, pagePath);
     PageData data = thePage.getData();
     return data.getAttribute(PageData.LAST_MODIFYING_USER);
+  }
+
+  public boolean pageIsASymbolicLink(String pageName) {
+    WikiPage root = FitnesseFixtureContext.root;
+    WikiPagePath pagePath = PathParser.parse(pageName);
+    WikiPage thePage = root.getPageCrawler().getPage(root, pagePath);
+    return thePage instanceof SymbolicPage;
+  }
+  
+  public boolean pageExists(String pageName) {
+	    WikiPage root = FitnesseFixtureContext.root;
+	    WikiPagePath pagePath = PathParser.parse(pageName);
+	    WikiPage thePage = root.getPageCrawler().getPage(root, pagePath);
+	    return thePage != null;
   }
 
   public void makeATestPage(String pageName) throws Exception {

--- a/src/fitnesse/responders/refactoring/PageMovementResponder.java
+++ b/src/fitnesse/responders/refactoring/PageMovementResponder.java
@@ -94,14 +94,20 @@ public abstract class PageMovementResponder implements SecureResponder {
   }
 
   protected void movePage(WikiPage movedPage, WikiPage targetPage) {
-    PageData pageData = movedPage.getData();
-
-    targetPage.commit(pageData);
-
-    moveChildren(movedPage, targetPage);
-
-    WikiPage parentOfMovedPage = movedPage.getParent();
-    parentOfMovedPage.removeChildPage(movedPage.getName());
+	  
+	// TODO: do not move symlinked pages like this -> change the symlink path accordingly
+	// check in parent page if the moved page is a symlink:
+	System.out.println("Moving page " + movedPage.getName() + " " + movedPage.getClass().getName());
+	if (!isSymlinkedPage(movedPage)) {
+	    PageData pageData = movedPage.getData();
+	
+	    targetPage.commit(pageData);
+	
+	    moveChildren(movedPage, targetPage);
+	
+	    WikiPage parentOfMovedPage = movedPage.getParent();
+	    parentOfMovedPage.removeChildPage(movedPage.getName());
+	}
   }
 
   protected void moveChildren(WikiPage movedPage, WikiPage newParentPage) {
@@ -111,6 +117,10 @@ public abstract class PageMovementResponder implements SecureResponder {
     }
   }
 
+  private boolean isSymlinkedPage(WikiPage page) {
+	  return page instanceof SymbolicPage;
+  }
+  
   public SecureOperation getSecureOperation() {
     return new AlwaysSecureOperation();
   }


### PR DESCRIPTION
Symbolic links were copied if a page containing symbolic links was moved. This caused unintentional duplication in test cases.

This patch takes into account symbolic links and keeps those in sync (and working) when a page is moved.
