### PR TITLE
Fix JSONObject asserts in PacketResponderTest

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -35,6 +35,7 @@
 		<dependency org="org.mockito" name="mockito-core" rev="1.9.5" conf="test->default" />
 		<dependency org="junit" name="junit-dep" rev="4.11" conf="test->default" />
 		<dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default" />
+		<dependency org="net.javacrumbs.json-unit" name="json-unit" rev="1.1.6" conf="test->default" />
 		<dependency org="org.mozilla" name="rhino" rev="1.7R4" conf="lesscss->default" />
 	</dependencies>
 </ivy-module>

--- a/test/fitnesse/responders/PacketResponderTest.java
+++ b/test/fitnesse/responders/PacketResponderTest.java
@@ -1,6 +1,7 @@
 package fitnesse.responders;
 
 import static org.junit.Assert.assertEquals;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
 
 import fitnesse.wiki.WikiPageUtil;
 import org.json.JSONObject;
@@ -34,11 +35,19 @@ public class PacketResponderTest {
     return (SimpleResponse) responder.makeResponse(context, request);
   }
 
+  private void assertResponseContentEquals(String expected, SimpleResponse response) {
+    if (expected.startsWith("{")) {
+      assertJsonEquals(expected, response.getContent());
+    } else {
+      assertEquals(expected, response.getContent());
+    }
+  }
+
   private void assertPageWithTableResponseWith(String table, String expected) throws Exception {
     WikiPageUtil.addPage(root, PathParser.parse("TablePage"), table);
     request.setResource("TablePage");
     SimpleResponse response = makeResponse();
-    assertEquals(expected, response.getContent());
+    assertResponseContentEquals(expected, response);
   }
 
   @Test


### PR DESCRIPTION
By definition a JSON object is an unordered set of key/value pairs (http://www.json.org/).

So this PR intends to fix some tests which depended on the order of pairs in the retrieved response. (Without this fix the offending tests are failing in my environment).
