### PR TITLE
SliM Java runner: formatting exceptions

### DIFF
--- a/src/fitnesse/slim/SlimException.java
+++ b/src/fitnesse/slim/SlimException.java
@@ -83,23 +83,30 @@ public class SlimException extends Exception {
     } else {
       sb.append(SlimServer.EXCEPTION_TAG);
     }
-    if (this.prettyPrint)
+    if (this.prettyPrint) {
       sb.append(PRETTY_PRINT_TAG_START);
+    }
 
-    if (tag != null && tag.length() > 0)
+    if (tag != null && tag.length() > 0) {
       sb.append(tag).append(" ");
+    }
 
     String msg = getMessage();
     if (msg != null && msg.length() > 0) {
       sb.append(msg);
     }
-    if (this.prettyPrint)
+    if (this.prettyPrint) {
       sb.append(PRETTY_PRINT_TAG_END);
+    }
 
+    StackTraceEnricher enricher = new StackTraceEnricher();
     if (getCause() != null) {
-      for (StackTraceElement element : getCause().getStackTrace()) {
-        sb.append("\n\tat ").append(element.toString());
+      sb.append(enricher.getStackTraceAsString(getCause()));
+    } else {
+      if (this.getStackTrace() == null || this.getStackTrace().length == 0) {
+        this.fillInStackTrace();
       }
+      sb.append(enricher.getStackTraceAsString(this));
     }
 
     return sb.toString();

--- a/src/fitnesse/slim/StackTraceEnricher.java
+++ b/src/fitnesse/slim/StackTraceEnricher.java
@@ -1,0 +1,250 @@
+package fitnesse.slim;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.security.CodeSource;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StackTraceEnricher {
+  private Map<String, ClassMetaInformation> elementInformation;
+
+  public StackTraceEnricher() {
+    this.elementInformation = new HashMap<String, ClassMetaInformation>();
+  }
+
+  public void printStackTrace(Throwable throwable) {
+    try {
+      printStackTrace(throwable, System.err);
+    } catch (IOException ioe) {
+      // Ignore.
+    }
+  }
+
+  public void printStackTrace(Throwable throwable, OutputStream stream) throws IOException {
+    stream.write(getStackTraceAsString(throwable).getBytes());
+    stream.flush();
+  }
+
+  public void printStackTrace(Throwable throwable, Writer writer) throws IOException {
+    writer.write(getStackTraceAsString(throwable));
+    writer.flush();
+  }
+
+  public String getStackTraceAsString(Throwable throwable) {
+    StringBuffer sb = new StringBuffer();
+    Throwable t = throwable;
+    if (throwable.getStackTrace() == null || throwable.getStackTrace().length == 0) {
+      t = throwable.fillInStackTrace();
+    }
+    for (StackTraceElement ste : t.getStackTrace()) {
+      sb.append("\n\tat ").append(ste.toString());
+      ClassMetaInformation cmi = getMetaInformation(ste);
+      sb.append(" [");
+      sb.append(cmi.getLocation());
+      if (!cmi.getVersion().equals(ClassMetaInformation.UNKNOWN)) {
+        sb.append(":").append(cmi.getVersion());
+      }
+      sb.append("]");
+    }
+    return sb.toString();
+  }
+
+  public String getVersion(Class<?> clazz) {
+    return getMetaInformation(clazz).getVersion();
+  }
+
+  public String getVersion(StackTraceElement element) {
+    return getMetaInformation(element).getVersion();
+  }
+
+  public String getLocation(Class<?> clazz) {
+    return getMetaInformation(clazz).getLocation();
+  }
+
+  public String getLocation(StackTraceElement element) {
+    return getMetaInformation(element).getLocation();
+  }
+
+  private ClassMetaInformation getMetaInformation(Class<?> clazz) {
+    ClassMetaInformation information;
+    if (elementInformation.containsKey(clazz.getName())) {
+      information = elementInformation.get(clazz.getName());
+    } else {
+      information = new ClassMetaInformation(clazz);
+      elementInformation.put(clazz.getName(), information);
+    }
+    return information;
+  }
+
+  private ClassMetaInformation getMetaInformation(StackTraceElement element) {
+    ClassMetaInformation information;
+    if (elementInformation.containsKey(element.getClassName())) {
+      information = elementInformation.get(element.getClassName());
+    } else {
+      information = new ClassMetaInformation(element);
+      elementInformation.put(element.getClassName(), information);
+    }
+    return information;
+  }
+
+  private static class ClassMetaInformation {
+    private static final String UNKNOWN = "n/a";
+    private static final String[] PACKAGE_PREFIXES_RTJAR = {"java.", "javax.", "sun.", "sunw.", "javafx.", "com.sun."};
+    private String version = UNKNOWN;
+    private String location = UNKNOWN;
+    private String className = UNKNOWN;
+    private String file = UNKNOWN;
+
+    public ClassMetaInformation(Class<?> clazz) {
+      analyse(clazz.getName());
+    }
+
+    public ClassMetaInformation(StackTraceElement ste) {
+      file = ste.getFileName();
+      analyse(ste.getClassName());
+    }
+
+    private void analyse(String className) {
+      try {
+        Class<?> elementClass = loadClass(className, ClassLoader.getSystemClassLoader());
+        analyse(elementClass);
+      } catch (ClassNotFoundException cnfe) {
+        this.className = className;
+      }
+    }
+
+    private void analyse(Class clazz) {
+      className = clazz.getName();
+      version = getVersion(clazz);
+      location = getLocation(clazz);
+    }
+
+    public String getVersion() {
+      return version;
+    }
+
+    public String getLocation() {
+      return location;
+    }
+
+    public String getClassName() {
+      return className;
+    }
+
+    public String getFile() {
+      return file;
+    }
+
+    private static ClassLoader getClassLoader(Class<?> clazz, ClassLoader defaultClassLoader) {
+      ClassLoader classLoader = defaultClassLoader;
+      if (clazz != null) {
+        if (clazz.getClassLoader() != null) {
+          classLoader = clazz.getClassLoader();
+        } else if ((clazz.getProtectionDomain() != null) && (clazz.getProtectionDomain().getClassLoader() != null)) {
+          classLoader = clazz.getProtectionDomain().getClassLoader();
+        }
+      }
+
+      if (classLoader == null) {
+        classLoader = ClassLoader.getSystemClassLoader();
+      }
+
+      return classLoader;
+    }
+
+    private static Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
+      if (className == null || className.length() == 0) {
+        throw new ClassNotFoundException("Unable to load a class with an empty or null name.");
+      }
+      Class<?> resolvedClass = null;
+      if (classLoader != null) {
+        try {
+          resolvedClass = classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+          // Ignore, try to resolve the class via other class loaders.
+        }
+      }
+      if (resolvedClass == null) {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null) {
+          resolvedClass = contextClassLoader.loadClass(className);
+        } else {
+          resolvedClass = StackTraceEnricher.class.getClassLoader().loadClass(className);
+        }
+      }
+      return resolvedClass;
+    }
+
+    private static String getLocation(Class<?> clazz) {
+      String location = UNKNOWN;
+      if (clazz != null) {
+        try {
+          CodeSource codeSource = clazz.getProtectionDomain().getCodeSource();
+          if (codeSource != null) {
+            String fullLocation = codeSource.getLocation().toString();
+            if (isDirectory(fullLocation)) {
+              location = fullLocation;
+            } else {
+              location = removeParentDirectories(fullLocation);
+            }
+          } else {
+            for (String rtPackage : PACKAGE_PREFIXES_RTJAR) {
+              if (clazz.getName().startsWith(rtPackage)) {
+                location = "rt.jar";
+                break;
+              }
+            }
+          }
+        } catch (Exception e) {
+          // Ignore.
+        }
+      }
+      return location;
+    }
+
+    private static String getVersion(Class<?> clazz) {
+      String version = UNKNOWN;
+      if (clazz != null) {
+        try {
+          Package pack = clazz.getPackage();
+          if (pack != null) {
+            if (pack.getImplementationVersion() != null) {
+              version = pack.getImplementationVersion();
+            } else if (pack.getSpecificationVersion() != null) {
+              version = pack.getSpecificationVersion();
+            }
+          }
+        } catch (Exception e) {
+          // Ignore.
+        }
+      }
+      return version;
+    }
+
+    private static String removeParentDirectories(String path) {
+      String parsedPath = path;
+      if (path.contains("/")) {
+        parsedPath = removeParentDirectories(path, "/");
+      } else if (path.contains("\\")) {
+        parsedPath = removeParentDirectories(path, "\\");
+      }
+      return parsedPath;
+    }
+
+    private static String removeParentDirectories(String path, String separator) {
+      String parsedPath = path;
+      if (path.indexOf(separator) > -1 && !path.endsWith(separator) || (path.indexOf(separator) < path.lastIndexOf
+          (separator))) {
+        parsedPath = parsedPath.substring(parsedPath.indexOf(separator) + 1);
+        parsedPath = removeParentDirectories(parsedPath, separator);
+      }
+      return parsedPath;
+    }
+
+    private static boolean isDirectory(String path) {
+      return path != null && (path.endsWith("/") || (path.endsWith("\\")));
+    }
+  }
+}

--- a/src/fitnesse/slim/StackTraceEnricherTest.java
+++ b/src/fitnesse/slim/StackTraceEnricherTest.java
@@ -1,0 +1,163 @@
+package fitnesse.slim;
+
+import java.io.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StackTraceEnricherTest {
+  private static final String JUNIT_JAR = "junit-4.11.jar";
+  private static final String RT_JAR = "rt.jar";
+  private static final String NON_EXISTING_FILE = "/this/should/not/exist/at/all/sadfbas";
+
+  private Throwable exception;
+  private String javaVersion;
+  private StackTraceEnricher enricher;
+
+  @Before
+  public void setUp() {
+    exception = createIoException();
+    javaVersion = getJavaVersion();
+    enricher = new StackTraceEnricher();
+  }
+
+  private Throwable createIoException() {
+    Throwable exception = null;
+    try {
+      new FileInputStream(new File(NON_EXISTING_FILE));
+      fail("Managed to find a file that shouldn't exist " + NON_EXISTING_FILE);
+    } catch (IOException ioe) {
+      if (ioe.getStackTrace() == null || ioe.getStackTrace().length == 0) {
+        ioe.fillInStackTrace();
+      }
+      exception = ioe;
+    }
+    return exception;
+  }
+
+  private String getJavaVersion() {
+    String version;
+    String fullVersion = System.getProperty("java.runtime.version", "Failed to read Java RT version");
+    if (fullVersion.contains("-")) {
+      version = fullVersion.substring(0, fullVersion.indexOf('-'));
+    } else {
+      version = fullVersion;
+    }
+    return version;
+  }
+
+  private StackTraceElement getJavaLangStackTraceElement(Throwable exception) {
+    StackTraceElement javaLangElement = null;
+    for (StackTraceElement element : exception.getStackTrace()) {
+      if (element.getClassName().startsWith("java.lang")) {
+        javaLangElement = element;
+        break;
+      }
+    }
+    if (javaLangElement == null) {
+      fail("Unable to find a java.lang class in the stack trace.");
+    }
+    return javaLangElement;
+  }
+
+  @Test
+  public void shouldWriteEnrichedStackTraceToWriter() throws Exception {
+    StringWriter writer = new StringWriter();
+    enricher.printStackTrace(exception, writer);
+    assertTrue("JUnit jar " + JUNIT_JAR + " not found in stack trace written to writer",
+        writer.toString().contains(JUNIT_JAR));
+  }
+
+  @Test
+  public void shouldWriteEnrichedStackTraceToOutputStream() throws Exception {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    enricher.printStackTrace(exception, outputStream);
+    String output = new String(outputStream.toByteArray());
+    assertTrue("JUnit jar " + JUNIT_JAR + " not found in stack trace written to output stream",
+        output.contains(JUNIT_JAR));
+  }
+
+  @Test
+  public void shouldReturnEnrichedStackTraceAsString() {
+    assertTrue("JUnit jar " + JUNIT_JAR + " not found in stack trace as String",
+        enricher.getStackTraceAsString(exception).contains(JUNIT_JAR));
+  }
+
+  @Test
+  public void shouldParseRtJar() {
+    assertTrue("Java RT jar not properly determined.", enricher.getStackTraceAsString(exception).contains(RT_JAR));
+  }
+
+  @Test
+  public void shouldAddVersionWhenAvailable() {
+    assertTrue("Version not added for rt.jar", enricher.getStackTraceAsString(exception).contains(RT_JAR + ":" +
+        javaVersion));
+  }
+
+  @Test
+  public void shouldGetVersionForClassInJarWithVersion() {
+    assertEquals("Version not retrieved for java.lang.reflect.Method",
+        enricher.getVersion(java.lang.reflect.Method.class), javaVersion);
+  }
+
+  @Test
+  public void shouldGetVersionForStackTraceElementInJarWithVersion() {
+    StackTraceElement javaLangElement = getJavaLangStackTraceElement(exception);
+    assertEquals("Version not retrieved for " + javaLangElement.getClassName(), enricher.getVersion(javaLangElement),
+        javaVersion);
+  }
+
+  @Test
+  public void shouldGetLocationForClassInJarWithVersion() {
+    assertEquals("Location not retrieved for java.lang.reflect.Method",
+        enricher.getLocation(java.lang.reflect.Method.class), RT_JAR);
+  }
+
+  @Test
+  public void shouldGetLocationForStackTraceElementInJarWithVersion() {
+    StackTraceElement javaLangElement = getJavaLangStackTraceElement(exception);
+    assertEquals("Version not retrieved for " + javaLangElement.getClassName(), enricher.getLocation(javaLangElement),
+        RT_JAR);
+  }
+
+  @Test
+  public void shouldParseDirectories() {
+    String classPath = System.getProperty("java.class.path");
+    classPath = classPath.replace('\\', '/');
+    String testLocation = enricher.getLocation(this.getClass());
+    if (!testLocation.contains(".jar")) {
+      testLocation = testLocation.replace('\\', '/');
+      if (testLocation.startsWith("file:/")) {
+        testLocation = testLocation.substring("file:/".length());
+      }
+      if (testLocation.endsWith("/")) {
+        testLocation = testLocation.substring(0, testLocation.length() - 1);
+      }
+      assertTrue("Location of unit test (" + testLocation + ") not found on the classpath.",
+          classPath.contains(testLocation));
+    } else {
+      // TODO Find a way to test this if the unit test is executed from a jar.
+      System.err.println("Unit test executed from jar file, no stable method available for testing the parsing of " +
+          "directory locations.");
+    }
+  }
+
+  @Test
+  public void shouldWriteToSystemErrByDefault() {
+    PrintStream originalErrStream = System.err;
+    try {
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      System.setErr(new PrintStream(out));
+      enricher.printStackTrace(exception);
+      String output = new String(out.toByteArray());
+      assertTrue("JUnit jar " + JUNIT_JAR + " not found in stack trace written to default System.err stream",
+          output.contains(JUNIT_JAR));
+    } finally {
+      System.setErr(originalErrStream);
+    }
+  }
+}


### PR DESCRIPTION
Initial implementation for a solution for issue unclebob/fitnesse#224

Added String parsing/enrichment of stacktraces to add the source location (jar or classpath directory) and source version if available in a jar manifest.

Also replaced the standard stacktraces send by the Slim server to fitnesse with the enriched ones.
