### PR TITLE
Java 7 returns localized error messages which causes two tests to fail...

### DIFF
--- a/test/fitnesse/testsystems/CommandRunnerTest.java
+++ b/test/fitnesse/testsystems/CommandRunnerTest.java
@@ -22,7 +22,7 @@ public class CommandRunnerTest {
 
   @Test
   public void testClassNotFound() throws Exception {
-    CommandRunner runner = new CommandRunner("java BadClass", "", null);
+    CommandRunner runner = new CommandRunner("java -Duser.country=US -Duser.language=en BadClass", "", null);
     runner.run();
     assertHasRegexp("Error", runner.getError());
     assertEquals("", runner.getOutput());

--- a/test/fitnesse/testsystems/fit/FitClientTest.java
+++ b/test/fitnesse/testsystems/fit/FitClientTest.java
@@ -72,7 +72,7 @@ public class FitClientTest implements FitClientListener {
 
   @Test
   public void testStandardError() throws Exception {
-    client = new CommandRunningFitClient(new CommandRunningFitClient.OutOfProcessCommandRunner("java blah", null));
+    client = new CommandRunningFitClient(new CommandRunningFitClient.OutOfProcessCommandRunner("java -Duser.country=US -Duser.language=en blah", null));
     client.addFitClientListener(this);
     client.start();
     Thread.sleep(100);


### PR DESCRIPTION
...on non-English machines (because the tests explicitly check parts of the error message). Adding the locale to the java command invocation fixes this.
