### PR TITLE
fixes #572: When running tests with 'runTestsMatchingAllTags' and 'exclu...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ fitserverSentinel*
 tmp/*
 /classes
 /test-classes/
+/bin/

--- a/src/fitnesse/testrunner/SuiteFilter.java
+++ b/src/fitnesse/testrunner/SuiteFilter.java
@@ -21,7 +21,6 @@ public class SuiteFilter {
 
   final private SuiteTagMatcher notMatchTags;
   final private SuiteTagMatcher matchTags;
-  final private boolean andStrategy;
   final private String startWithTest;
   
   public static final SuiteFilter NO_MATCHING = new SuiteFilter(null, null, null, null) {
@@ -35,19 +34,16 @@ public class SuiteFilter {
   public SuiteFilter(String orTags, String mustNotMatchTags, String andTags, String startWithTest) {
     this.startWithTest = (!"".equals(startWithTest)) ? startWithTest : null;
     if(andTags != null) {
-      matchTags = new SuiteTagMatcher(andTags, true);
-      andStrategy = true;
+      matchTags = new SuiteTagMatcher(andTags, true, true);
     } else {
-      matchTags = new SuiteTagMatcher(orTags, true);
-      andStrategy = false;
+      matchTags = new SuiteTagMatcher(orTags, true, false);
     }
-    notMatchTags = new SuiteTagMatcher(mustNotMatchTags, false);
+    notMatchTags = new SuiteTagMatcher(mustNotMatchTags, false, false);
   }
 
   public SuiteFilter(String suiteFilter, String excludeSuiteFilter) {
-    matchTags = new SuiteTagMatcher(suiteFilter, true);
-    notMatchTags = new SuiteTagMatcher(excludeSuiteFilter, false);
-    andStrategy = false;
+    matchTags = new SuiteTagMatcher(suiteFilter, true, false);
+    notMatchTags = new SuiteTagMatcher(excludeSuiteFilter, false, false);
     startWithTest = null;
   }
 
@@ -92,7 +88,7 @@ public class SuiteFilter {
     List<String> criterias = new LinkedList<String>();
     
     if (matchTags.isFiltering()) {
-      if(andStrategy){
+      if(matchTags.andStrategy){
         criterias.add("matches all of '" + matchTags.tagString + "'");
       } else {
         criterias.add("matches '" + matchTags.tagString + "'");
@@ -115,8 +111,9 @@ public class SuiteFilter {
     final private List<String> tags;
     final String tagString;
     final private boolean matchIfNoTags;
-    
-    public SuiteTagMatcher(String suiteTags, boolean matchIfNoTags) {
+    final private boolean andStrategy;
+
+    public SuiteTagMatcher(String suiteTags, boolean matchIfNoTags, boolean andStrategy) {
       tagString = suiteTags;
       if (suiteTags != null) {
         tags = Arrays.asList(suiteTags.split(LIST_SEPARATOR));
@@ -125,6 +122,7 @@ public class SuiteFilter {
         tags = null;
       }
       this.matchIfNoTags = matchIfNoTags;
+      this.andStrategy = andStrategy;
     }
     
     boolean isFiltering() {

--- a/test/fitnesse/testrunner/SuiteFilterTest.java
+++ b/test/fitnesse/testrunner/SuiteFilterTest.java
@@ -166,6 +166,19 @@ public class SuiteFilterTest {
   }
 
   @Test
+  public void testChecksNotMatchFilterWithInvalidTagSuite() throws Exception {
+    SuiteFilter filter = new SuiteFilter(null, "bad, notsobad", "",  null);
+
+    WikiPage failSuite = addTestPage(root, "FailSuite", "Bad Test");
+    PageData data = failSuite.getData();
+    data.setAttribute(PageData.PropertySUITES, "bad");
+    data.setAttribute("Suite");
+    failSuite.commit(data);
+
+    assertFalse(filter.getFilterForTestsInSuite(failSuite).hasMatchingTests());
+  }
+
+  @Test
   public void testFilterDescription() throws Exception {
     SuiteFilter filter = new SuiteFilter("good", "bad", null, "FirstTest");
     assertEquals("matches 'good' & doesn't match 'bad' & starts with test 'FirstTest'", filter.toString());


### PR DESCRIPTION
...deSuiteFilter', the exclude filter behaves AND-like

moved the 'andStrategy' property into the SuiteMatcherClass
added testcase