### PR TITLE
fix for collapsable page sections on iOS

### DIFF
--- a/src/fitnesse/resources/javascript/fitnesse.js
+++ b/src/fitnesse/resources/javascript/fitnesse.js
@@ -26,7 +26,7 @@ $(document).on("click", "article tr.scenario td, article tr.exception td", funct
  * Collapsible section
  */
 $(document)
-	.on("click", "article .collapsible > p.title", function () {
+	.on("touchstart click", "article .collapsible > p.title", function () {
 		$(this).parent().toggleClass('closed');
 	})
 	.on("click", "article .collapsible > p.title a", function (event) {


### PR DESCRIPTION
Currently, the collapsable sections (eg SetUp, TearDown) don't work on an iPad (ie nothing happens when you touch the collapsed section). This is because mobile safari doesn't appear to emit a "click" event. The fix is to [listen to the "touchstart" event](http://stackoverflow.com/questions/13612275/ipad-touchstart-events).
