### PR TITLE
Add option to suppress decoration

### DIFF
--- a/src/fitnesse/Arguments.java
+++ b/src/fitnesse/Arguments.java
@@ -18,6 +18,8 @@ public class Arguments {
   private String userpass;
   private boolean installOnly;
   private String command = null;
+  /** suppress headers, exit code from output */
+  private boolean suppressDecoration = false;
 
   public String getRootPath() {
     return rootPath;
@@ -99,5 +101,13 @@ public class Arguments {
 
   public void setCommand(String command) {
     this.command = command;
+  }
+
+  public boolean getSuppressDecoration() {
+    return suppressDecoration;
+  }
+
+  public void setSuppressDecoration(boolean suppressDecoration) {
+    this.suppressDecoration = suppressDecoration;
   }
 }

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -103,11 +103,11 @@ public class FitNesse {
     return context;
   }
 
-  public void executeSingleCommand(String command, OutputStream out) throws Exception {
+  public void executeSingleCommand(String command, OutputStream out, boolean includeDecoration) throws Exception {
     Request request = new MockRequestBuilder(command).noChunk().build();
     FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(), context);
     Response response = expediter.createGoodResponse(request);
     MockResponseSender sender = new MockResponseSender.OutputStreamSender(out);
-    sender.doSending(response);
+    sender.doSending(response, includeDecoration);
   }
 }

--- a/src/fitnesse/http/ChunkedDataProvider.java
+++ b/src/fitnesse/http/ChunkedDataProvider.java
@@ -2,6 +2,6 @@ package fitnesse.http;
 
 public interface ChunkedDataProvider {
 
-  void startSending();
+  void startSending(boolean includeDecoration);
 
 }

--- a/src/fitnesse/http/ChunkedResponse.java
+++ b/src/fitnesse/http/ChunkedResponse.java
@@ -19,11 +19,13 @@ public class ChunkedResponse extends Response {
       dontChunk = true;
   }
 
-  public void sendTo(ResponseSender sender) {
+  public void sendTo(ResponseSender sender, boolean includeDecoration) {
     this.sender = sender;
-    addStandardHeaders();
-    sender.send(makeHttpHeaders().getBytes());
-    chunckedDataProvider.startSending();
+    if (includeDecoration) {
+      addStandardHeaders();
+      sender.send(makeHttpHeaders().getBytes());
+    }
+    chunckedDataProvider.startSending(includeDecoration);
   }
 
   @Override

--- a/src/fitnesse/http/InputStreamResponse.java
+++ b/src/fitnesse/http/InputStreamResponse.java
@@ -18,10 +18,12 @@ public class InputStreamResponse extends Response {
     super("html");
   }
 
-  public void sendTo(ResponseSender sender) throws IOException {
+  public void sendTo(ResponseSender sender, boolean includeDecoration) throws IOException {
     try {
-      addStandardHeaders();
-      sender.send(makeHttpHeaders().getBytes());
+      if (includeDecoration) {
+        addStandardHeaders();
+        sender.send(makeHttpHeaders().getBytes());
+      }
       while (!reader.isEof())
         sender.send(reader.readBytes(1000));
     } finally {

--- a/src/fitnesse/http/MockChunkedDataProvider.java
+++ b/src/fitnesse/http/MockChunkedDataProvider.java
@@ -3,7 +3,7 @@ package fitnesse.http;
 public class MockChunkedDataProvider implements ChunkedDataProvider {
 
   @Override
-  public void startSending() {
+  public void startSending(boolean includeDecoration) {
     // Nothing to send.
     
   }

--- a/src/fitnesse/http/MockResponseSender.java
+++ b/src/fitnesse/http/MockResponseSender.java
@@ -40,7 +40,11 @@ public class MockResponseSender implements ResponseSender {
   }
 
   public void doSending(Response response) throws IOException {
-    response.sendTo(this);
+    doSending(response, true);
+  }
+
+  public void doSending(Response response, boolean includeDecoration) throws IOException {
+    response.sendTo(this, includeDecoration);
     assert closed == true;
   }
 
@@ -53,8 +57,8 @@ public class MockResponseSender implements ResponseSender {
       socket = new MockSocket(new PipedInputStream(), out);
     }
 
-    public void doSending(Response response) throws IOException {
-      response.sendTo(this);
+    public void doSending(Response response, boolean includeDecoration) throws IOException {
+      response.sendTo(this, includeDecoration);
       assert closed == true;
     }
   }

--- a/src/fitnesse/http/Response.java
+++ b/src/fitnesse/http/Response.java
@@ -82,7 +82,11 @@ public abstract class Response {
     return Format.JAVA.contentType.equals(contentType);
   }
 
-  public abstract void sendTo(ResponseSender sender) throws IOException;
+  public void sendTo(ResponseSender sender) throws IOException {
+    sendTo(sender, true);
+  }
+
+  public abstract void sendTo(ResponseSender sender, boolean includeDecoration) throws IOException;
 
   public abstract int getContentSize();
 

--- a/src/fitnesse/http/ResponseTest.java
+++ b/src/fitnesse/http/ResponseTest.java
@@ -61,7 +61,7 @@ public class ResponseTest {
       super(formatString);
     }
 
-    public void sendTo(ResponseSender sender) {
+    public void sendTo(ResponseSender sender, boolean includeDecoration) {
     }
 
     public int getContentSize() {

--- a/src/fitnesse/http/SimpleResponse.java
+++ b/src/fitnesse/http/SimpleResponse.java
@@ -16,10 +16,12 @@ public class SimpleResponse extends Response {
   }
 
   @Override
-  public void sendTo(ResponseSender sender) {
-    addStandardHeaders();
+  public void sendTo(ResponseSender sender, boolean includeDecoration) {
     try {
-      sender.send(makeHttpHeaders().getBytes());
+      if (includeDecoration) {
+        addStandardHeaders();
+        sender.send(makeHttpHeaders().getBytes());
+      }
       sender.send(content);
     } finally {
       sender.close();

--- a/src/fitnesse/responders/ChunkingResponder.java
+++ b/src/fitnesse/responders/ChunkingResponder.java
@@ -61,9 +61,9 @@ public abstract class ChunkingResponder implements Responder, ChunkedDataProvide
     return true;
   }
 
-  public void startSending() {
+  public void startSending(boolean includeDecoration) {
     try {
-      doSending();
+      doSending(includeDecoration);
     }
     catch (SocketException e) {
       System.out.println("Socket Exception at: " + System.currentTimeMillis());
@@ -101,5 +101,5 @@ public abstract class ChunkingResponder implements Responder, ChunkedDataProvide
    * 
    * @throws Exception
    */
-  protected abstract void doSending() throws Exception;
+  protected abstract void doSending(boolean includeDecoration) throws Exception;
 }

--- a/src/fitnesse/responders/ChunkingResponderTest.java
+++ b/src/fitnesse/responders/ChunkingResponderTest.java
@@ -21,7 +21,7 @@ public class ChunkingResponderTest {
   private FitNesseContext context;
   private WikiPage root = new WikiPageDummy();
   private ChunkingResponder responder = new ChunkingResponder() {
-    protected void doSending() throws Exception {
+    protected void doSending(boolean includeDecoration) throws Exception {
       throw exception;
     }
   };

--- a/src/fitnesse/responders/WikiImportingResponder.java
+++ b/src/fitnesse/responders/WikiImportingResponder.java
@@ -28,7 +28,7 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
     this.importer = importer;
   }
 
-  protected void doSending() throws Exception {
+  protected void doSending(boolean includeDecoration) throws Exception {
     data = page.getData();
 
     initializeImporter();

--- a/src/fitnesse/responders/run/PuppetResponse.java
+++ b/src/fitnesse/responders/run/PuppetResponse.java
@@ -13,7 +13,7 @@ public class PuppetResponse extends Response {
     this.puppeteer = puppeteer;
   }
 
-  public void sendTo(ResponseSender sender) {
+  public void sendTo(ResponseSender sender, boolean includeDecoration) {
     puppeteer.readyToSend(sender);
   }
 

--- a/src/fitnesse/responders/run/TestResponder.java
+++ b/src/fitnesse/responders/run/TestResponder.java
@@ -53,7 +53,7 @@ public class TestResponder extends ChunkingResponder implements SecureResponder 
     formatters = new CompositeFormatter();
   }
 
-  protected void doSending() throws Exception {
+  protected void doSending(boolean includeDecoration) throws Exception {
     checkArguments();
     data = page.getData();
 
@@ -65,7 +65,7 @@ public class TestResponder extends ChunkingResponder implements SecureResponder 
       doExecuteTests();
     }
 
-    closeHtmlResponse(exitCode);
+    closeHtmlResponse(exitCode, includeDecoration);
   }
 
   public void doExecuteTests() {
@@ -227,11 +227,15 @@ public class TestResponder extends ChunkingResponder implements SecureResponder 
     isClosed = true;
   }
 
-  void closeHtmlResponse(int exitCode) {
+  void closeHtmlResponse(int exitCode, boolean includeDecoration) {
     if (!isClosed()) {
       setClosed();
       response.closeChunks();
-      response.addTrailingHeader("Exit-Code", String.valueOf(exitCode));
+
+      if (includeDecoration) {
+        response.addTrailingHeader("Exit-Code", String.valueOf(exitCode));
+      }
+
       response.closeTrailer();
       response.close();
     }

--- a/src/fitnesse/responders/search/ResultResponder.java
+++ b/src/fitnesse/responders/search/ResultResponder.java
@@ -20,7 +20,7 @@ public abstract class ResultResponder extends ChunkingResponder implements
     return root.getPageCrawler();
   }
 
-  protected void doSending() {
+  protected void doSending(boolean includeDecoration) {
     HtmlPage htmlPage = context.pageFactory.newPage();
     htmlPage.setTitle(getTitle());
     htmlPage.setPageTitle(new PageTitle(getTitle()) {

--- a/src/fitnesseMain/FitNesseMain.java
+++ b/src/fitnesseMain/FitNesseMain.java
@@ -69,7 +69,7 @@ public class FitNesseMain {
     TestTextFormatter.finalErrorCount = 0;
     System.out.println("Executing command: " + arguments.getCommand());
     System.out.println("-----Command Output-----");
-    fitnesse.executeSingleCommand(arguments.getCommand(), System.out);
+    fitnesse.executeSingleCommand(arguments.getCommand(), System.out, !arguments.getSuppressDecoration());
     System.out.println("-----Command Complete-----");
     fitnesse.stop();
     if (shouldExitAfterSingleCommand()) {
@@ -100,12 +100,12 @@ public class FitNesseMain {
 
     builder.logger = makeLogger(arguments);
     builder.authenticator = makeAuthenticator(arguments.getUserpass(),
-      componentFactory);
+            componentFactory);
 
     FitNesseContext context = builder.createFitNesseContext();
 
     extraOutput = componentFactory.loadPlugins(context.responderFactory,
-        wikiPageFactory);
+            wikiPageFactory);
     extraOutput += componentFactory.loadWikiPage(wikiPageFactory);
     extraOutput += componentFactory.loadResponders(context.responderFactory);
     extraOutput += componentFactory.loadSymbolTypes();
@@ -120,7 +120,7 @@ public class FitNesseMain {
 
   public static Arguments parseCommandLine(String[] args) {
     CommandLine commandLine = new CommandLine(
-      "[-p port][-d dir][-r root][-l logDir][-e days][-o][-i][-a userpass][-c command]");
+      "[-p port][-d dir][-r root][-l logDir][-e days][-o][-i][-a userpass][-c command][-s]");
     Arguments arguments = null;
     if (commandLine.parse(args)) {
       arguments = new Arguments();
@@ -138,6 +138,8 @@ public class FitNesseMain {
         arguments.setUserpass(commandLine.getOptionArgument("a", "userpass"));
       if (commandLine.hasOption("c"))
         arguments.setCommand(commandLine.getOptionArgument("c", "command"));
+      if (commandLine.hasOption("s"))
+        arguments.setSuppressDecoration(true);
       arguments.setOmitUpdates(commandLine.hasOption("o"));
       arguments.setInstallOnly(commandLine.hasOption("i"));
     }
@@ -179,6 +181,7 @@ public class FitNesseMain {
       .println("\t-a {user:pwd | user-file-name} enable authentication.");
     System.err.println("\t-i Install only, then quit.");
     System.err.println("\t-c <command> execute single command.");
+    System.err.println("\t-s suppress output decoration (headers, exit code)");
   }
 
   private static void printStartMessage(Arguments args, FitNesseContext context) {

--- a/src/fitnesseMain/FitNesseMainTest.java
+++ b/src/fitnesseMain/FitNesseMainTest.java
@@ -59,7 +59,7 @@ public class FitNesseMainTest {
     FitNesseMain.launch(args, context, fitnesse);
     verify(fitnesse, times(1)).applyUpdates();
     verify(fitnesse, times(1)).start();
-    verify(fitnesse, times(1)).executeSingleCommand("command", System.out);
+    verify(fitnesse, times(1)).executeSingleCommand("command", System.out, true);
     verify(fitnesse, times(1)).stop();
   }
 


### PR DESCRIPTION
Adds an option to skip outputting just the test output, not the HTTP header and 'Exit-Code' footer.
