### PR TITLE
Upgraded dependencies

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -34,12 +34,12 @@
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="default,maven->default" />
 		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="default,maven->default" />
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
-		<dependency org="org.apache.ant" name="ant" rev="1.7.1" conf="default" transitive="false" />
-		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.2.1" conf="default,maven->default"/>
-		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.5.1.201410131835-r" conf="default,maven->default" transitive="false"/>
+		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />
+		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.3.0" conf="default,maven->default"/>
+		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.5.2.201411120430-r" conf="default,maven->default" transitive="false"/>
 		<dependency org="junit" name="junit-dep" rev="4.11" conf="default,test->default" />
 		<!-- scope: test -->
-		<dependency org="org.mockito" name="mockito-core" rev="1.10.8" conf="test->default" />
+		<dependency org="org.mockito" name="mockito-core" rev="1.10.17" conf="test->default" />
 		<dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default" />
 		<dependency org="net.javacrumbs.json-unit" name="json-unit" rev="1.1.6" conf="test->default" />
 		<dependency org="org.mozilla" name="rhino" rev="1.7R4" conf="lesscss->default" />


### PR DESCRIPTION
Upgrades various build dependencies to later versions.

Two notes:
I had some tests failing the first time I tried to build this, but I have not been able to reproduce this on subsequent runs. Don't really know why that would be, but let me know if you encounter problems.
JUnit recently released version 4.12, but I couldn't find a newer version of the junit-dep artifact.
