### PR TITLE
Submit search form with GET instead of POST

### DIFF
--- a/src/fitnesse/resources/templates/searchForm.vm
+++ b/src/fitnesse/resources/templates/searchForm.vm
@@ -31,6 +31,8 @@
    #foreach( $pageType in $pageTypeAttributes )
    <label for="$pageType"><input type="checkbox" id="$pageType" name="PageType" value="$pageType"#checked( "PageType" $pageType)/>$pageType</label>
    #end
+
+   <label for="Prune"><input type="checkbox" id="Prune" name="Prune"#checked( "Prune" )/>Skip</label>
   </fieldset>
      
   <fieldset>

--- a/src/fitnesse/responders/search/ExecuteSearchPropertiesResponder.java
+++ b/src/fitnesse/responders/search/ExecuteSearchPropertiesResponder.java
@@ -1,6 +1,7 @@
 package fitnesse.responders.search;
 
 import static fitnesse.responders.search.SearchFormResponder.SEARCH_ACTION_ATTRIBUTES;
+import static fitnesse.responders.search.SearchFormResponder.SEARCH_ATTRIBUTE_SKIP;
 import static fitnesse.responders.search.SearchFormResponder.SPECIAL_ATTRIBUTES;
 import static fitnesse.wiki.PageData.PAGE_TYPE_ATTRIBUTE;
 import static fitnesse.wiki.PageData.PropertyPRUNE;
@@ -67,10 +68,9 @@ public class ExecuteSearchPropertiesResponder extends ResultResponder {
     getListboxAttributesFromRequest(request, SPECIAL, SPECIAL_ATTRIBUTES,
         attributes);
 
-    // this is an ugly renaming we need to make
-    Boolean obsoleteFlag = attributes.remove("obsolete");
-    if (obsoleteFlag != null)
-      attributes.put(PropertyPRUNE, obsoleteFlag);
+    Object skip = request.getInput(SEARCH_ATTRIBUTE_SKIP);
+    if (skip != null)
+      attributes.put(SEARCH_ATTRIBUTE_SKIP, true);
 
     return attributes;
   }

--- a/src/fitnesse/responders/search/SearchFormResponder.java
+++ b/src/fitnesse/responders/search/SearchFormResponder.java
@@ -5,6 +5,7 @@ package fitnesse.responders.search;
 import static fitnesse.wiki.PageData.PropertyEDIT;
 import static fitnesse.wiki.PageData.PropertyFILES;
 import static fitnesse.wiki.PageData.PropertyPROPERTIES;
+import static fitnesse.wiki.PageData.PropertyPRUNE;
 import static fitnesse.wiki.PageData.PropertyRECENT_CHANGES;
 import static fitnesse.wiki.PageData.PropertyREFACTOR;
 import static fitnesse.wiki.PageData.PropertySEARCH;
@@ -24,7 +25,8 @@ public class SearchFormResponder implements Responder {
   public static final String[] SEARCH_ACTION_ATTRIBUTES = { PropertyEDIT, PropertyVERSIONS,
     PropertyPROPERTIES, PropertyREFACTOR, PropertyWHERE_USED };
   public static final String[] SEARCH_NAVIGATION_ATTRIBUTES = { PropertyRECENT_CHANGES, PropertyFILES, PropertySEARCH };
-  public static final String[] SPECIAL_ATTRIBUTES = { "obsolete", "SetUp", "TearDown" };
+  public static final String SEARCH_ATTRIBUTE_SKIP = PropertyPRUNE;
+  public static final String[] SPECIAL_ATTRIBUTES = { "SetUp", "TearDown" };
 
   public Response makeResponse(FitNesseContext context, Request request) {
     SimpleResponse response = new SimpleResponse();


### PR DESCRIPTION
This is convenient, and also makes the 'To save this search as a link, paste
the text below into a page.' functionality on the search results page actually
work
