### PR TITLE
Upgrade Mockito dependency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -39,7 +39,7 @@
 		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.5.1.201410131835-r" conf="default,maven->default" transitive="false"/>
 		<dependency org="junit" name="junit-dep" rev="4.11" conf="default,test->default" />
 		<!-- scope: test -->
-		<dependency org="org.mockito" name="mockito-core" rev="1.9.5" conf="test->default" />
+		<dependency org="org.mockito" name="mockito-core" rev="1.10.8" conf="test->default" />
 		<dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default" />
 		<dependency org="net.javacrumbs.json-unit" name="json-unit" rev="1.1.6" conf="test->default" />
 		<dependency org="org.mozilla" name="rhino" rev="1.7R4" conf="lesscss->default" />


### PR DESCRIPTION
Upgrades Mockito dependency to point to a more recent release.

(Strictly speaking, 1.10.13 would be the latest at this point in time, but when attempting to build it didn't seem to find newer versions in the repo)
