### PR TITLE
Support "script:" prefix.

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestScriptTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestScriptTable/content.txt
@@ -1,0 +1,6 @@
+| script | echo fixture |
+| check | echo | Hello | Hello |
+
+
+| script: echo fixture |
+| check | echo | Hello | Hello |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestScriptTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestScriptTable/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
@@ -26,6 +26,7 @@ public class SlimTableFactory {
     addTableType("query:", QueryTable.class);
     addTableType("table:", TableTable.class);
     addTableType("script", ScriptTable.class);
+    addTableType("script:", ScriptTable.class);
     addTableType("scenario", ScenarioTable.class);
     addTableType("import", ImportTable.class);
     addTableType("library", LibraryTable.class);

--- a/test/fitnesse/testsystems/slim/tables/SlimTableFactoryTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableFactoryTest.java
@@ -33,6 +33,7 @@ public class SlimTableFactoryTest {
     map.put("query:", QueryTable.class);
     map.put("table:", TableTable.class);
     map.put("script", ScriptTable.class);
+    map.put("script:", ScriptTable.class);
     map.put("scenario", ScenarioTable.class);
     map.put("import", ImportTable.class);
     map.put("something", DecisionTable.class);
@@ -81,6 +82,8 @@ public class SlimTableFactoryTest {
     assertThatTableTypeImportWorks("Colon is okay too", "as:Table", "Colon is okay too", TableTable.class);
 
     assertThatTableTypeImportWorks("", "", "This should be default", DecisionTable.class);
+
+    assertThatTableTypeImportWorks("My script table", "Script", "My script Table", ScriptTable.class);
   }
 
   @Test


### PR DESCRIPTION
It's one of those issues still on the PivotalTracker site.

This enables us to define a script table type in a "define table type" table.
