### PR TITLE
StopTest in a constructor

### DIFF
--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -18,7 +18,7 @@ import static fitnesse.slim.JavaSlimFactory.createJavaSlimFactory;
 
 public class SlimService {
   public static final String OPTION_DESCRIPTOR = "[-v] [-i interactionClass] [-s statementTimeout] [-d] port";
-  static Class<? extends DefaultInteraction> interactionClass;
+  static Class<? extends DefaultInteraction> interactionClass = DefaultInteraction.class;
 
   public static class Options {
     final boolean verbose;

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -85,6 +85,7 @@ public class StatementExecutor implements StatementExecutorInterface {
       throw new SlimException(format("%s[%d]", className, args.length), e, SlimServer.COULD_NOT_INVOKE_CONSTRUCTOR,
           true);
     } catch (InvocationTargetException e) {
+      checkExceptionForStop(e.getTargetException());
       throw new SlimException(e.getTargetException(), true);
     } catch (Throwable e) {
       checkExceptionForStop(e);

--- a/src/fitnesse/slim/test/ConstructorThrows.java
+++ b/src/fitnesse/slim/test/ConstructorThrows.java
@@ -2,6 +2,16 @@ package fitnesse.slim.test;
 
 public class ConstructorThrows {
   public ConstructorThrows(String message) {
+    if ("stop test".equals(message)) {
+      throw new StopTestException(message);
+    }
     throw new RuntimeException(message);
+  }
+
+}
+
+class StopTestException extends RuntimeException {
+  public StopTestException(String message) {
+    super(message);
   }
 }

--- a/test/fitnesse/slim/StatementExecutorTestBase.java
+++ b/test/fitnesse/slim/StatementExecutorTestBase.java
@@ -1,5 +1,6 @@
 package fitnesse.slim;
 
+import fitnesse.slim.test.ConstructorThrows;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -113,7 +114,7 @@ public abstract class StatementExecutorTestBase {
     } catch (SlimException e) {
       String expectedErrorMessage = String.format(MESSAGE_NO_METHOD_IN_CLASS, "noSuchMethod", 0,
           annotatedFixtureName());
-      assertTrue(e.getMessage().contains(expectedErrorMessage));
+      assertTrue(e.getMessage(), e.getMessage().contains(expectedErrorMessage));
     }
   }
 
@@ -174,6 +175,18 @@ public abstract class StatementExecutorTestBase {
     Object result = statementExecutor.call(INSTANCE_NAME, deleteMethodName(), "filename.txt");
     assertEquals(voidMessage(), result);
     assertTrue(library.deleteCalled());
+  }
+
+  @Test
+  public void shouldThrowStopTestExceptionFromConstructor() {
+    try {
+      statementExecutor.create(INSTANCE_NAME, ConstructorThrows.class.getCanonicalName(), new Object[] { "stop test" });
+    } catch (SlimException e) {
+      assertTrue(e.toString(), e.toString().startsWith(SlimServer.EXCEPTION_STOP_TEST_TAG));
+      assertTrue(statementExecutor.stopHasBeenRequested());
+      return;
+    }
+    fail("should not get here");
   }
 
   protected MyAnnotatedSystemUnderTestFixture createAnnotatedFixture() throws Exception {


### PR DESCRIPTION
When throwing a StopTestException in a constructor, fitNesse continues to process the rest of the table. For example in the following example if an exception "StopTestException" is thrown inside of the FixtureTwo fixture's constructor, FitNesse will process the remainder of the table and give error messages that read "Method color[0] not found in com.fitnesse.FixtureOne", "Method size[0] not found in com.fitnesse.FixtureOne". It should be blue with "Test not run.". This result is confusing because it associates the error message with the previous fixture.

|script|fixture one|
|do something|

|fixture two|param1|
|color|size|
|blue|green|
