### PR TITLE
Fix build on windows by using native file separator

### DIFF
--- a/src/fitnesse/FitNesseContext.java
+++ b/src/fitnesse/FitNesseContext.java
@@ -137,7 +137,7 @@ public class FitNesseContext {
   }
 
   public String getRootPagePath() {
-    return String.format("%s/%s", rootPath, rootDirectoryName);
+    return String.format("%s%s%s", rootPath, File.separator, rootDirectoryName);
   }
 
   public Properties getProperties() {

--- a/test/fitnesse/FitNesseContextTest.java
+++ b/test/fitnesse/FitNesseContextTest.java
@@ -1,0 +1,19 @@
+package fitnesse;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import fitnesse.testutil.FitNesseUtil;
+
+public class FitNesseContextTest {
+
+  @Test
+  public void testGetRootPagePath() {
+    FitNesseContext context = FitNesseUtil.makeTestContext(null);
+    assertEquals("." + File.separator + "TestDir", context.getRootPagePath());
+  }
+
+}


### PR DESCRIPTION
On Windows platform the `ant` build was failing with ...

```
[junit] Testsuite: fitnesse.responders.files.FileResponderTest
[junit] Tests run: 15, Failures: 1, Errors: 0, Time elapsed: 0.977 sec
[junit]
[junit] Testcase: testFileContent took 0.067 sec
[junit] Testcase: test304IfNotModifiedForClasspathResources took 0.055 sec
[junit] Testcase: testRecoverFromUnparseableDateInIfNotModifiedHeader took 0.066 sec
[junit] Testcase: test304IfNotModifiedForFiles took 0.126 sec
[junit] Testcase: testLastModifiedHeaderForClasspathResources took 0.042 sec

[junit] Testcase: shouldNotDealWithEscapedDirectoryOutsideFilesFolder took 0.06 sec
[junit] Testcase: testLastModifiedHeader took 0.058 sec
[junit] Testcase: shouldNotDealWithDirectoryOutsideFilesFolder took 0.061 sec
[junit] Testcase: testClasspathResourceContent took 0.048 sec
[junit] Testcase: shouldTellIfFileIsInFilesFolder took 0.05 sec
[junit] Testcase: testNotFoundFile took 0.055 sec
[junit] Testcase: testSpacesInFileName took 0.051 sec
[junit]     FAILED
[junit] expected:<.[/]TestDir\files\test F...> but was:<.[\]TestDir\files\test F...>
[junit] junit.framework.AssertionFailedError: expected:<.[/]TestDir\files\test F...> but was:<.[\]TestDir\files\test F...>
[junit]     at fitnesse.responders.files.FileResponderTest.testSpacesInFileName(FileResponderTest.java:83)
[junit]
[junit] Testcase: testUrlEncodedSpacesInFileName took 0.046 sec
[junit] Testcase: testCssMimeType took 0.057 sec
[junit] Testcase: testNavigationBackToFrontPage took 0.086 sec

BUILD FAILED
```

This was caused by `FitNesseContext#getRootPagePath` hardcoding the path separator to /.
