### PR TITLE
Switch from junit-dep to junit and upgrade to latest version (4.12)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -37,7 +37,7 @@
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.3.0" conf="default,maven->default"/>
 		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.5.2.201411120430-r" conf="default,maven->default" transitive="false"/>
-		<dependency org="junit" name="junit-dep" rev="4.11" conf="default,test->default" />
+		<dependency org="junit" name="junit" rev="4.12" conf="default,test->default" />
 		<!-- scope: test -->
 		<dependency org="org.mockito" name="mockito-core" rev="1.10.17" conf="test->default" />
 		<dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default" />


### PR DESCRIPTION
During the last batch of dependency upgrades I wasn't able to find a newer version of junit-dep even though Junit 4.12 had been released. When running `ant` I've now seen that I get the following output:
```
[ivy:resolve] junit#junit-dep;4.11 is relocated to junit#junit;4.11. Please update your dependencies.
[ivy:resolve] 	found junit#junit-dep;4.11 in maven2
[ivy:resolve] 	found junit#junit;4.11 in maven2
```

Therefore I've switched to junit#junit. (See also junit 4.11 release notes https://github.com/junit-team/junit/blob/master/doc/ReleaseNotes4.11.md)