### PR TITLE
Upgrades to ivy 2.4.0 and dependencies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -364,7 +364,7 @@
 
 	<target name="ivy-download" unless="ivy.download.not.required">
 		<mkdir dir="${antlib.dir}" />
-		<get src="${maven.central.url}/org/apache/ivy/ivy/2.3.0/ivy-2.3.0.jar" dest="${antlib.dir}/ivy.jar" usetimestamp="true" verbose="true" />
+		<get src="${maven.central.url}/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar" dest="${antlib.dir}/ivy.jar" usetimestamp="true" verbose="true" />
 		<!-- The following libs are used for signing artifacts
 		     when deployed to Maven Central.  -->
 		<get src="${maven.central.url}/org/bouncycastle/bcprov-jdk16/1.46/bcprov-jdk16-1.46.jar" dest="${antlib.dir}/bcprov.jar" usetimestamp="true" verbose="true" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -36,10 +36,10 @@
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.3.0" conf="default,maven->default"/>
-		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.5.2.201411120430-r" conf="default,maven->default" transitive="false"/>
+		<dependency org="org.eclipse.jgit" name="org.eclipse.jgit" rev="3.6.1.201501031845-r" conf="default,maven->default" transitive="false"/>
 		<dependency org="junit" name="junit" rev="4.12" conf="default,test->default" />
 		<!-- scope: test -->
-		<dependency org="org.mockito" name="mockito-core" rev="1.10.17" conf="test->default" />
+		<dependency org="org.mockito" name="mockito-core" rev="1.10.19" conf="test->default" />
 		<dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" conf="test->default" />
 		<dependency org="net.javacrumbs.json-unit" name="json-unit" rev="1.1.6" conf="test->default" />
 		<dependency org="org.mozilla" name="rhino" rev="1.7R4" conf="lesscss->default" />


### PR DESCRIPTION
Upgraded dependencies with new releases for mockito and jgit. 

Also upgraded ivy to latest release (remember to remove the old jar from antlib/ when testing this).
`ant` still runs successfully, but beyond that I haven't done much thorough testing with the newer version ivy.