### PR TITLE
Rest of the test table interrupted with __EXCEPTION__:ABORT_SLIM_TEST colored as passed

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/TestPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/TestPage/content.txt
@@ -1,0 +1,17 @@
+!define TEST_SYSTEM {slim}
+
+!|import|
+|fitnesse.slim.test|
+
+!|Scenario|Stop Test|
+|start|ConstructorThrows|stop test|
+
+!|Scenario|Not Executed|MESSAGE |
+|check|echo|@MESSAGE|cannot fail @MESSAGE|
+
+!|Script|
+|Stop Test|
+|Not Executed and should be ignored|
+
+!|Script|
+|Not Executed and should be ignored as well|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/TestPage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/TestPage/properties.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit/>
+	<Files/>
+	<Help>The test page, as stated in the table</Help>
+	<Properties/>
+	<Prune/>
+	<RecentChanges/>
+	<Refactor/>
+	<Search/>
+	<Test/>
+	<Versions/>
+	<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
@@ -1,0 +1,30 @@
+See also: >TestPage.
+
+!| script |
+|given page|TestPage|with content|${SUT_PATH} !-
+
+!define TEST_SYSTEM {slim}
+
+!|import|
+|fitnesse.slim.test|
+
+!|Scenario|Stop Test|
+|start|ConstructorThrows|stop test|
+
+!|Scenario|Not Executed|MESSAGE |
+|check|echo|@MESSAGE|cannot fail @MESSAGE|
+
+!|Script|
+|Stop Test|
+|Not Executed and should be ignored|
+
+!|Script|
+|Not Executed and should be ignored as well|
+-!|
+|test results for page|TestPage|should contain|Test not run|
+
+!|Response Examiner. |
+|type |pattern |matches?|
+|contents|class="ignore"\W+Test not run|true |
+|contents|class="pass">Not Executed |false |
+|contents|class="ignore">Not Executed |true |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test>true</Test>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/src/fitnesse/testsystems/ExecutionResult.java
+++ b/src/fitnesse/testsystems/ExecutionResult.java
@@ -28,14 +28,14 @@ public enum ExecutionResult {
   }
   
   public static ExecutionResult getExecutionResult(TestSummary testSummary) {
-	if (testSummary.getWrong() > 0) {
-	  return FAIL;
+    if (testSummary.getWrong() > 0) {
+      return FAIL;
     } else if (testSummary.getExceptions() > 0) {
-	  return ERROR;
-	} else if (testSummary.getIgnores() > 0 && testSummary.getRight() == 0) {
-	  return IGNORE;
-	}
-	return PASS;
+      return ERROR;
+    } else if (testSummary.getRight() > 0) {
+      return PASS;
+    }
+    return IGNORE;
   }
   
   public static boolean isSuiteMetaPage(String relativeName) {


### PR DESCRIPTION
When test runner throws **EXCEPTION**:ABORT_SLIM_TEST then test execution interrupts (as it should) and all tables after exception have "test not run" message. Message itself is colored grey (ignored style).
However all table rows which include "test not run" message in them colored green (passed style).
Some of the older versions from 2013 colored rest of table in grey if test was not run. 
IMHO old behavior was correct and new one is wrong.
