### PR TITLE
Make path to git executable more preferable and configurable

### DIFF
--- a/src/fitnesse/testsystems/CommandRunner.java
+++ b/src/fitnesse/testsystems/CommandRunner.java
@@ -25,23 +25,23 @@ public class CommandRunner {
   protected StringBuffer errorBuffer = new StringBuffer();
   protected int exitCode = -1;
   private TimeMeasurement timeMeasurement = new TimeMeasurement();
-  private String command = "";
+  private String[] command = { "", "" };
   private Map<String, String> environmentVariables;
 
   public CommandRunner() {
   }
 
-  public CommandRunner(String command, String input) {
+  public CommandRunner(String[] command, String input) {
     this(command, input, null);
   }
 
-  public CommandRunner(String command, String input, Map<String, String> environmentVariables) {
+  public CommandRunner(String[] command, String input, Map<String, String> environmentVariables) {
     this.command = command;
     this.input = input;
     this.environmentVariables = environmentVariables;
   }
 
-  protected CommandRunner(String command, String input, int exitCode) {
+  protected CommandRunner(String[] command, String input, int exitCode) {
     this(command, input);
     this.exitCode = exitCode;
   }
@@ -116,11 +116,11 @@ public class CommandRunner {
     }
   }
 
-  protected void setCommand(String command) {
+  protected void setCommand(String[] command) {
     this.command = command;
   }
 
-  public String getCommand() {
+  public String[] getCommand() {
     return command;
   }
 

--- a/src/fitnesse/wiki/FileSystemPage.java
+++ b/src/fitnesse/wiki/FileSystemPage.java
@@ -30,6 +30,7 @@ public class FileSystemPage extends CachingPage {
 
     versionsController = createVersionsController(componentFactory);
     createDirectoryIfNewPage(fileSystem);
+    cmSystem.setExecutable();
   }
 
   public FileSystemPage(final String path, final String name) {
@@ -299,6 +300,12 @@ public class FileSystemPage extends CachingPage {
   }
 
   class CmSystem {
+    public void setExecutable() {
+      String executable = getCmExecutable();
+      if (executable != null && !executable.isEmpty())
+        invokeCmMethod("cmSetExecutable", getCmExecutable());
+    }
+
     public void update(String fileName) {
       invokeCmMethod("cmUpdate", fileName);
     }
@@ -342,6 +349,10 @@ public class FileSystemPage extends CachingPage {
 
     private String getCmSystemVariable() {
       return readOnlyData().getVariable("CM_SYSTEM");
+    }
+
+    private String getCmExecutable() {
+      return readOnlyData().getVariable("CM_EXECUTABLE");
     }
   }
 }

--- a/src/fitnesse/wiki/cmSystems/GitCmSystem.java
+++ b/src/fitnesse/wiki/cmSystems/GitCmSystem.java
@@ -27,16 +27,43 @@ import fitnesse.testsystems.CommandRunner;
  *
  * Oh, by the way, if there is no !define for CM_SYSTEM, fitnesse is happy to use the CM_SYSTEM environment variable
  * or system property in its place (as for all variables).
+ * In addition, specify !define CM_EXECUTABLE to the path to git executable if it is not in the default location.
  * </pre>
  */
 public class GitCmSystem {
+  private static String cmExecutable = "git";
+
+  static {
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      String pf32 = System.getenv("ProgramFiles(X86)");
+      if (pf32.isEmpty()) {
+          String pf = System.getenv("ProgramFiles");
+          if (!pf.isEmpty())
+            cmExecutable = pf + "\\Git\\bin\\git.exe";
+      }
+      else
+        cmExecutable = pf32 + "\\Git\\bin\\git.exe";
+    }
+  }
+
+  /**
+   * Set the path to the CM executable.
+   *
+   * @param executable
+   */
+  public static void cmSetExecutable(String executable) {
+    if (executable == null || executable.isEmpty())
+      return;
+    cmExecutable = executable;
+  }
+
   /**
    * Called just after file has been written.
    *
    * @param payload Not needed for Git..
    */
   public static void cmUpdate(String file, String payload) throws Exception {
-    execute("cmUpdate", "/usr/local/bin/git add " + file);
+    execute("cmUpdate", new String[] { cmExecutable, "add", file });
   }
 
   /**
@@ -55,7 +82,7 @@ public class GitCmSystem {
    * @param payload Not needed for Git..
    */
   public static void cmDelete(String file, String payload) throws Exception {
-    execute("cmDelete", "/usr/local/bin/git rm -rf --cached " + file);
+    execute("cmDelete",  new String[] { cmExecutable, "rm", "-rf", "--cached", file });
   }
 
   /**
@@ -68,11 +95,14 @@ public class GitCmSystem {
     //git doesn't need this.
   }
 
-  private static void execute(String method, String command) throws Exception {
+  private static void execute(String method, String[] command) throws Exception {
     CommandRunner runner = new CommandRunner(command, "");
     runner.run();
     if (runner.getOutput().length() + runner.getError().length() > 0) {
-      System.err.println(method + " command: " + command);
+      System.err.print(method + " command: ");
+      for (int i = 0; i < command.length; i++)
+        System.err.print((i > 0 ? " " : "") + command[i]);
+      System.err.println();
       System.err.println(method + " exit code: " + runner.getExitCode());
       System.err.println(method + " out:" + runner.getOutput());
       System.err.println(method + " err:" + runner.getError());


### PR DESCRIPTION
Make it work on Windows without requiring the user to modify the source, normally in `C:\Program Files (x86)\Git\bin\git.exe` or `C:\Program Files\Git\bin\git.exe`.
Also, on Linux, it can be `/usr/local/bin/git` or `/usr/bin/git`, so simply use `git`.
