### PR TITLE
call kill() to close socket after slim "bye"

### DIFF
--- a/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
+++ b/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
@@ -221,6 +221,7 @@ public class SlimCommandRunningClient implements SlimClient {
   public void bye() throws IOException {
     writeString("bye");
     slimRunner.join();
+    kill();
   }
 
   public static Map<String, Object> resultToMap(List<? extends Object> slimResults) {


### PR DESCRIPTION
Possible fix for Issue #341, though it might be to harsh. That's for you to decide.
Seems to resolve leaving sockets in CLOSE_WAIT. 
Unittests and integration test run succesfully.
