### PR TITLE
Custom comparator

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/PluginUsage/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/PluginUsage/content.txt
@@ -79,6 +79,41 @@ The classes supplied must extend ''!-fitnesse.responders.editing.ContentFilter-!
 
 There may be certain (rare) situations where the default table types are not sufficient. This hook allows for custom SLiM table types. A custom table must extend fitnesse.slimTables.
 
+!3 !-Custom Comparators-!
+''required property:'' '''!-CustomComparators-! = <prefix>:<class name>'''
+
+''motivation:'' The Slim protocol is all String values. It means that comparison of an expected and actual result for complex datatypes is limited to String equality or Regular Expression matching.
+If that is not sufficient, a Custom Comparator can do more sophisticated comparisons. Once registered, a Custom Comparator is triggered by its prefix, followed by a colon, in front of the expected value.
+
+Example Comparator implementation:
+
+{{{
+public class JSONAssertComparator implements CustomComparator {
+  @Override
+  public boolean matches(String actual, String expected) {
+    try {
+      JSONAssert.assertEquals(expected, actual, false);
+      return true;
+    } catch (JSONException e) {
+      throw new RuntimeException(e.getMessage(), e);
+    }
+  }
+}
+}}}
+
+Example plugins.properties:
+
+{{{
+CustomComparators = json:com.acme.JSONAssertComparator
+}}}
+
+Example !-ScriptTable-! usage:
+
+{{{
+|script|Customer|
+|check|get|cust1|json:{id:cust1,name:"John Doe"}|
+}}}
+
 !3 !-Plugins-!
 ''required property:'' '''!-Plugins-! = <class name>[,<class name>]'''
 

--- a/src/fitnesse/PluginsLoader.java
+++ b/src/fitnesse/PluginsLoader.java
@@ -13,6 +13,8 @@ import fitnesse.components.Logger;
 import fitnesse.responders.ResponderFactory;
 import fitnesse.responders.editing.ContentFilter;
 import fitnesse.responders.editing.SaveResponder;
+import fitnesse.testsystems.slim.CustomComparator;
+import fitnesse.testsystems.slim.CustomComparatorRegistry;
 import fitnesse.testsystems.slim.tables.SlimTable;
 import fitnesse.testsystems.slim.tables.SlimTableFactory;
 import fitnesse.wikitext.parser.SymbolProvider;
@@ -155,4 +157,21 @@ public class PluginsLoader {
     return buffer.toString();
   }
 
+  public String loadCustomComparators() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+      StringBuffer buffer = new StringBuffer();
+      String[] tableList = getListFromProperties(CUSTOM_COMPARATORS);
+      if (tableList != null) {
+        buffer.append("\tCustom Comparators loaded:").append(endl);
+        for (String table : tableList) {
+          table = table.trim();
+          int colonIndex = table.lastIndexOf(':');
+          String prefix = table.substring(0, colonIndex);
+          String className = table.substring(colonIndex + 1, table.length());
+          
+          CustomComparatorRegistry.addCustomComparator(prefix, (CustomComparator) Class.forName(className).newInstance());
+          buffer.append("\t\t").append(prefix).append(":").append(className).append(endl);
+        }
+      }
+      return buffer.toString();
+    }
 }

--- a/src/fitnesse/PluginsLoaderTest.java
+++ b/src/fitnesse/PluginsLoaderTest.java
@@ -16,6 +16,8 @@ import fitnesse.responders.WikiPageResponder;
 import fitnesse.responders.editing.ContentFilter;
 import fitnesse.responders.editing.EditResponder;
 import fitnesse.responders.editing.SaveResponder;
+import fitnesse.testsystems.slim.CustomComparator;
+import fitnesse.testsystems.slim.CustomComparatorRegistry;
 import fitnesse.testsystems.slim.HtmlTable;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
@@ -188,6 +190,18 @@ public class PluginsLoaderTest {
     assertSame(TestSlimTable.class, slimTable.getClass());
   }
 
+  public void testCustomComparatorsCreation() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    testProperties.setProperty(ComponentFactory.CUSTOM_COMPARATORS, "test:" + TestCustomComparator.class.getName());
+    String content = loader.loadCustomComparators();
+
+    assertTrue(content.contains("test:"));
+    assertTrue(content.contains("TestCustomComparator"));
+
+    CustomComparator customComparator = CustomComparatorRegistry.getCustomComparatorForPrefix("test");
+    assertNotNull(customComparator);
+    assertTrue(customComparator instanceof TestCustomComparator);
+  }
+
   private HtmlTable makeMockTable(String tableIdentifier) {
     // Create just enough "table" to test if
     TableTag tableTag = new TableTag();
@@ -235,6 +249,13 @@ public class PluginsLoaderTest {
     @Override
     public List<SlimAssertion> getAssertions() {
       return null;
+    }
+  }
+  
+  public static class TestCustomComparator implements CustomComparator {
+    @Override
+    public boolean matches(String actual, String expected) {
+      return false;
     }
   }
 }

--- a/src/fitnesse/components/ComponentFactory.java
+++ b/src/fitnesse/components/ComponentFactory.java
@@ -13,6 +13,7 @@ public class ComponentFactory {
   public static final String SYMBOL_TYPES = "SymbolTypes";
   public static final String SLIM_TABLES = "SlimTables";
   public static final String AUTHENTICATOR = "Authenticator";
+  public static final String CUSTOM_COMPARATORS = "CustomComparators";
   public static final String CONTENT_FILTER = "ContentFilter";
   public static final String VERSIONS_CONTROLLER_CLASS = "VersionsController";
   public static final String VERSIONS_CONTROLLER_DAYS = VERSIONS_CONTROLLER_CLASS + ".days";

--- a/src/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
+++ b/src/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
@@ -370,6 +370,47 @@ public class HtmlSlimResponderTest {
         .getScenarios().iterator().next().getScenarioName().equals("myScenario"));
   }
 
+  @Test
+  public void customComparatorReturnsPass() throws Exception {
+    CustomComparatorRegistry.addCustomComparator("equalsIgnoreCase", new EqualsIgnoreCaseComparator());
+    getResultsForPageContents("!|script|\n"
+        + "|start|fitnesse.slim.test.TestSlim|\n"
+        + "|check|return string|equalsIgnoreCase:STRING|\n");
+    assertTestResultsContain("<td><span class=\"pass\">STRING matches string</span></td>");
+  }
+
+  @Test
+  public void customComparatorReturnsFail() throws Exception {
+    CustomComparatorRegistry.addCustomComparator("equalsIgnoreCase", new EqualsIgnoreCaseComparator());
+    getResultsForPageContents("!|script|\n"
+        + "|start|fitnesse.slim.test.TestSlim|\n"
+        + "|check|return string|equalsIgnoreCase:STRINGS|\n");
+    assertTestResultsContain("<td><span class=\"fail\">STRINGS doesn't match string</span></td>");
+  }
+
+  @Test
+  public void customComparatorReturnsMessage() throws Exception {
+    CustomComparatorRegistry.addCustomComparator("exceptionMessage", new ExceptionMessageComparator());
+    getResultsForPageContents("!|script|\n"
+        + "|start|fitnesse.slim.test.TestSlim|\n"
+        + "|check|return string|exceptionMessage:STRINGS|\n");
+    assertTestResultsContain("<td><span class=\"fail\">STRINGS doesn't match string:\nexception message</span></td>");
+  }
+
+  class EqualsIgnoreCaseComparator implements CustomComparator {
+    @Override
+    public boolean matches(String actual, String expected) {
+      return expected.equalsIgnoreCase(actual);
+    }
+  }
+	  
+  class ExceptionMessageComparator implements CustomComparator {
+    @Override
+    public boolean matches(String actual, String expected) {
+      throw new RuntimeException("exception message");
+    }
+  }
+	  
   private static class DummyListener implements TestSystemListener {
     @Override
     public void testSystemStarted(TestSystem testSystem) {

--- a/src/fitnesse/testsystems/slim/CustomComparator.java
+++ b/src/fitnesse/testsystems/slim/CustomComparator.java
@@ -1,0 +1,19 @@
+package fitnesse.testsystems.slim;
+
+/**
+ * Custom Comparator for matching strings (registered using the CustomComparator plugin).
+ */
+public interface CustomComparator {
+
+  /**
+   * Compare two string representations, to determine whether the expected result matches
+   * the actual result.
+   * @param actual String representation of the actual result
+   * @param expected String representation of the expected result
+   * @return true if they match, false if they don't match
+   * @throws Throwable if an exception or error is thrown, the throwable message is appended
+   * to the failure output
+   */
+  boolean matches(String actual, String expected);
+
+}

--- a/src/fitnesse/testsystems/slim/CustomComparatorRegistry.java
+++ b/src/fitnesse/testsystems/slim/CustomComparatorRegistry.java
@@ -1,0 +1,26 @@
+package fitnesse.testsystems.slim;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomComparatorRegistry {
+
+  final static Map<String, CustomComparator> customComparators = new HashMap<String, CustomComparator>();
+
+  public static  CustomComparator getCustomComparatorForPrefix(String prefix) {
+    if (customComparators.containsKey(prefix))
+      return (CustomComparator) customComparators.get(prefix);
+    else
+      return null;
+  }
+
+  public static void addCustomComparator(String prefix, CustomComparator customComparator) {
+    customComparators.put(prefix, customComparator);
+  }
+
+  public static Map<String, CustomComparator> getCustomComparators() {
+    return Collections.unmodifiableMap(customComparators);
+  }
+
+}

--- a/src/fitnesse/testsystems/slim/CustomComparatorRegistryTest.java
+++ b/src/fitnesse/testsystems/slim/CustomComparatorRegistryTest.java
@@ -1,0 +1,23 @@
+package fitnesse.testsystems.slim;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class CustomComparatorRegistryTest {
+
+  @Test
+  public void useConverterFromCustomizing() {
+    CustomComparatorRegistry.addCustomComparator("prefix", new Comparator());
+
+    CustomComparator comparator = CustomComparatorRegistry.getCustomComparatorForPrefix("prefix");
+    Assert.assertTrue(comparator.matches("SAME", "same"));
+  }
+
+  static class Comparator implements CustomComparator {
+    @Override
+    public boolean matches(String actual, String expected) {
+      return expected.equalsIgnoreCase(actual);
+    }
+  }
+}

--- a/src/fitnesseMain/FitNesseMain.java
+++ b/src/fitnesseMain/FitNesseMain.java
@@ -145,6 +145,7 @@ public class FitNesseMain {
     extraOutput += pluginsLoader.loadSymbolTypes(symbolProvider);
     extraOutput += pluginsLoader.loadContentFilter();
     extraOutput += pluginsLoader.loadSlimTables();
+    extraOutput += pluginsLoader.loadCustomComparators();
 
 
     WikiImportTestEventListener.register();


### PR DESCRIPTION
Allow a CustomComparator to provide a matches() implementation to compare expected and actual string representations:

public interface CustomComparator {
  /**
- Compare two string representations, to determine whether the expected result matches
- the actual result.
- @param actual String representation of the actual result
- @param expected String representation of the expected result
- @return true if they match, false if they don't match
- @throws Throwable if an exception or error is thrown, the throwable message is appended
- to the failure output
  */
  boolean matches(String actual, String expected);
  }

An example of a matches() implementation using the JSONAssert library to do matching of JSON objects could be:

  @Override
  public boolean matches(String actual, String expected) {
    try {
      JSONAssert.assertEquals(expected, actual, false);
      return true;
    } catch (JSONException e) {
      throw new RuntimeException(e.getMessage(), e);
    }
  }

Unlike Custom Type converters, Type information cannot be used to determine if a specific Custom Comparator should be used. Hence a comparator-specific prefix is needed to prefix the expected string. Since the matcher is used by FitNesse, not the Fixture, it cannot be registered by the Fixture as Custom Type converters are. Hence the Plugins mechanism should be used instead. So to register a Custom Comparator, a CustomComparators = <prefix>:<class name> entry is added to plugins.properties. An example plugins.properties for the JSON comparator would be

CustomComparators = json:test.JSONAssertComparator

Finally, a sample ScriptTable check action using the json comparator could look like this:
|script|Customer|
|check|get|cust1|json:{id:cust1,name:"John Doe"}|
