### PR TITLE
Fix for #296: ListConverter broken for empty lists

### DIFF
--- a/src/fitnesse/slim/converters/ListConverter.java
+++ b/src/fitnesse/slim/converters/ListConverter.java
@@ -24,7 +24,12 @@ public class ListConverter implements Converter<List> {
       arg = arg.substring(1);
     if (arg.endsWith("]"))
       arg = arg.substring(0, arg.length() - 1);
-    String[] strings = arg.split(",");
+    String[] strings;
+    if ("".equals(arg.trim())) {
+	  strings = new String[]{};
+    } else {
+      strings = arg.split(",");
+    }  
     for (int i = 0; i < strings.length; i++)
       strings[i] = strings[i].trim();
     return strings;

--- a/src/fitnesse/slim/converters/ListConverterTest.java
+++ b/src/fitnesse/slim/converters/ListConverterTest.java
@@ -1,0 +1,41 @@
+package fitnesse.slim.converters;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ListConverterTest {
+  private ListConverter converter;
+  private List<String> result;
+
+  @Before
+  public void setup() {
+
+    converter = new ListConverter();
+  }
+
+  @Test
+  public void fromEmptyList_shouldCreateEmptyList() throws Exception {
+    makeList("[]");
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void fromEmptyString_shouldCreateEmptyList() throws Exception {
+    makeList("");
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void fromStringContaingOnlyBlanks_shouldCreateEmptyList() throws Exception {
+    makeList(" ");
+    assertEquals(0, result.size());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void makeList(String inputString) {
+    result = (List<String>) converter.fromString(inputString);
+  }
+}


### PR DESCRIPTION
See #296:
This pull request contains a unit test to show that slim.converters.ListConverter is broken, and a simple fix.
