### PR TITLE
parser: render non-existent link correctly

### DIFF
--- a/src/fitnesse/wikitext/parser/WikiWordBuilder.java
+++ b/src/fitnesse/wikitext/parser/WikiWordBuilder.java
@@ -83,7 +83,7 @@ public class WikiWordBuilder {
         HtmlTag link = new HtmlTag("a", "[?]");
         link.addAttribute("title", "create page");
         link.addAttribute("href", url+ "?edit&nonExistent=true");
-        return new HtmlText(text).html() + link.htmlInline();
+        return text + link.htmlInline();
     }
 
     private String makeParentPath(SourcePage page, String content) {

--- a/src/fitnesse/wikitext/test/WikiWordBuilderTest.java
+++ b/src/fitnesse/wikitext/test/WikiWordBuilderTest.java
@@ -1,0 +1,13 @@
+package fitnesse.wikitext.test;
+
+import fitnesse.wikitext.parser.WikiWordBuilder;
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class WikiWordBuilderTest {
+  @Test public void buildsLinkToNonExistent() {
+    WikiWordBuilder builder = new WikiWordBuilder(new TestSourcePage().withUrl("NonExistentPage"), "", "");
+    String result = builder.buildLink("", "<i>name</i>");
+    Assert.assertEquals("<i>name</i><a title=\"create page\" href=\"NonExistentPage?edit&nonExistent=true\">[?]</a>", result);
+  }
+}


### PR DESCRIPTION
From fitnesse@yahoogroups.com:
I wrote this: |[['''Test TATF001C1'''][>TestTaTf001c1]]|First Test (xy)|
but '''Test TATF001C1''' isn't bold, but displayed like that: Test TATF002C1
