### PR TITLE
Decimal separator i18n in unit test not implemented

### DIFF
--- a/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
@@ -2,9 +2,7 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.reporting;
 
-import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.util.Date;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Added decimal separator i18n to the SuiteHtmlFormatterTest.

Issue based on message

http://groups.yahoo.com/neo/groups/fitnesse/conversations/messages/20522
