### PR TITLE
FitNesse used text/plain as the content type for images.

### DIFF
--- a/src/fitnesse/responders/files/FileResponder.java
+++ b/src/fitnesse/responders/files/FileResponder.java
@@ -151,6 +151,12 @@ public class FileResponder implements Responder {
         contentType = "text/javascript";
       } else if (filename.endsWith(".jar")) {
         contentType = "application/x-java-archive";
+      } else if ((filename.endsWith(".jpg")) || (filename.endsWith(".jpeg"))) {
+          contentType = "image/jpeg";
+      } else if (filename.endsWith(".png")) {
+          contentType = "image/png";
+      } else if (filename.endsWith(".gif")) {
+          contentType = "image/gif";
       } else {
         contentType = "text/plain";
       }


### PR DESCRIPTION
We use SIKULI for the GUI testing and Ideally would like to use files folder to store sample images.
Without proper contentType for images SIKULI was throwing "bad request" error.
