### PR TITLE
Zipfile versions increasing in size on every save

### DIFF
--- a/src/fitnesse/wiki/fs/ZipFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/ZipFileVersionsController.java
@@ -98,20 +98,20 @@ public class ZipFileVersionsController implements VersionsController {
 
   protected VersionInfo makeZipVersion(FileSystemPage page, PageData data) {
     final String dirPath = page.getFileSystemPath();
-    final Set<File> filesToZip = getFilesToZip(dirPath);
-
+    final File contentFile = new File(dirPath, contentFilename);
+    final File propertiesFile = new File(dirPath, propertiesFilename);
     final VersionInfo version = VersionInfo.makeVersionInfo(data);
 
-    if (filesToZip.size() == 0) {
+    if (!contentFile.exists() || !propertiesFile.exists()) {
       return version;
     }
+
     ZipOutputStream zos = null;
     try {
       final String filename = makeVersionFileName(page, version.getName());
       zos = new ZipOutputStream(new FileOutputStream(filename));
-      for (File aFilesToZip : filesToZip) {
-        addToZip(aFilesToZip, zos);
-      }
+      addToZip(contentFile, zos);
+      addToZip(propertiesFile, zos);
       return version;
     } catch (Throwable th) {
       throw new RuntimeException(th);
@@ -137,21 +137,6 @@ public class ZipFileVersionsController implements VersionsController {
     is.read(bytes);
     is.close();
     zos.write(bytes, 0, size);
-  }
-
-  private Set<File> getFilesToZip(final String dirPath) {
-    final Set<File> filesToZip = new HashSet<File>();
-    final File dir = new File(dirPath);
-    final File[] files = dir.listFiles();
-    if (files == null) {
-      return filesToZip;
-    }
-    for (final File file : files) {
-      if (!(isVersionFile(file) || file.isDirectory())) {
-        filesToZip.add(file);
-      }
-    }
-    return filesToZip;
   }
 
   private boolean isVersionFile(final File file) {


### PR DESCRIPTION
It seems like fitnesse is including every previous version of a zipfile when saving a page. Even if nothing gets changed, the size nearly doubles every time.

Here is an example of a page, where I just hit Edit and then Save again, without changing any content:

4,0K -rw-r--r--  1 jenkins jenkins  951 2013-09-10 07:58 content.txt
3,7M -rw-r--r--  1 jenkins jenkins 3,7M 2013-09-10 07:49 martin stange-20130909093411.zip
3,7M -rw-r--r--  1 jenkins jenkins 3,6M 2013-09-10 07:49 martin stange-20130910074904.zip
7,3M -rw-r--r--  1 jenkins jenkins 7,2M 2013-09-10 07:58 martin stange-20130910074959.zip
 15M -rw-r--r--  1 jenkins jenkins  15M 2013-09-10 07:58 martin stange-20130910075815.zip
 29M -rw-r--r--  1 jenkins jenkins  29M 2013-09-10 07:58 martin stange-20130910075817.zip
 58M -rw-r--r--  1 jenkins jenkins  58M 2013-09-10 07:58 martin stange-20130910075821.zip
4,0K -rw-r--r--  1 jenkins jenkins  314 2013-09-10 07:58 properties.xml

The problem is, that the filesize rises very quickly and if it is about ~2G, the JVM gets an OutOfMemory Exception ( depends on Xmx etc. of course ). 

We are using the latest fitnesse build ( Build #378 ) but it also occured on earlier builds. 
There are no logs that give any indication on whats happening. 
