### PR TITLE
Added decimal separator i18n support to the remaining unit tests

### DIFF
--- a/test/fitnesse/reporting/DecimalSeparatorUtil.java
+++ b/test/fitnesse/reporting/DecimalSeparatorUtil.java
@@ -1,0 +1,15 @@
+package fitnesse.reporting;
+
+import java.text.DecimalFormatSymbols;
+
+public class DecimalSeparatorUtil {
+
+	public static String getDecimalSeparator() {
+	    return String.valueOf(DecimalFormatSymbols.getInstance().getDecimalSeparator());
+	  }
+
+	public static String getDecimalSeparatorForRegExp() {
+	    return getDecimalSeparator().replace(".", "\\.");
+	  }
+
+}

--- a/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
@@ -2,9 +2,10 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.reporting;
 
-import java.text.DecimalFormatSymbols;
 import java.util.Date;
 
+import static fitnesse.reporting.DecimalSeparatorUtil.getDecimalSeparator;
+import static fitnesse.reporting.DecimalSeparatorUtil.getDecimalSeparatorForRegExp;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static util.RegexTestCase.assertHasRegexp;
@@ -212,13 +213,5 @@ public class SuiteHtmlFormatterTest {
         return theElapsedTime;
       }
     };
-  }
-
-  private String getDecimalSeparator() {
-    return String.valueOf(DecimalFormatSymbols.getInstance().getDecimalSeparator());
-  }
-
-  private String getDecimalSeparatorForRegExp() {
-    return getDecimalSeparator().replace(".", "\\.");
   }
 }

--- a/test/fitnesse/reporting/TestHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/TestHtmlFormatterTest.java
@@ -4,6 +4,7 @@ package fitnesse.reporting;
 
 import java.util.Date;
 
+import static fitnesse.reporting.DecimalSeparatorUtil.getDecimalSeparator;
 import static util.RegexTestCase.assertSubString;
 
 import fitnesse.FitNesseContext;
@@ -120,7 +121,7 @@ public class TestHtmlFormatterTest {
     clock.elapse(600);
     formatter.testComplete(page, new TestSummary(1, 2, 3, 4));
     formatter.close();
-    assertSubString("<strong>Assertions:</strong> 1 right, 2 wrong, 3 ignored, 4 exceptions (0.600 seconds)", pageBuffer.toString());
+    assertSubString("<strong>Assertions:</strong> 1 right, 2 wrong, 3 ignored, 4 exceptions (0" + getDecimalSeparator() + "600 seconds)", pageBuffer.toString());
   }
 
   private TimeMeasurement newConstantElapsedTimeMeasurement(final long theElapsedTime) {

--- a/test/fitnesse/reporting/TestTextFormatterTest.java
+++ b/test/fitnesse/reporting/TestTextFormatterTest.java
@@ -1,5 +1,6 @@
 package fitnesse.reporting;
 
+import static fitnesse.reporting.DecimalSeparatorUtil.getDecimalSeparator;
 import static org.mockito.Mockito.*;
 
 import java.text.ParseException;
@@ -44,7 +45,7 @@ public class TestTextFormatterTest {
     formatter.testStarted(page);
     clock.elapse(9800);
     formatter.testComplete(page, summary);
-    verify(response).add("F " + START_TIME + " R:1    W:2    I:3    E:4    page\t()\t9.800 seconds\n");
+    verify(response).add("F " + START_TIME + " R:1    W:2    I:3    E:4    page\t()\t9" + getDecimalSeparator() + "800 seconds\n");
   }
   
   @Test
@@ -55,6 +56,6 @@ public class TestTextFormatterTest {
     clock.elapse(7600);
 
     formatter.close();
-    verify(response).add("--------\n0 Tests,\t0 Failures\t7.600 seconds.\n");
+    verify(response).add("--------\n0 Tests,\t0 Failures\t7" + getDecimalSeparator() + "600 seconds.\n");
   }
 }


### PR DESCRIPTION
One test was fixed by Barre Dijkstra, but two other tests were still failing on my (German) machine. They are now i18n'ed as well.
