### PR TITLE
Issue 537 - Ignore ';' when script table looking up scenario name.

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestSequentialArgumentProcessing/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestSequentialArgumentProcessing/content.txt
@@ -34,3 +34,26 @@
 
 !|script                        |
 |check|echo string|$RESULT|x y z|
+
+!3 Script name's character case should be identical to scenario name's character case.
+!|scenario|conCatentate _ _ _     |input1,input2,input3   |
+|$RESULT= |concatenate three args;|@input1|@input2|@input3|
+
+!|script                                |
+|conCatentate a b c                     |
+|check        |echo string|$RESULT|a b c|
+|conCatentate;|a          |b      |c    |
+|check        |echo string|$RESULT|a b c|
+
+!|scenario|con                    |input1 |cAt    |input2|enate|input3|
+|$RESULT= |concatenate three args;|@input1|@input2|@input3            |
+
+!|ConCAtEnate;|input1     |input2 |input3|
+|input1       |input2     |input3        |
+|x            |y          |z             |
+|check        |echo string|$RESULT|x y z |
+
+!|Con  |input1     |CAt    |input2|Enate|input3|
+|input1|input2     |input3                     |
+|x     |y          |z                          |
+|check |echo string|$RESULT|x y z              |

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -153,7 +153,8 @@ public class ScriptTable extends SlimTable {
   protected List<SlimAssertion> assertionsFromScenario(int row) throws SyntaxError {
     int lastCol = table.getColumnCountInRow(row) - 1;
     String actionName = getActionNameStartingAt(0, lastCol, row);
-    ScenarioTable scenario = getTestContext().getScenario(Disgracer.disgraceClassName(actionName));
+    ScenarioTable scenario = getTestContext().getScenario(Disgracer.disgraceClassName(
+            actionName.replace(SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX, "")));
     List<SlimAssertion> assertions = new ArrayList<SlimAssertion>();
     if (scenario != null) {
       scenario.setCustomComparatorRegistry(customComparatorRegistry);


### PR DESCRIPTION
The logic to calculate function names in Scenario and Script Tables uses the same code (Disgracer).  However, Script function names can have additional ';' character (to signify sequential argument processing) that causes the name to be disgraced (camel-cased) and possibly differ from the saved Scenario name.

Pull request is suggested fix of ignoring ';' character in Script Table's calculating of function name.