### PR TITLE
Use UTF-8 encoding for the captured Standard Output and Standard Error o...

### DIFF
--- a/src/fitnesse/testsystems/CommandRunner.java
+++ b/src/fitnesse/testsystems/CommandRunner.java
@@ -3,10 +3,12 @@
 
 package fitnesse.testsystems;
 
-import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +19,7 @@ import java.util.logging.Logger;
 import util.TimeMeasurement;
 
 public class CommandRunner {
+  private static final String DEFAULT_CHARSET_NAME = "UTF-8";
   private static final Logger LOG = Logger.getLogger(CommandRunner.class.getName());
 
   private Process process;
@@ -160,7 +163,7 @@ public class CommandRunner {
 
   protected void sendInput(OutputStream stdin) throws IOException {
     try {
-      stdin.write(input.getBytes("UTF-8"));
+      stdin.write(input.getBytes(DEFAULT_CHARSET_NAME));
       stdin.flush();
     } finally {
       try {
@@ -172,18 +175,22 @@ public class CommandRunner {
   }
 
   private class OutputReadingRunnable implements Runnable {
-    public InputStream input;
     public StringBuffer buffer;
+    private BufferedReader reader;
 
     public OutputReadingRunnable(InputStream input, StringBuffer buffer) {
-      this.input = new BufferedInputStream(input);
+      try {
+        reader = new BufferedReader(new InputStreamReader(input, DEFAULT_CHARSET_NAME));
+      } catch (UnsupportedEncodingException e) {
+        exceptionOccurred(e);
+      }
       this.buffer = buffer;
     }
 
     public void run() {
       try {
         int c;
-        while ((c = input.read()) != -1)
+        while ((c = reader.read()) != -1)
           buffer.append((char) c);
       } catch (Exception e) {
         exceptionOccurred(e);


### PR DESCRIPTION
...n the ErrorLogs ("Output Captured") Pages

Until now, the Output written by the started process was captured as ASCII, which is different from the default encoding used by FitNesse.

I am not sure about proper handling of the UnsupportedEncodingException, though.

There is no unit test for this. Writing one, might involve Stubbing the java.lang.Runtime.getRuntime() call or making the OutputReadingRunnable a public inner class and stubbing the InputStream. (Both probably needs some byte code manipulation library like PowerMock)
