### PR TITLE
Modified command Line parser with support for config files with space in the file/folder name i.e. "c:\program files\file name.config"

### DIFF
--- a/src/fitnesse/testsystems/ClientBuilder.java
+++ b/src/fitnesse/testsystems/ClientBuilder.java
@@ -107,11 +107,11 @@ public abstract class ClientBuilder<T> {
 
   private String[] parseCommandLine(String commandLine) {
 		ArrayList<String> result = new ArrayList<String>();
-		Pattern p = Pattern.compile("\"[^\"]*\"["+System.getProperty("path.separator")+"]?|\\S+");
+		Pattern p = Pattern.compile("\"([^\"]*)\"|[\\S]+");
 		Matcher m = p.matcher(commandLine);
 		while(m.find())
 		{
-		  String token = m.group( 0 );   
+		  String token = (m.group(1)==null) ? m.group(0) : m.group(1);   
 		  result.add(token);
 		}
 		return result.toArray(new String[result.size()]); 

--- a/test/fitnesse/testsystems/ClientBuilderTest.java
+++ b/test/fitnesse/testsystems/ClientBuilderTest.java
@@ -269,9 +269,9 @@ public class ClientBuilderTest {
   public void testCommandPatternCSharpWithSuiteConfig() throws Exception {
     String specifiedPageText = "!define COMMAND_PATTERN {%m -r fitSharp.Slim.Service.Runner,fitsharp.dll -c \"c:\\program files\\suite.config\" %p}\n";
     WikiPage specifiedPage = makeTestPage(specifiedPageText);
-    WikiPageDescriptor descriptor = new WikiPageDescriptor(specifiedPage.readOnlyData(), false, false, getClassPath(specifiedPage));
+    WikiPageDescriptor descriptor = new WikiPageDescriptor(specifiedPage, false, false, getClassPath(specifiedPage));
     MockClientBuilder clientBuilder = new MockClientBuilder(descriptor);
-    assertTrue(Arrays.asList(clientBuilder.getCommandPattern()).contains("\"c:\\program files\\suite.config\""));
+    assertTrue(Arrays.asList(clientBuilder.getCommandPattern()).contains("c:\\program files\\suite.config"));
 
   }
 


### PR DESCRIPTION
As per discussion in #497 strips out double quotes.
