### PR TITLE
Fix build on Windows

### DIFF
--- a/src/fitnesse/responders/run/TestSystem.java
+++ b/src/fitnesse/responders/run/TestSystem.java
@@ -29,7 +29,7 @@ public abstract class TestSystem implements TestSystemListener {
 
   protected static String fitnesseJar(String classpath) {
 	  for (String pathEntry: classpath.split(System.getProperty("path.separator"))) {
-		  String[] paths = pathEntry.split(System.getProperty("file.separator"));
+		  String[] paths = pathEntry.split(getFileSeparator());
 		  String jarFile = paths[paths.length-1];
 		  if ("fitnesse-standalone.jar".equals(jarFile)) {
 			  return pathEntry;
@@ -43,6 +43,12 @@ public abstract class TestSystem implements TestSystemListener {
 	  }
 	  
 	  return "fitnesse.jar";
+  }
+  
+  protected static String getFileSeparator() {
+    if ("\\".equals(System.getProperty("file.separator")))
+	  return "\\\\";
+    return System.getProperty("file.separator");
   }
   
   public TestSystem(WikiPage page, TestSystemListener testSystemListener) {


### PR DESCRIPTION
Commit cfcc9b63 causes unit test failure on Windows.

```
[junit] Testsuite: fitnesse.components.ClassPathBuilderTest
[junit] Tests run: 1, Failures: 0, Errors: 1, Time elapsed: 0.032 sec
[junit]
[junit] Testcase: testGetClasspath took 0.022 sec
[junit]     Caused an ERROR
[junit] null
[junit] java.lang.ExceptionInInitializerError
[junit]     at fitnesse.components.ClassPathBuilder.getPathSeparator(ClassPathBuilder.java:27)
[junit]     at fitnesse.components.ClassPathBuilder.getClasspath(ClassPathBuilder.java:23)
[junit]     at fitnesse.components.ClassPathBuilderTest.testGetClasspath(ClassPathBuilderTest.java:35)
[junit] Caused by: java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
[junit] \
[junit]  ^
[junit]     at java.util.regex.Pattern.error(Pattern.java:1713)
[junit]     at java.util.regex.Pattern.compile(Pattern.java:1466)
[junit]     at java.util.regex.Pattern.<init>(Pattern.java:1133)
[junit]     at java.util.regex.Pattern.compile(Pattern.java:823)
[junit]     at java.lang.String.split(String.java:2292)
[junit]     at java.lang.String.split(String.java:2334)
[junit]     at fitnesse.responders.run.TestSystem.fitnesseJar(TestSystem.java:32)
[junit]     at fitnesse.responders.run.TestSystem.<clinit>(TestSystem.java:16)
[junit]

BUILD FAILED
```

This is due to the path separator on Windows being the backslash () character and that, on its own, is not a valid regex pattern.
