### PR TITLE
Fix test suite execution from build path

### DIFF
--- a/src/fitnesse/testsystems/TestSystem.java
+++ b/src/fitnesse/testsystems/TestSystem.java
@@ -18,9 +18,7 @@ import fitnesse.wiki.WikiPage;
 
 public abstract class TestSystem implements TestSystemListener {
   public static final String DEFAULT_COMMAND_PATTERN =
-    "java -cp " + fitnesseJar(System.getProperty("java.class.path")) +
-      System.getProperty("path.separator") +
-      "%p %m";
+          "java -cp %P" + System.getProperty("path.separator") + "%p %m";
 
   public static final String DEFAULT_JAVA_DEBUG_COMMAND = "java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 -cp %p %m";
   public static final String DEFAULT_CSHARP_DEBUG_RUNNER_FIND = "runner.exe";
@@ -31,24 +29,6 @@ public abstract class TestSystem implements TestSystemListener {
   protected boolean manualStart;
   private ExecutionLog log;
 
-  protected static String fitnesseJar(String classpath) {
-    for (String pathEntry: classpath.split(System.getProperty("path.separator"))) {
-      String[] paths = pathEntry.split(java.util.regex.Pattern.quote(System.getProperty("file.separator")));
-      String jarFile = paths[paths.length-1];
-      if ("fitnesse-standalone.jar".equals(jarFile)) {
-        return pathEntry;
-      }
-      if (jarFile.matches("fitnesse-\\d\\d\\d\\d\\d\\d\\d\\d.jar")) {
-        return pathEntry;
-      }
-      if (jarFile.matches("fitnesse-standalone-\\d\\d\\d\\d\\d\\d\\d\\d.jar")) {
-        return pathEntry;
-      }
-    }
-
-    return "fitnesse.jar";
-  }
-
   public TestSystem(WikiPage page, TestSystemListener testSystemListener) {
     this.page = page;
     this.testSystemListener = testSystemListener;
@@ -56,7 +36,8 @@ public abstract class TestSystem implements TestSystemListener {
 
   protected String buildCommand(TestSystem.Descriptor descriptor) {
     String commandPattern = descriptor.getCommandPattern();
-    String command = replace(commandPattern, "%p", descriptor.getClassPath());
+    String command = replace(commandPattern, "%P", System.getProperty("java.class.path"));
+    command = replace(command, "%p", descriptor.getClassPath());
     command = replace(command, "%m", descriptor.getTestRunner());
     return command;
   }

--- a/src/fitnesse/testsystems/TestSystemTest.java
+++ b/src/fitnesse/testsystems/TestSystemTest.java
@@ -2,8 +2,6 @@ package fitnesse.testsystems;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-
 import fitnesse.FitNesse;
 import fitnesse.FitNesseContext;
 import fitnesse.testsystems.TestSystem.Descriptor;
@@ -137,25 +135,5 @@ public class TestSystemTest {
     assertEquals("/path/to/somewhere", TestSystem.replace("/path%p", "%p", "/to/somewhere"));
     assertEquals("\\path\\to\\somewhere", TestSystem.replace("\\path\\%p\\somewhere", "%p", "to"));
     assertEquals("\\path\\to\\somewhere", TestSystem.replace("\\path%p", "%p", "\\to\\somewhere"));
-  }
-
-  @Test
-  public void shouldIncludeStandaloneJarByDefault() {
-    assertEquals("fitnesse.jar", TestSystem.fitnesseJar("fitnesse.jar"));
-    assertEquals("fitnesse-20121220.jar",
-            TestSystem.fitnesseJar("fitnesse-20121220.jar"));
-    assertEquals("fitnesse-standalone.jar",
-            TestSystem.fitnesseJar("fitnesse-standalone.jar"));
-    assertEquals("fitnesse-standalone-20121220.jar",
-            TestSystem.fitnesseJar("fitnesse-standalone-20121220.jar"));
-    assertEquals("fitnesse.jar",
-            TestSystem.fitnesseJar("fitnesse-book.jar"));
-    assertEquals(
-            "fitnesse-standalone-20121220.jar",
-            TestSystem.fitnesseJar(String
-                    .format("irrelevant.jar%1$sfitnesse-book.jar%1$sfitnesse-standalone-20121220.jar",
-                            System.getProperty("path.separator"))));
-    assertEquals(String.format("lib%sfitnesse-standalone.jar", File.separator),
-            TestSystem.fitnesseJar(String.format("lib%sfitnesse-standalone.jar", File.separator)));
   }
 }


### PR DESCRIPTION
I had a problem running the acceptance test suite in the fitnesse project through the browser. A "git bisect" (what a remarkable tool that is!) marked commit cfcc9b63 as the one introducing the problem.

I made a small fix, introducing a "%P" (capital P) in the command pattern. This marker is replaced by the classpath used to launch FitNesse. This is enough to het stuff working for both the "normal" fitnesse config, as well as the stand alone running.

Downside may be that also plugin jars are added to the classpath.
