### PR TITLE
Upgrade JGit to version 3.0

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -36,7 +36,7 @@
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.7.1" conf="default" transitive="false" />
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.2.1" conf="default,maven->default"/>
-		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="2.3.1.201302201838-r" conf="default,maven->default" transitive="false"/>
+		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.0.0.201306101825-r" conf="default,maven->default" transitive="false"/>
 		<dependency org="junit" name="junit-dep" rev="4.11" conf="default,test->default" />
 		<!-- scope: test -->
 		<dependency org="org.mockito" name="mockito-core" rev="1.9.5" conf="test->default" />


### PR DESCRIPTION
Noticed FitNesse depends on an older version of JGit, and thought it could be upgraded to a more recent version.
Verified unit and acceptance tests still run green with the newer version.

It should be noted that the version in this patch (3.0) isn't the latest version either, that would be 3.5.0.201409260305-r. I naturally tried to upgrade to the latest version first, but ran into problems. Unit tests ran fine, but when I attempted to run the acceptance tests I got the following error message:
acceptance_tests:
     [java] Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
     [java]     at sun.security.util.SignatureFileVerifier.processImpl(SignatureFileVerifier.java:284)
     [java]     at sun.security.util.SignatureFileVerifier.process(SignatureFileVerifier.java:238)
     [java]     at java.util.jar.JarVerifier.processEntry(JarVerifier.java:273)
     [java]     at java.util.jar.JarVerifier.update(JarVerifier.java:228)
     [java]     at java.util.jar.JarFile.initializeVerifier(JarFile.java:383)
     [java]     at java.util.jar.JarFile.getInputStream(JarFile.java:450)
     [java]     at sun.misc.URLClassPath$JarLoader$2.getInputStream(URLClassPath.java:776)
     [java]     at sun.misc.Resource.cachedInputStream(Resource.java:77)
     [java]     at sun.misc.Resource.getByteBuffer(Resource.java:160)
     [java]     at java.net.URLClassLoader.defineClass(URLClassLoader.java:442)
     [java]     at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
     [java]     at java.net.URLClassLoader$1.run(URLClassLoader.java:367)
     [java]     at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
     [java]     at java.security.AccessController.doPrivileged(Native Method)
     [java]     at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
     [java]     at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
     [java]     at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
     [java]     at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
     [java]     at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)

BUILD FAILED

Read a bit about this online, and the error seems to occur if signed jars are combined into one large jar. Sounds like fitnesse-standalone.jar would do something like that by combining all required dependencies. One of the suggested fixes is to strip out the signatures from the dependencies when creating the combined jar. I don't know if that is something one would want to do though... See also  http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar.

I don't know how to proceede with that, but it's possible it should be dealt with in a separate issue whether or not this is merged, if it would be preferable to upgrade to JGit 3.5.
