### PR TITLE
More useful failure messages with JUnit runner.

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -3,6 +3,7 @@ package fitnesse.junit;
 import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
 import fitnesse.testsystems.ExecutionLog;
+import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
@@ -17,6 +18,7 @@ public class JUnitRunNotifierResultsListener implements TestSystemListener<WikiT
 
   private final Class<?> mainClass;
   private final RunNotifier notifier;
+  private Throwable firstFailure;
 
   public JUnitRunNotifierResultsListener(RunNotifier notifier, Class<?> mainClass) {
     this.notifier = notifier;
@@ -25,24 +27,18 @@ public class JUnitRunNotifierResultsListener implements TestSystemListener<WikiT
 
   @Override
   public void testStarted(WikiTestPage test) {
+    firstFailure = null;
     if (test.isTestPage()) {
       notifier.fireTestStarted(descriptionFor(test));
     }
   }
 
-  private Description descriptionFor(WikiTestPage test) {
-    return Description.createTestDescription(mainClass, new WikiPagePath(test.getSourcePage()).toString());
-  }
-
   @Override
   public void testComplete(WikiTestPage test, TestSummary testSummary) {
-    if (testSummary.getWrong() == 0 && testSummary.getExceptions() == 0) {
-      if (test.isTestPage()) {
-        notifier.fireTestFinished(descriptionFor(test));
-      }
-    } else {
-      notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("wrong: "
-          + testSummary.getWrong() + " exceptions: " + testSummary.getExceptions())));
+    if (firstFailure != null) {
+      notifier.fireTestFailure(new Failure(descriptionFor(test), firstFailure));
+    } else if (test.isTestPage()) {
+      notifier.fireTestFinished(descriptionFor(test));
     }
   }
 
@@ -52,10 +48,17 @@ public class JUnitRunNotifierResultsListener implements TestSystemListener<WikiT
 
   @Override
   public void testAssertionVerified(Assertion assertion, TestResult testResult) {
+    if (testResult != null &&
+            testResult.doesCount() &&
+            (testResult.getExecutionResult() == ExecutionResult.FAIL ||
+                    testResult.getExecutionResult() == ExecutionResult.ERROR)) {
+      firstFailure(testResult.getExecutionResult(), createMessage(testResult));
+    }
   }
 
   @Override
   public void testExceptionOccurred(Assertion assertion, ExceptionResult exceptionResult) {
+    firstFailure(exceptionResult.getExecutionResult(), exceptionResult.getMessage());
   }
 
   @Override
@@ -66,4 +69,31 @@ public class JUnitRunNotifierResultsListener implements TestSystemListener<WikiT
   public void testSystemStopped(TestSystem testSystem, ExecutionLog executionLog, Throwable cause) {
   }
 
+  private Description descriptionFor(WikiTestPage test) {
+    return Description.createTestDescription(mainClass, new WikiPagePath(test.getSourcePage()).toString());
+  }
+
+  String createMessage(TestResult testResult) {
+    if (testResult.hasActual() && testResult.hasExpected()) {
+      return String.format("[%s] expected [%s]",
+              testResult.getActual(),
+              testResult.getExpected());
+    } else if ((testResult.hasActual() || testResult.hasExpected()) && testResult.hasMessage()) {
+      return String.format("[%s] %s",
+              testResult.hasActual() ? testResult.getActual() : testResult.getExpected(),
+              testResult.getMessage());
+    }
+    return testResult.getMessage();
+  }
+
+  private void firstFailure(ExecutionResult executionResult, String message) {
+    if (firstFailure != null) {
+      return;
+    }
+    if (executionResult == ExecutionResult.ERROR) {
+      firstFailure = new Exception(message);
+    } else {
+      firstFailure = new AssertionError(message);
+    }
+  }
 }

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -1,0 +1,62 @@
+package fitnesse.junit;
+
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestResult;
+import fitnesse.testsystems.TestSummary;
+import fitnesse.testsystems.slim.results.SlimTestResult;
+import fitnesse.wiki.WikiPage;
+import org.junit.Test;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class JUnitRunNotifierResultsListenerTest {
+
+  @Test
+  public void shouldProvideFirstFailure() {
+    RunNotifier notifier = mock(RunNotifier.class);
+    JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
+
+    TestResult testResult = SlimTestResult.fail("Actual", "Expected");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), new TestSummary(0, 1, 0, 0));
+
+    ArgumentCaptor<Failure> argument = ArgumentCaptor.forClass(Failure.class);
+    verify(notifier).fireTestFailure(argument.capture());
+    Failure failure = argument.getValue();
+
+    assertThat(failure.getException(), instanceOf(AssertionError.class));
+    assertThat(failure.getMessage(), is("[Actual] expected [Expected]"));
+  }
+
+  @Test
+  public void shouldProvideFirstException() {
+    RunNotifier notifier = mock(RunNotifier.class);
+    JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
+
+    TestResult testResult = SlimTestResult.error("Message", "Actual");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), new TestSummary(0, 0, 0, 1));
+
+    ArgumentCaptor<Failure> argument = ArgumentCaptor.forClass(Failure.class);
+    verify(notifier).fireTestFailure(argument.capture());
+    Failure failure = argument.getValue();
+
+    assertThat(failure.getException(), instanceOf(Exception.class));
+    assertThat(failure.getMessage(), is("[Actual] Message"));
+  }
+
+  private WikiTestPage mockWikiTestPage() {
+    WikiPage mock = mock(WikiPage.class);
+    when(mock.isRoot()).thenReturn(true);
+    when(mock.getName()).thenReturn("WikiPage");
+    return new WikiTestPage(mock);
+  }
+}


### PR DESCRIPTION
Set the first failure or error message as failure message in the JUnit report.
