### PR TITLE
Create synonyms for row instructions

### DIFF
--- a/src/fitnesse/responders/run/slimResponder/MockSlimTestContext.java
+++ b/src/fitnesse/responders/run/slimResponder/MockSlimTestContext.java
@@ -2,6 +2,7 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.responders.run.slimResponder;
 
+import fitnesse.slimTables.RowInstructionSelector;
 import fitnesse.slimTables.ScenarioTable;
 import fitnesse.slimTables.SlimTable;
 
@@ -14,7 +15,7 @@ public class MockSlimTestContext implements SlimTestContext {
   private Map<String, String> symbols = new HashMap<String, String>();
   private Map<String, ScenarioTable> scenarios = new HashMap<String, ScenarioTable>();
   private List<SlimTable.Expectation> expectations = new ArrayList<SlimTable.Expectation>();
-
+  
   public String getSymbol(String symbolName) {
     return symbols.get(symbolName);
   }
@@ -42,5 +43,10 @@ public class MockSlimTestContext implements SlimTestContext {
   public void evaluateExpectations(Map<String, Object> results) {
     for (SlimTable.Expectation e : expectations)
       e.evaluateExpectation(results);
+  }
+  
+
+  public RowInstructionSelector getRowInstructionSelector() {
+      return new RowInstructionSelector();
   }
 }

--- a/src/fitnesse/responders/run/slimResponder/SlimTestContext.java
+++ b/src/fitnesse/responders/run/slimResponder/SlimTestContext.java
@@ -2,6 +2,7 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.responders.run.slimResponder;
 
+import fitnesse.slimTables.RowInstructionSelector;
 import fitnesse.slimTables.ScenarioTable;
 import fitnesse.slimTables.SlimTable;
 
@@ -19,4 +20,6 @@ public interface SlimTestContext {
   void addExpectation(SlimTable.Expectation e);
 
   Map<String, ScenarioTable> getScenarios();
+  
+  RowInstructionSelector getRowInstructionSelector();
 }

--- a/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
+++ b/src/fitnesse/responders/run/slimResponder/SlimTestSystem.java
@@ -58,11 +58,13 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
   protected List<SlimTable.Expectation> expectations = new ArrayList<SlimTable.Expectation>();
   private SlimTableFactory slimTableFactory = new SlimTableFactory();
   private ParsedPage preparsedScenarioLibrary;
+  private RowInstructionSelector rowInstructionSelector = new RowInstructionSelector();
 
 
   public SlimTestSystem(WikiPage page, TestSystemListener listener) {
     super(page, listener);
     testSummary = new TestSummary(0, 0, 0, 0);
+    addRowInstructions();
   }
 
   public String getSymbol(String symbolName) {
@@ -101,6 +103,19 @@ public abstract class SlimTestSystem extends TestSystem implements SlimTestConte
     if (slimFlags == null)
       slimFlags = "";
     return slimFlags;
+  }
+  
+  private void addRowInstructions() {
+      for (RowInstructionVariable variable : RowInstructionVariable.values()) {
+          String synonym = page.readOnlyData().getVariable(variable.name());
+          rowInstructionSelector.setSynonym(variable, synonym);
+      }
+
+  }
+  
+  @Override
+  public RowInstructionSelector getRowInstructionSelector() {
+      return rowInstructionSelector;
   }
 
   protected ExecutionLog createExecutionLog(String classPath, Descriptor descriptor) throws SocketException {

--- a/src/fitnesse/slimTables/RowInstructionSelector.java
+++ b/src/fitnesse/slimTables/RowInstructionSelector.java
@@ -1,0 +1,33 @@
+package fitnesse.slimTables;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class RowInstructionSelector {
+    Map<RowInstructionVariable, String> synonyms = new HashMap<RowInstructionVariable,String>();
+    
+    public boolean isInstruction(RowInstructionVariable instruction, String cell) {
+        if (cell.equalsIgnoreCase(instruction.originalValue)) {
+            return true;
+        }
+        String synonymForInstruction = synonyms.get(instruction);
+        if (synonymForInstruction == null) {
+            return false;
+        }
+        return synonymForInstruction.equalsIgnoreCase(cell);
+            
+        
+    }
+    
+    public void setSynonym(RowInstructionVariable original, String synonym) {
+        if (synonym == null) {
+            return;
+        }
+     
+        
+        synonyms.put(original, synonym);
+        
+    }
+
+}

--- a/src/fitnesse/slimTables/RowInstructionSelectorTest.java
+++ b/src/fitnesse/slimTables/RowInstructionSelectorTest.java
@@ -1,0 +1,30 @@
+package fitnesse.slimTables;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class RowInstructionSelectorTest {
+
+    RowInstructionSelector selector = new RowInstructionSelector();
+
+    @Test
+    public void shouldBeStartInstruction() {
+
+        assertTrue(selector.isInstruction(RowInstructionVariable.SYNONYM_START, "start"));
+        assertTrue(selector.isInstruction(RowInstructionVariable.SYNONYM_START, "sTart"));
+        assertTrue(selector.isInstruction(RowInstructionVariable.SYNONYM_START, "START"));
+
+    }
+
+    @Test
+    public void shouldBeStartInstructionSynonym() {
+
+        selector.setSynonym(RowInstructionVariable.SYNONYM_START, "börjar");
+        assertTrue(selector.isInstruction(RowInstructionVariable.SYNONYM_START, "börJar"));
+        assertTrue(selector.isInstruction(RowInstructionVariable.SYNONYM_START, "börjAr"));
+       
+
+    }
+
+}

--- a/src/fitnesse/slimTables/RowInstructionVariable.java
+++ b/src/fitnesse/slimTables/RowInstructionVariable.java
@@ -1,0 +1,12 @@
+package fitnesse.slimTables;
+
+public enum RowInstructionVariable {
+    SYNONYM_START("start"), SYNONYM_CHECK("check"), SYNONYM_CHECK_NOT("check not"), SYNONYM_ENSURE("ensure"), SYNONYM_REJECT("reject"), SYNONYM_NOTE(
+        "note"), SYNONYM_SHOW("show");
+    public final String originalValue;
+    private RowInstructionVariable(final String originalValue) {
+        this.originalValue = originalValue; 
+    }
+    
+
+}

--- a/src/fitnesse/slimTables/ScriptTable.java
+++ b/src/fitnesse/slimTables/ScriptTable.java
@@ -14,9 +14,11 @@ import java.util.regex.Matcher;
 public class ScriptTable extends SlimTable {
   private static final String SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX = ";";
   private Matcher symbolAssignmentMatcher;
-
+  private RowInstructionSelector instructionSelector;
+  
   public ScriptTable(Table table, String tableId, SlimTestContext context) {
     super(table, tableId, context);
+    instructionSelector = getTestContext().getRowInstructionSelector();
   }
 
   protected String getTableType() {
@@ -38,20 +40,20 @@ public class ScriptTable extends SlimTable {
 
   private void appendInstructionForRow(int row) {
     String firstCell = table.getCellContents(0, row).trim();
-    if (firstCell.equalsIgnoreCase("start"))
-      startActor(row);
-    else if (firstCell.equalsIgnoreCase("check"))
-      checkAction(row);
-    else if (firstCell.equalsIgnoreCase("check not"))
-      checkNotAction(row);
-    else if (firstCell.equalsIgnoreCase("reject"))
-      reject(row);
-    else if (firstCell.equalsIgnoreCase("ensure"))
-      ensure(row);
-    else if (firstCell.equalsIgnoreCase("show"))
-      show(row);
-    else if (firstCell.equalsIgnoreCase("note"))
-      note(row);
+    if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_START, firstCell))
+        startActor(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_CHECK, firstCell))
+        checkAction(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_CHECK_NOT, firstCell))
+        checkNotAction(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_REJECT, firstCell))
+        reject(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_ENSURE, firstCell))
+        ensure(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_SHOW, firstCell))
+        show(row);
+    else if (instructionSelector.isInstruction(RowInstructionVariable.SYNONYM_NOTE, firstCell))
+        note(row);
     else if (isSymbolAssignment(firstCell))
       actionAndAssign(row);
     else if (firstCell.length() == 0)


### PR DESCRIPTION
Allow creation of synonyms for script table row instructions "check", "ensure", "reject" etc. This is particularly useful if tests are being written in a language other than english.

For example, instead of having to write (in this case swedish):

| ensure | innehåll matchar | @htmlText|   

set variable
!define SYNONYM_ENSURE {försäkra}

and write
| försäkra | innehåll matchar | @htmlText|   
