### PR TITLE
JUnit results printer now consistent for exceptions

### DIFF
--- a/src/fitnesse/junit/PrintTestListener.java
+++ b/src/fitnesse/junit/PrintTestListener.java
@@ -29,7 +29,7 @@ public class PrintTestListener implements ResultsListener {
   @Override
   public void testComplete(TestPage test, TestSummary testSummary, TimeMeasurement timeMeasurement) {
     System.out.println(new WikiPagePath(test.getSourcePage()).toString() + " r " + testSummary.right + " w "
-        + testSummary.wrong + " " + testSummary.exceptions 
+        + testSummary.wrong + " e " + testSummary.exceptions
         + " " + timeMeasurement.elapsedSeconds() + " seconds");
   }
 


### PR DESCRIPTION
Before the change, the output of the JUnit results printer:

```
TestName r 1 w 0 0 0.016 seconds
```

After the change:

```
TestName r 1 w 0 e 0 0.016 seconds
```
