### PR TITLE
fixes 575

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/OrderedQueryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/OrderedQueryTable.java
@@ -30,7 +30,9 @@ public class OrderedQueryTable extends QueryTable {
       }
     }
 
-    return markSurplusRows(queryResults, unmatchedResultRows);
+    markSurplusRows(queryResults, unmatchedResultRows);
+
+    return unmatchedResultRows.size() > 0 ? ExecutionResult.FAIL : ExecutionResult.PASS;
   }
 
   private MatchedResult takeBestMatch(Iterable<MatchedResult> potentialMatchesByScore, int tableRow) {

--- a/src/fitnesse/testsystems/slim/tables/QueryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/QueryTable.java
@@ -111,7 +111,9 @@ public class QueryTable extends SlimTable {
     }
 
     markMissingRows(unmatchedTableRows);
-    return markSurplusRows(queryResults, unmatchedResultRows);
+    markSurplusRows(queryResults, unmatchedResultRows);
+
+    return unmatchedTableRows.size() > 0 || unmatchedResultRows.size() > 0 ? ExecutionResult.FAIL : ExecutionResult.PASS;
   }
 
   protected MatchedResult takeBestMatch(Iterable<MatchedResult> potentialMatchesByScore) {
@@ -159,8 +161,7 @@ public class QueryTable extends SlimTable {
     getTestContext().increment(testResult.getExecutionResult());
   }
 
-  protected ExecutionResult markSurplusRows(final QueryResults queryResults, List<Integer> unmatchedRows) {
-    ExecutionResult result = ExecutionResult.PASS;
+  protected void markSurplusRows(final QueryResults queryResults, List<Integer> unmatchedRows) {
     for (int unmatchedRow : unmatchedRows) {
       List<String> surplusRow = queryResults.getList(fieldNames, unmatchedRow);
       int newTableRow = table.addRow(surplusRow);
@@ -168,9 +169,7 @@ public class QueryTable extends SlimTable {
       table.updateContent(0, newTableRow, testResult);
       getTestContext().increment(ExecutionResult.FAIL);
       markMissingFields(surplusRow, newTableRow);
-      result = ExecutionResult.FAIL;
     }
-    return result;
   }
 
   private void markMissingFields(List<String> surplusRow, int newTableRow) {


### PR DESCRIPTION
When using a Query decission table, not all wrongs are reported in the JUnitRunNotifierResultsListener

when evaluating the missing & surplus rows, only ExecutionResult was based on the surplus rows, not the missing rows. changed the logic to check if either one has rows left and return the ExecutionResult status based on that

Change-Id: I1902a412e6e589982a4da48dd1603698ac641c44