### PR TITLE
Add a log in standard output for backward compatibility with Jenkins Fitnesse plugin

### DIFF
--- a/src/fitnesseMain/FitNesseMain.java
+++ b/src/fitnesseMain/FitNesseMain.java
@@ -126,6 +126,10 @@ public class FitNesseMain {
   }
 
   private void logStartupInfo(FitNesseContext context) {
+    // This message is on standard output for backward compatibility with Jenkins Fitnesse plugin.
+    // (ConsoleHandler of JUL uses standard error output for all messages).
+    System.out.println("Bootstrapping FitNesse, the fully integrated standalone wiki and acceptance testing framework.");
+    
     LOG.info("root page: " + context.root);
     LOG.info("logger: " + (context.logger == null ? "none" : context.logger.toString()));
     LOG.info("authenticator: " + context.authenticator);


### PR DESCRIPTION
As we have discussed in my previous pull request (https://github.com/unclebob/fitnesse/pull/452), 
I've just added a message in stdout at fitnesse startup step.
(tested with last jenkins plugin)
