### PR TITLE
If classpath contains folders with spaces wrap it with double-quotes to resolve "test not run"

### DIFF
--- a/src/fitnesse/testsystems/ClassPath.java
+++ b/src/fitnesse/testsystems/ClassPath.java
@@ -46,7 +46,11 @@ public class ClassPath {
     if (elements.isEmpty()) {
       return "defaultPath";
     } else {
-      return StringUtils.join(elements, separator);
+      String result = StringUtils.join(elements, separator);
+      if (result.contains(" ") && !(result.startsWith("\"") && result.endsWith("\""))) {
+    	 result = "\""+result +"\"";
+      }
+      return result;
     }
   }
 }


### PR DESCRIPTION
Wrap full classpath into double quotes otherwise class path splits into few
command line parameters. External runner (fitSharp) could not load classes. This is what was causing "test not run" returned for fitSharp. We did discuss this subject before in #497. 
We relied on ProcessBuilder to wrap parameters with double-quotes and unfortunately I ran into cases when auto-wrapping didn't work. Unlike previous version which was wrapping classpath tokens this fix wraps the whole classpath which doesn't conflict with ProcessBuilder expectation.
