### PR TITLE
Fixes for GitFileVersionsController

### DIFF
--- a/src/fitnesse/wiki/fs/GitFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/GitFileVersionsController.java
@@ -125,7 +125,7 @@ public class GitFileVersionsController implements VersionsController, RecentChan
         adder.addFilepattern(getPath(fileVersion.getFile(), repository));
       }
       adder.call();
-      commit(git, String.format("[FitNesse] Updated files: %s.", formatFileVersions(fileVersions)));
+      commit(git, String.format("[FitNesse] Updated files: %s.", formatFileVersions(fileVersions)), fileVersions[0].getAuthor());
     } catch (GitAPIException e) {
       throw new IOException("Unable to commit changes", e);
     }
@@ -142,7 +142,7 @@ public class GitFileVersionsController implements VersionsController, RecentChan
         remover.addFilepattern(getPath(fileVersion.getFile(), repository));
       }
       remover.call();
-      commit(git, String.format("[FitNesse] Deleted files: %s.", formatFileVersions(files)));
+      commit(git, String.format("[FitNesse] Deleted files: %s.", formatFileVersions(files)), files[0].getAuthor());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -171,10 +171,13 @@ public class GitFileVersionsController implements VersionsController, RecentChan
     return builder.toString();
   }
 
-  private void commit(Git git, String message) throws GitAPIException {
+  private void commit(Git git, String message, String author) throws GitAPIException {
     Status status = git.status().call();
     if (!status.getAdded().isEmpty() || !status.getChanged().isEmpty() || !status.getRemoved().isEmpty()) {
-      git.commit().setMessage(message).call();
+      if (author==null)
+        author = "";
+      // set the commit author (if given) but ignores the email
+      git.commit().setAuthor(author, "").setMessage(message).call();
     }
   }
 
@@ -274,7 +277,7 @@ public class GitFileVersionsController implements VersionsController, RecentChan
       git.rm()
               .addFilepattern(getPath(oldFile, repository))
               .call();
-      commit(git, String.format("[FitNesse] Renamed file %s to %s.", oldFile.getPath(), renameTo.getPath()));
+      commit(git, String.format("[FitNesse] Renamed file %s to %s.", oldFile.getPath(), renameTo.getPath()), fileVersion.getAuthor());
     } catch (GitAPIException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
I had some issues using git with fitnesse, so I decided to look at the source code to see if I could fix them and contribute to the project. 
The proposed fixes solved the following problems:
1) IndexOutOfBouldsException: when pagePath=workTreePath, adding 1 to the length of workTreePath was causing substring() to throw that exception.
2) The author of the commits to the git repository was the user who executed fitnesse and not the user logged on (we have secure-write enabled).
