### PR TITLE
PageHeader not included when executing test or suite since version 20140623

### DIFF
--- a/src/fitnesse/resources/templates/testPage.vm
+++ b/src/fitnesse/resources/templates/testPage.vm
@@ -8,6 +8,8 @@
     }
 </script>
 
+$!headerContent.render()
+
 <div id="test-summary">Running Tests ...</div>
 
 <div id="test-action">

--- a/src/fitnesse/responders/run/TestResponder.java
+++ b/src/fitnesse/responders/run/TestResponder.java
@@ -160,6 +160,7 @@ public class TestResponder extends ChunkingResponder implements SecureResponder 
     htmlPage.setMainTemplate(mainTemplate());
     htmlPage.put("testExecutor", new TestExecutor());
     htmlPage.setFooterTemplate("wikiFooter.vm");
+    htmlPage.put("headerContent", new WikiPageHeaderRenderer());
     htmlPage.put("footerContent", new WikiPageFooterRenderer());
     htmlPage.setErrorNavTemplate("errorNavigator");
     htmlPage.put("errorNavOnDocumentReady", false);
@@ -175,6 +176,14 @@ public class TestResponder extends ChunkingResponder implements SecureResponder 
 
   public void setDebug(boolean debug) {
     this.debug = debug;
+  }
+
+  public class WikiPageHeaderRenderer {
+
+    public String render() {
+      return WikiPageUtil.getHeaderPageHtml(page);
+    }
+
   }
 
   public class WikiPageFooterRenderer {

--- a/test/fitnesse/responders/run/TestResponderTest.java
+++ b/test/fitnesse/responders/run/TestResponderTest.java
@@ -241,11 +241,11 @@ public class TestResponderTest {
   }
 
   @Test
-  public void testResultsDoNotHaveHeaderAndFooter() throws Exception {
+  public void testResultsDoHaveHeaderAndFooter() throws Exception {
     WikiPageUtil.addPage(root, PathParser.parse("PageHeader"), "HEADER");
     WikiPageUtil.addPage(root, PathParser.parse("PageFooter"), "FOOTER");
     doSimpleRun(passFixtureTable());
-    assertNotSubString("HEADER", results);
+    assertSubString("HEADER", results);
     assertSubString("FOOTER", results);
   }
 


### PR DESCRIPTION
The PageHeader is not included any more, when I execute a test or a suite page.
It is included, when displaying the page normally.
The PageFooter is working fine.
In version 20140418, the PageHeader was included when executing test or suite page.
