### PR TITLE
Regression: a stuck SlimClient is no longer killed

### DIFF
--- a/src/fitnesse/testsystems/CommandRunner.java
+++ b/src/fitnesse/testsystems/CommandRunner.java
@@ -76,7 +76,9 @@ public class CommandRunner {
   public void join() {
     waitForDeathOf(process);
     timeMeasurement.stop();
-    exitCode = process.exitValue();
+    if (isDead(process)) {
+      exitCode = process.exitValue();
+    }
   }
 
   private void waitForDeathOf(Process process) {
@@ -95,7 +97,7 @@ public class CommandRunner {
     LOG.warning("Could not detect death of command line test runner.");
   }
 
-  private boolean isDead(Process process) throws InterruptedException {
+  private boolean isDead(Process process) {
     try {
       process.exitValue();
       return true;


### PR DESCRIPTION
In version 20130531, when the SlimService process did not properly close itself after receiving a 'bye', it would be killed.

In 20131110 (and git master HEAD), this is no longer the case.

While I do think this would be desirable behavior, the way it happened in 20130531 was not very nice either (it happened as a side-effect of the MultipleTestsRunner registering an exception). AFAICS the following change makes the code work as it was actually intended: the stuck Slim command will be killed by the SlimCommandRunningClient.
