### PR TITLE
Allow touch handling of mouseover menus

### DIFF
--- a/src/fitnesse/resources/templates/wikiNav.vm
+++ b/src/fitnesse/resources/templates/wikiNav.vm
@@ -17,7 +17,7 @@
  #end
 
  #if( $actions.withEdit)
- <li id="add"><a href="$localPath?new" class="label">Add</a>
+ <li id="add" aria-haspopup="true"><a href="$localPath?new" class="label">Add</a>
   <ul>
    #foreach ($tmpl in $actions.newPageTemplates.entrySet())
    <li><a href="$localPath?new&pageTemplate=$tmpl.value">$tmpl.key</a></li>
@@ -26,7 +26,7 @@
  </li>
  #end
  
- <li id="tools"><a href="#" class="label">Tools</a>
+ <li id="tools" aria-haspopup="true"><a href="#" class="label">Tools</a>
   #set( $nav_newsection = 0 )
   #macro( group $n )#if( $nav_newsection != 0 && $nav_newsection != $n ) class="divider"#end#set( $nav_newsection = $n )#end
   <ul>


### PR DESCRIPTION
Use the aria-haspopup property for the Tools button to indicate that it has hidden hover content, so that IE 10 and greater simulates a hover on the first tap, rather than activating the link. I guess this is needed for the Add button also, but it may change the default action for non-touch,
  See http://msdn.microsoft.com/en-us/library/ie/dn265029(v=vs.85).aspx
