### PR TITLE
Plugins are always loaded from CWD/plugins

### DIFF
--- a/src/fitnesse/components/PluginsClassLoader.java
+++ b/src/fitnesse/components/PluginsClassLoader.java
@@ -1,19 +1,25 @@
 package fitnesse.components;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
 
 public class PluginsClassLoader {
 
-  protected String pluginsDirectory = "plugins";
+  private File pluginsDirectory;
+
+  public PluginsClassLoader(String rootPath) {
+    pluginsDirectory = new File(rootPath, "plugins");
+  }
 
   public void addPluginsToClassLoader() throws Exception {
-    File pluginsDir = new File(pluginsDirectory);
-    if (pluginsDir.exists())
-      for (File plugin : pluginsDir.listFiles())
+    if (pluginsDirectory.exists())
+      for (File plugin : pluginsDirectory.listFiles())
         if (plugin.getName().endsWith("jar"))
           addItemsToClasspath(plugin.getCanonicalPath());
   }

--- a/src/fitnesseMain/FitNesseMain.java
+++ b/src/fitnesseMain/FitNesseMain.java
@@ -50,7 +50,7 @@ public class FitNesseMain {
 
   public Integer launchFitNesse(ContextConfigurator contextConfigurator) throws Exception {
     configureLogging("verbose".equalsIgnoreCase(contextConfigurator.get(LOG_LEVEL)));
-    loadPlugins();
+    loadPlugins(contextConfigurator.get(ConfigurationParameter.ROOT_PATH));
 
     FitNesseContext context = contextConfigurator.makeFitNesseContext();
 
@@ -69,8 +69,8 @@ public class FitNesseMain {
     return false;
   }
 
-  private void loadPlugins() throws Exception {
-    new PluginsClassLoader().addPluginsToClassLoader();
+  private void loadPlugins(String rootPath) throws Exception {
+    new PluginsClassLoader(rootPath).addPluginsToClassLoader();
   }
 
   Integer launch(FitNesseContext context) throws Exception {

--- a/test/fitnesse/components/PluginsClassLoaderTest.java
+++ b/test/fitnesse/components/PluginsClassLoaderTest.java
@@ -16,24 +16,17 @@ import java.net.URLClassLoader;
 public class PluginsClassLoaderTest {
 
   @Test
-  public void whenPluginsDirectoryDoesNotExist() {
-    try {
-      PluginsClassLoader pluginsClassLoader = new PluginsClassLoader();
-      pluginsClassLoader.pluginsDirectory = "nonExistingPluginsDirectory";
-      assertFalse(new File(pluginsClassLoader.pluginsDirectory).exists());
-      pluginsClassLoader.addPluginsToClassLoader();
-      assertTrue("didn't cause exception", true);
-    } catch (Exception e) {
-      fail("if exception occurs when plugins directory does not exist");
-    }
+  public void whenPluginsDirectoryDoesNotExist() throws Exception {
+    PluginsClassLoader pluginsClassLoader = new PluginsClassLoader("nonExistingRootDirectory");
+    pluginsClassLoader.addPluginsToClassLoader();
+    assertTrue("didn't cause exception", true);
   }
 
   @Test
   public void addPluginsToClassLoader() throws Exception {
     String[] dynamicClasses = new String[]{"fitnesse.testing.PluginX", "fitnesse.testing.PluginY"};
-//todo This fails because some other test probably loads plugin path    assertLoadingClassCausesException(dynamicClasses);
-    PluginsClassLoader pluginsClassLoader = new PluginsClassLoader();
-    assertTrue(new File(pluginsClassLoader.pluginsDirectory).exists());
+    //todo This fails because some other test probably loads plugin path    assertLoadingClassCausesException(dynamicClasses);
+    PluginsClassLoader pluginsClassLoader = new PluginsClassLoader(".");
     pluginsClassLoader.addPluginsToClassLoader();
     assertLoadingClassWorksNow(dynamicClasses);
   }


### PR DESCRIPTION
It appears plugins are always loaded from the 'plugins' directory in the directory where FitNesse is started.

I think the plugins directory should either be relative to the root working directory specified with '-d', or it should be possible to override the plugin path with a new option. Or both :).
