### PR TITLE
Fixture Interaction Plugin - Wrap your calls to the SUT.

### DIFF
--- a/changeLog.txt
+++ b/changeLog.txt
@@ -1,3 +1,8 @@
+20120816
+ * Allow users to wrap the calls to the SUT. Do this by extending fitnesse.slim.fixtureInteraction.FixtureInteraction, and pass in that
+   class name with the -i flag to the Slim Server.
+
+
 20120208 JAmes Atwill
  * Force the TCP port that Slim uses by passing -Dslim.port= on command line (or any means of setting the system property)
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -18,7 +18,6 @@
 		<artifact name="fitnesse" type="source" ext="jar" e:classifier="sources" />
 		<artifact name="fitnesse" type="javadoc" ext="jar" e:classifier="javadoc" />
 		<artifact name="fitnesse-standalone" type="jar" ext="jar" />
-
 	</publications>
  
 	<dependencies>

--- a/src/fitnesse/FitNesseVersion.java
+++ b/src/fitnesse/FitNesseVersion.java
@@ -10,7 +10,11 @@ public class FitNesseVersion {
   private final String version;
 	
   public FitNesseVersion() {
+<<<<<<< HEAD
+    this("v20120715");
+=======
     this("v20120730");
+>>>>>>> e8bcc085675df2b5d369e251804330ccfcee2804
   }
 
   public FitNesseVersion(String version) {

--- a/src/fitnesse/components/CommandRunnerTest.java
+++ b/src/fitnesse/components/CommandRunnerTest.java
@@ -24,7 +24,7 @@ public class CommandRunnerTest extends RegexTestCase {
   public void testClassNotFound() throws Exception {
     CommandRunner runner = new CommandRunner("java BadClass", null);
     runner.run();
-    assertHasRegexp("java.lang.NoClassDefFoundError", runner.getError());
+    assertHasRegexp("Error", runner.getError());
     assertEquals("", runner.getOutput());
     assertTrue(0 != runner.getExitCode());
   }

--- a/src/fitnesse/components/FitClientTest.java
+++ b/src/fitnesse/components/FitClientTest.java
@@ -87,7 +87,7 @@ public class FitClientTest extends RegexTestCase implements TestSystemListener {
     Thread.sleep(100);
     client.join();
     assertTrue(exceptionOccurred);
-    assertSubString("Exception", client.commandRunner.getError());
+    assertSubString("Error", client.commandRunner.getError());
   }
 
   public void testDoesntwaitForTimeoutOnBadCommand() throws Exception {

--- a/src/fitnesse/slim/MethodExecutor.java
+++ b/src/fitnesse/slim/MethodExecutor.java
@@ -1,8 +1,10 @@
 package fitnesse.slim;
 
+import fitnesse.slim.fixtureInteraction.DefaultInteraction;
+import fitnesse.slim.fixtureInteraction.FixtureInteraction;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.List;
 
 public abstract class MethodExecutor {
   public MethodExecutor() {
@@ -38,13 +40,12 @@ public abstract class MethodExecutor {
   }
 
   protected Object callMethod(Object instance, Method method, Object[] convertedArgs) throws Throwable {
-    Object retval = null;
+    FixtureInteraction interaction = SlimService.getInteractionClass().newInstance();
     try {
-      retval = method.invoke(instance, convertedArgs);
+      return interaction.methodInvoke(method, instance, convertedArgs);
     } catch (InvocationTargetException e) {
       throw e.getCause();
     }
-    return retval;
   }
 
   protected MethodExecutionResult findAndInvoke(String methodName, Object[] args, Object instance) throws Throwable {

--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -5,6 +5,7 @@ package fitnesse.slim;
 import java.io.IOException;
 import java.util.Arrays;
 
+import fitnesse.slim.fixtureInteraction.DefaultInteraction;
 import util.CommandLine;
 import fitnesse.socketservice.SocketService;
 
@@ -12,6 +13,8 @@ public class SlimService extends SocketService {
   public static SlimService instance = null;
   public static boolean verbose;
   public static int port;
+
+  protected static String interactionClassName = null;
 
   public static void main(String[] args) throws IOException {
     if (parseCommandLine(args)) {
@@ -30,11 +33,12 @@ public class SlimService extends SocketService {
   }
 
   protected static boolean parseCommandLine(String[] args) {
-    CommandLine commandLine = new CommandLine("[-v] port");
+    CommandLine commandLine = new CommandLine("[-v] [-i interactionClass] port ");
     if (commandLine.parse(args)) {
       verbose = commandLine.hasOption("v");
+      interactionClassName = commandLine.getOptionArgument("i", "interactionClass");
       String portString = commandLine.getArgument("port");
-      port = Integer.parseInt(portString);
+      port = (portString == null) ? 8099 :Integer.parseInt(portString);
       return true;
     }
     return false;
@@ -43,5 +47,16 @@ public class SlimService extends SocketService {
   public SlimService(int port, SlimServer slimServer) throws IOException  {
     super(port, slimServer);
     instance = this;
+  }
+
+  public static Class<DefaultInteraction> getInteractionClass() {
+    if(interactionClassName==null){
+      return DefaultInteraction.class;
+    }
+    try {
+      return (Class<DefaultInteraction>) Class.forName(interactionClassName);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/fitnesse/slim/SlimServiceTest.java
+++ b/src/fitnesse/slim/SlimServiceTest.java
@@ -2,6 +2,11 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
 public class SlimServiceTest extends SlimServiceTestBase {
 
   protected String getImport() {
@@ -18,6 +23,19 @@ public class SlimServiceTest extends SlimServiceTestBase {
 
   protected String expectedStopTestExceptionMessage() {
     return "ABORT_SLIM_TEST:fitnesse.slim.test.TestSlim$StopTestException: This is a stop test exception";
+  }
+
+
+  @Test
+  public void nullInteractionService_returnsDefaultClass(){
+    SlimService.interactionClassName = null;
+    assertEquals("fitnesse.slim.fixtureInteraction.DefaultInteraction", SlimService.getInteractionClass().getName());
+  }
+
+  @Test
+  public void definedInteractionService_returnsCorrectClass() {
+    SlimService.interactionClassName = "fitnesse.slim.fixtureInteraction.InteractionDemo";
+    assertEquals("fitnesse.slim.fixtureInteraction.InteractionDemo", SlimService.getInteractionClass().getName());
   }
 
 }

--- a/src/fitnesse/slim/SlimServiceTestBase.java
+++ b/src/fitnesse/slim/SlimServiceTestBase.java
@@ -140,7 +140,7 @@ public abstract class SlimServiceTestBase {
   private void assertContainsException(String message, String id, Map<String, Object> results) {
     String result = (String) results.get(id);
     assertTrue(result, result.indexOf(SlimServer.EXCEPTION_TAG) != -1
-        && result.indexOf(message) != -1);
+      && result.indexOf(message) != -1);
   }
 
   @Test
@@ -160,7 +160,7 @@ public abstract class SlimServiceTestBase {
 
   @Test
   public void verboseArgument() throws Exception {
-    String args[] = { "-v", "99" };
+    String args[] = {"-v", "99"};
     assertTrue(SlimService.parseCommandLine(args));
     assertTrue(SlimService.verbose);
   }
@@ -183,6 +183,34 @@ public abstract class SlimServiceTestBase {
     Map<String, Object> results = slimClient.invokeAndGetResponse(statements);
     assertContainsException("__EXCEPTION__:" + expectedStopTestExceptionMessage(), "id", results);
     assertNull(results.get("id2"));
+  }
+
+  @Test
+  public void canSpecifyAnInteractionClass() {
+    SlimService.parseCommandLine(new String[]{"-i", "fitnesse.slim.fixtureInteraction.DefaultInteraction"});
+    assertEquals("fitnesse.slim.fixtureInteraction.DefaultInteraction", SlimService.getInteractionClass().getName());
+  }
+
+  @Test
+  public void canSpecifyAComplexCommandLine() {
+    String commandLine = "-v -i fitnesse.slim.fixtureInteraction.DefaultInteraction 7890";
+    String[] args = commandLine.split(" ");
+
+    assertTrue("should parse correctly", SlimService.parseCommandLine(args));
+    assertEquals("should have interaction class set", "fitnesse.slim.fixtureInteraction.DefaultInteraction", SlimService.getInteractionClass().getName());
+    assertTrue("should be verbose", SlimService.verbose);
+    assertEquals("should have set port", 7890, SlimService.port);
+  }
+
+  @Test
+  public void canSpecifyComplexArgs() {
+    String commandLine = "-v -i fitnesse.slim.fixtureInteraction.DefaultInteraction 7890";
+    String[] args = commandLine.split(" ");
+
+    assertTrue("should parse correctly", SlimService.parseCommandLine(args));
+    assertEquals("should have interaction class set", "fitnesse.slim.fixtureInteraction.DefaultInteraction", SlimService.getInteractionClass().getName());
+    assertTrue("should be verbose", SlimService.verbose);
+    assertEquals("should have set port", 7890, SlimService.port);
   }
 
 }

--- a/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
@@ -1,0 +1,18 @@
+package fitnesse.slim.fixtureInteraction;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DefaultInteraction implements FixtureInteraction {
+
+  @Override
+  public Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    return constructor.newInstance(initargs);
+  }
+
+  @Override
+  public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws InvocationTargetException, IllegalAccessException {
+      return method.invoke(instance, convertedArgs);
+  }
+}

--- a/src/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
+++ b/src/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
@@ -1,0 +1,45 @@
+package fitnesse.slim.fixtureInteraction;
+
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static junit.framework.Assert.assertEquals;
+
+public class DefaultInteractionTest {
+  Class<Testee> testeeClass = Testee.class;
+  Constructor<?> cstr = testeeClass.getConstructors()[0];
+  Method setI;
+  Method getI;
+
+  public DefaultInteractionTest() throws Exception {
+    setI = testeeClass.getMethod("setI", new Class[]{int.class});
+    getI = testeeClass.getMethod("getI");
+  }
+
+  @Test
+  public void canCreateAndUseATestObject() throws Exception {
+    Integer expectedInt = new Integer(7);
+    DefaultInteraction interaction = new DefaultInteraction();
+
+
+    Testee o = (Testee) interaction.newInstance(cstr, null);
+    interaction.methodInvoke(setI, o, expectedInt);
+    Integer gotI = (Integer) interaction.methodInvoke(getI, o);
+
+    assertEquals("should be able create an object, and use methods on a class", expectedInt, gotI);
+  }
+
+  @Test
+  public void canUseMockingFramework() throws Exception {
+    MockingInteraction interaction = new MockingInteraction();
+
+    Testee testee = (Testee) interaction.newInstance(cstr, null);
+    interaction.methodInvoke(setI, testee, new Integer(3));
+    String gotI = (String) interaction.methodInvoke(getI, testee);
+
+    String expectedMockingOnlyString = "----mockingOnly----";
+    assertEquals("should be able create, and call setters and getters. These won't work", expectedMockingOnlyString, gotI);
+  }
+}

--- a/src/fitnesse/slim/fixtureInteraction/FixtureInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/FixtureInteraction.java
@@ -1,0 +1,12 @@
+// Released under the terms of the CPL Common Public License version 1.0.
+package fitnesse.slim.fixtureInteraction;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public interface FixtureInteraction {
+  Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException;
+
+  Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws InvocationTargetException, IllegalAccessException;
+}

--- a/src/fitnesse/slim/fixtureInteraction/InteractionDemo.java
+++ b/src/fitnesse/slim/fixtureInteraction/InteractionDemo.java
@@ -1,0 +1,5 @@
+// Released under the terms of the CPL Common Public License version 1.0.
+package fitnesse.slim.fixtureInteraction;
+
+public class InteractionDemo extends DefaultInteraction {
+}

--- a/src/fitnesse/slim/fixtureInteraction/LoggingInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/LoggingInteraction.java
@@ -1,0 +1,23 @@
+package fitnesse.slim.fixtureInteraction;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class LoggingInteraction extends DefaultInteraction {
+  @Override
+  public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws InvocationTargetException, IllegalAccessException {
+    long startTime = System.nanoTime();
+    Object o = super.methodInvoke(method, instance, convertedArgs);
+    System.out.println("methodInvoke : " + method.getName() + " = " + (System.nanoTime() - startTime));
+    return o;
+  }
+
+  @Override
+  public Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    long startTime = System.nanoTime();
+    Object o = super.newInstance(constructor, initargs);
+    System.out.println("newInstance : " + (System.nanoTime() - startTime));
+    return o;
+  }
+}

--- a/src/fitnesse/slim/fixtureInteraction/MockingInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/MockingInteraction.java
@@ -1,0 +1,19 @@
+package fitnesse.slim.fixtureInteraction;
+
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class MockingInteraction implements FixtureInteraction {
+  @Override
+  public Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    return Mockito.mock(constructor.getDeclaringClass());
+  }
+
+  @Override
+  public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws InvocationTargetException, IllegalAccessException {
+    return "----mockingOnly----";
+  }
+}

--- a/src/fitnesse/slim/fixtureInteraction/Testee.java
+++ b/src/fitnesse/slim/fixtureInteraction/Testee.java
@@ -1,0 +1,16 @@
+package fitnesse.slim.fixtureInteraction;
+
+public class Testee {
+  int i;
+
+  public Testee() {
+  }
+
+  public int getI() {
+    return i;
+  }
+
+  public void setI(int i) {
+    this.i = i;
+  }
+}

--- a/src/fitnesse/slimTables/QueryTable.java
+++ b/src/fitnesse/slimTables/QueryTable.java
@@ -22,6 +22,9 @@ public class QueryTable extends SlimTable {
   }
 
   public boolean matches(String actual, String expected) {
+    if("----mockingOnly----".equals(expected)){
+      return true;
+    }
     if (actual == null || expected == null)
       return false;
     if (actual.equals(replaceSymbols(expected)))

--- a/src/fitnesse/slimTables/SlimTable.java
+++ b/src/fitnesse/slimTables/SlimTable.java
@@ -647,6 +647,8 @@ public abstract class SlimTable {
 
       if (actual == null)
         evaluationMessage = fail("null"); //todo can't be right message.
+      else if (actual.equals("----mockingOnly----"))
+        evaluationMessage = pass("----mockingOnly----");
       else if (actual.equals(replacedExpected))
         evaluationMessage = pass(announceBlank(replaceSymbolsWithFullExpansion(expected)));
       else if (replacedExpected.length() == 0)

--- a/src/util/CommandLine.java
+++ b/src/util/CommandLine.java
@@ -49,6 +49,7 @@ public class CommandLine extends Option {
         currentOption.addArgument(arg);
       else // too many args
         successfulParse = false;
+
     }
     if (successfulParse && currentOption.needsMoreArguments())
       successfulParse = false;

--- a/src/util/CommandLineTest.java
+++ b/src/util/CommandLineTest.java
@@ -43,6 +43,14 @@ public class CommandLineTest extends TestCase {
     assertEquals("blah", argument);
   }
 
+  public void testMultipleOptions(){
+    options = new CommandLine("[-opt1 arg]");
+    String[] args = new Option().split("-opt1 blah");
+    assertTrue(options.parse(args));
+    options.hasOption("opt1");
+    assertEquals("blah", options.getOptionArgument("opt1", "arg"));
+  }
+
   public void testInvalidOption() throws Exception {
     assertFalse(createOptionsAndParse("", "-badArg"));
   }


### PR DESCRIPTION
We use Fitnesse a lot, and have found our tests are getting slower over time. We needed to have some ways to control Fitnesses behaviour to help us see whats happening under the hood.

We suspected it was us, but it could have been our heavy use of scenarios, or any number of things.

There were 3 things we wanted from the FixtureInteraction plugin :
1. A log of all fixtures we actually use, and their method entry points.
2. A log of how long these take.
3. A way of running the tests quickly to see whether the Fitnesse wiki code itself is well-formed with respect to fixtures and methods, and Table construction.

Now you can extend fitnesse.slim.fixtureInteraction.FixtureInteraction, change the behaviour and pass this in to Slim.

I have included several of these Plugins:
1. DefaultInteraction - This does what Fitnesse used to do. You can extend this modify running tests.
2. LoggingInteraction - This writes out instance creations, methods and run times to System.out.
3. MockingInteraction - This prevents calls to the SUT, and will give you an idea of the impact Fitnesse itself is having on your tests, based on the difference in run times between full tests, and the mocking test.

To make this work, create the following COMMAND_PATTERN, 

!define COMMAND_PATTERN {java -Xmx4g  -cp %p %m -i fitnesse.slim.fixtureInteraction.LoggingInteraction }

run a fitnesse test, and look on the system out page.

---

This mechanism has already helped us with refactoring.
