### PR TITLE
Fix unit test failure on Windows jdk7

### DIFF
--- a/src/fitnesse/responders/WikiImportingResponderAuthenticationTest.java
+++ b/src/fitnesse/responders/WikiImportingResponderAuthenticationTest.java
@@ -29,6 +29,10 @@ public class WikiImportingResponderAuthenticationTest extends RegexTestCase {
     baseUrl = FitNesseUtil.URL;
 
     createResponder();
+
+    // clear out any credentials from a previous test
+    WikiImporter.remoteUsername = null;
+    WikiImporter.remotePassword = null;
   }
 
   private void createResponder() throws Exception {
@@ -78,6 +82,9 @@ public class WikiImportingResponderAuthenticationTest extends RegexTestCase {
   }
 
   public void testUnauthorizedResponse() throws Exception {
+    // ensure any credentials from a previous test have been cleared out
+    assertNull(WikiImporter.remoteUsername);
+
     makeSecurePage(testData.remoteRoot);
 
     Response response = makeSampleResponse(baseUrl);
@@ -88,6 +95,9 @@ public class WikiImportingResponderAuthenticationTest extends RegexTestCase {
   }
 
   public void testUnauthorizedResponseFromNonRoot() throws Exception {
+    // ensure any credentials from a previous test have been cleared out
+    assertNull(WikiImporter.remoteUsername);
+
     WikiPage childPage = testData.remoteRoot.getChildPage("PageOne");
     makeSecurePage(childPage);
 


### PR DESCRIPTION
If on Windows and using jdk7 unit test WikiImportingResponderAuthenticationTest
was failing due to test order dependency.

On Windows when using jdk6 order of execution of tests in WikiImportingResponderAuthenticationTest is:

```
testUnauthorizedResponse
testUnauthorizedResponseFromNonRoot
testImportingFromSecurePageWithCredentials
```

On jdk7 the order is:

```
testImportingFromSecurePageWithCredentials
testUnauthorizedResponse
testUnauthorizedResponseFromNonRoot
```

This change (documented by Oracle [here](http://www.oracle.com/technetwork/java/javase/compatibility-417013.html#jdk7)) caused both _Unauthorized_ tests to fail on jdk7 as the credentials are cached in WikiImporter from the first test and used in the subsequent tests thus causing the imports to be authorized and not then rendering the message **The wiki at .\* requires authentication.** which both test check for.

A number of questions spring up about this.
1. Should I be using jdk6 or 7 for development?
2. Do any other developers use jdk7 on platforms other than Windows and not see this issue?
3. Do any other developers use jdk7 on Windows and not have this issue?
