### PR TITLE
Resolved failure of GitFileVersionsController Tests on Windows

### DIFF
--- a/src/fitnesse/wiki/fs/GitFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/GitFileVersionsController.java
@@ -169,7 +169,10 @@ public class GitFileVersionsController implements VersionsController, RecentChan
     assert pagePath.startsWith(workTreePath);
 
     // Add 1 for trailing '/' (not included in abs. path)
-    return pagePath.substring(workTreePath.length() + 1);
+    pagePath = pagePath.substring(workTreePath.length() + 1);
+    // git stores paths unix-style
+    pagePath = pagePath.replace(File.separatorChar, '/');
+    return pagePath;
   }
 
   private VersionInfo getCurrentVersion(FileSystemPage page, Repository repository) {


### PR DESCRIPTION
Reason: Git on windows is using unix-style file separator (/). On windows pagePath was passed to git using windows-style separator (\) which caused failure on add or delete. Forced pagePath to always use unix-style separator.
