### PR TITLE
Allow null values when converting to and from wrapper types (in Slim)

### DIFF
--- a/src/fitnesse/slim/ConverterTest.java
+++ b/src/fitnesse/slim/ConverterTest.java
@@ -43,7 +43,18 @@ public class ConverterTest {
 		assertConverts("false", converter, "0");
 		assertConverts("false", converter, "1");
 		assertConverts("false", converter, "x");
-	}
+    assertConverts("false", converter, "null");
+    assertConverts("false", converter, "NULL");
+  }
+
+  @Test
+  public void convertBooleanWrapperNull() {
+    // the string "null" should convert to null iff the argument type is a
+    // Boolean wrapper.
+    Object[] converted = ConverterSupport.convertArgs(new Object[] { "null" },
+        new Class<?>[] { Boolean.class });
+    assertNull(converted[0]);
+  }
 
 	@Test
 	public void defaultEnumConversion() {

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -12,58 +12,62 @@ import fitnesse.slim.Converter;
 
 public class ConverterRegistry {
 
-	static Map<Class<?>, Converter<?>> converters = new HashMap<Class<?>, Converter<?>>();
+  static Map<Class<?>, Converter<?>> converters = new HashMap<Class<?>, Converter<?>>();
 
-	static {
-		addStandardConverters();
-	}
+  static {
+    addStandardConverters();
+  }
 
-	@SuppressWarnings("unchecked")
-	protected static void addStandardConverters() {
-		addConverter(void.class, new VoidConverter());
-		addConverter(String.class, new StringConverter());
-		addConverter(int.class, new IntConverter());
-		addConverter(double.class, new DoubleConverter());
-		addConverter(Integer.class, new IntConverter());
-		addConverter(Double.class, new DoubleConverter());
-		addConverter(char.class, new CharConverter());
-		addConverter(boolean.class, new BooleanConverter());
-		addConverter(Boolean.class, new BooleanConverter());
-		addConverter(Date.class, new DateConverter());
-		addConverter(List.class, new ListConverter());
-		addConverter(Integer[].class, new IntegerArrayConverter());
-		addConverter(int[].class, new IntegerArrayConverter());
-		addConverter(String[].class, new StringArrayConverter());
-		addConverter(boolean[].class, new BooleanArrayConverter());
-		addConverter(Boolean[].class, new BooleanArrayConverter());
-		addConverter(double[].class, new DoubleArrayConverter());
-		addConverter(Double[].class, new DoubleArrayConverter());
-	}
+  @SuppressWarnings("unchecked")
+  protected static void addStandardConverters() {
+    addConverter(void.class, new VoidConverter());
+    addConverter(String.class, new StringConverter());
+    addConverter(int.class, new IntConverter());
+    addConverter(Integer.class, NullableConverter.decorate(new IntConverter()));
+    addConverter(double.class, new DoubleConverter());
+    addConverter(Double.class,
+        NullableConverter.decorate(new DoubleConverter()));
+    addConverter(char.class, new CharConverter());
+    addConverter(Character.class,
+        NullableConverter.decorate(new CharConverter()));
+    addConverter(boolean.class, new BooleanConverter());
+    addConverter(Boolean.class,
+        NullableConverter.decorate(new BooleanConverter()));
+    addConverter(Date.class, NullableConverter.decorate(new DateConverter()));
+    addConverter(List.class, new ListConverter());
+    addConverter(Integer[].class, new IntegerArrayConverter());
+    addConverter(int[].class, new IntegerArrayConverter());
+    addConverter(String[].class, new StringArrayConverter());
+    addConverter(boolean[].class, new BooleanArrayConverter());
+    addConverter(Boolean[].class, new BooleanArrayConverter());
+    addConverter(double[].class, new DoubleArrayConverter());
+    addConverter(Double[].class, new DoubleArrayConverter());
+  }
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public static <T> Converter<T> getConverterForClass(Class<? extends T> clazz) {
-		if (converters.containsKey(clazz))
-			return (Converter<T>) converters.get(clazz);
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static <T> Converter<T> getConverterForClass(Class<? extends T> clazz) {
+    if (converters.containsKey(clazz))
+      return (Converter<T>) converters.get(clazz);
 
-		PropertyEditor pe = PropertyEditorManager.findEditor(clazz);
-		// com.sun.beans.EnumEditor and sun.beans.EnumEditor seem to be used in
-		// different usages.
-		if (Enum.class.isAssignableFrom(clazz)
-				&& (pe == null || "EnumEditor".equals(pe.getClass().getSimpleName())))
-			return new EnumConverter(clazz);
+    PropertyEditor pe = PropertyEditorManager.findEditor(clazz);
+    // com.sun.beans.EnumEditor and sun.beans.EnumEditor seem to be used in
+    // different usages.
+    if (Enum.class.isAssignableFrom(clazz)
+        && (pe == null || "EnumEditor".equals(pe.getClass().getSimpleName())))
+      return new EnumConverter(clazz);
 
-		if (pe != null) {
-			return new PropertyEditorConverter<T>(pe);
-		}
-		return null;
-	}
+    if (pe != null) {
+      return new PropertyEditorConverter<T>(pe);
+    }
+    return null;
+  }
 
-	public static <T> void addConverter(Class<? extends T> clazz,
-			Converter<T> converter) {
-		converters.put(clazz, converter);
-	}
+  public static <T> void addConverter(Class<? extends T> clazz,
+      Converter<T> converter) {
+    converters.put(clazz, converter);
+  }
 
-	public static Map<Class<?>, Converter<?>> getConverters() {
-		return Collections.unmodifiableMap(converters);
-	}
+  public static Map<Class<?>, Converter<?>> getConverters() {
+    return Collections.unmodifiableMap(converters);
+  }
 }

--- a/src/fitnesse/slim/converters/NullableConverter.java
+++ b/src/fitnesse/slim/converters/NullableConverter.java
@@ -1,0 +1,44 @@
+package fitnesse.slim.converters;
+
+import fitnesse.slim.Converter;
+
+/**
+ * A converter that decorates another converter, but handles <code>null</code>
+ * values.
+ * <p>
+ * If the input is <code>null</code> or "null" (case-insensitive) the converted
+ * value will be <code>null</code>. In all other cases the conversion is handed
+ * over to the delegate converter.
+ * 
+ * @author Philipp Jardas &lt;philipp@jardas.de&gt;
+ */
+public final class NullableConverter<T> implements Converter<T> {
+  private static final String NULL = "null";
+  private final Converter<T> delegate;
+
+  private NullableConverter(final Converter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  public static <T> Converter<T> decorate(final Converter<T> converter) {
+    return new NullableConverter<T>(converter);
+  }
+
+  @Override
+  public T fromString(final String arg) {
+    if (arg == null || NULL.equalsIgnoreCase(arg)) {
+      return null;
+    }
+
+    return delegate.fromString(arg);
+  }
+
+  @Override
+  public String toString(final T o) {
+    if (o == null) {
+      return NULL;
+    }
+
+    return delegate.toString(o);
+  }
+}


### PR DESCRIPTION
Currently all converters are registered for both primitive and wrapper types. These converters assume that neither the argument nor the value are ever null. This causes problems when you want to actually set a property with a wrapper type to null or want to check whether such a property is null.

I know it's bad style to explicitly set and return null, but we need to test legacy code, so there's no way around.
### Example

``` java
public class Fixutre {
    private Boolean value;
    public Boolean getValue() { return value; }
    public void setValue(Boolean value) { this.value = value; }
}
```

```
| Fixture |
| value | getValue? |
| true | true |
| false | false |
| null | null |
```

The last line in this test fixture will fail.

This pull request aims to fix issue #215.
