### PR TITLE
Image parser: sort options by their keys

### DIFF
--- a/src/fitnesse/wikitext/parser/Image.java
+++ b/src/fitnesse/wikitext/parser/Image.java
@@ -1,6 +1,6 @@
 package fitnesse.wikitext.parser;
 
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 
 import util.Maybe;
@@ -27,7 +27,7 @@ public class Image extends SymbolType implements Rule {
 
         parser.moveNext(1);
         
-        Map<String, String> options = new HashMap<String, String>();
+        Map<String, String> options = new TreeMap<String, String>();
         while (parser.getCurrent().isType(SymbolType.Text) && parser.getCurrent().getContent().startsWith("-")) {
             String option = parser.getCurrent().getContent();
             parser.moveNext(1);


### PR DESCRIPTION
This ensures deterministic output like

```
  style="border:1px solid black;margin:5px 5px 5px 5px"
```

instead of also allowing the alternative:

```
  style="margin:5px 5px 5px 5px;border:1px solid black"
```

This is in order to fix ImageTest unit test failures (when executed using JVM8): it relies on order-sensitive String comparison vs expected output.
