### PR TITLE
Switch from commons-lang to commons-lang3

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -32,7 +32,7 @@
 			<exclude org="com.sun" module="tools" />
 		</dependency>
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="default,maven->default" />
-		<dependency org="org.apache.commons" name="commons-lang3" rev="3.0" conf="default,maven->default" />
+		<dependency org="org.apache.commons" name="commons-lang3" rev="3.3.2" conf="default,maven->default" />
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.3.0" conf="default,maven->default"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -32,7 +32,6 @@
 			<exclude org="com.sun" module="tools" />
 		</dependency>
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="default,maven->default" />
-		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="default,maven->default" />
 		<dependency org="org.apache.commons" name="commons-lang3" rev="3.0" conf="default,maven->default" />
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -33,6 +33,7 @@
 		</dependency>
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="default,maven->default" />
 		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="default,maven->default" />
+		<dependency org="org.apache.commons" name="commons-lang3" rev="3.0" conf="default,maven->default" />
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />
 		<dependency org="com.googlecode.java-diff-utils" name="diffutils" rev="1.3.0" conf="default,maven->default"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -32,6 +32,7 @@
 			<exclude org="com.sun" module="tools" />
 		</dependency>
 		<dependency org="org.apache.velocity" name="velocity" rev="1.7" conf="default,maven->default" />
+		<dependency org="commons-lang" name="commons-lang" rev="2.6" conf="default,maven->default" />
 		<dependency org="org.apache.commons" name="commons-lang3" rev="3.3.2" conf="default,maven->default" />
 		<dependency org="org.json" name="json" rev="20140107" conf="default,maven->default" />
 		<dependency org="org.apache.ant" name="ant" rev="1.9.4" conf="default" transitive="false" />

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -9,7 +9,7 @@ import fitnesse.http.Response;
 import fitnesse.http.ResponseSender;
 import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ErrorResponder;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import fitnesse.util.Clock;
 
 import java.io.IOException;

--- a/src/fitnesse/html/template/ClasspathResourceLoader.java
+++ b/src/fitnesse/html/template/ClasspathResourceLoader.java
@@ -3,7 +3,7 @@ package fitnesse.html.template;
 import java.io.InputStream;
 
 import org.apache.commons.collections.ExtendedProperties;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.runtime.resource.Resource;
 import org.apache.velocity.runtime.resource.loader.ResourceLoader;

--- a/src/fitnesse/reporting/history/ExecutionReport.java
+++ b/src/fitnesse/reporting/history/ExecutionReport.java
@@ -3,7 +3,7 @@ package fitnesse.reporting.history;
 import java.util.Date;
 
 import fitnesse.testsystems.ExecutionResult;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/src/fitnesse/reporting/history/SuiteExecutionReport.java
+++ b/src/fitnesse/reporting/history/SuiteExecutionReport.java
@@ -5,7 +5,7 @@ import fitnesse.responders.run.SuiteResponder;
 import fitnesse.testsystems.TestSummary;
 
 import fitnesse.wiki.PathParser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;

--- a/src/fitnesse/responders/NameWikiPageResponder.java
+++ b/src/fitnesse/responders/NameWikiPageResponder.java
@@ -8,7 +8,7 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.PageData;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureReadOperation;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 
 import java.util.Arrays;

--- a/src/fitnesse/responders/ResponderFactory.java
+++ b/src/fitnesse/responders/ResponderFactory.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
 import fitnesse.responders.run.SuiteResponder;
 import fitnesse.responders.run.TestResponder;
 import fitnesse.wiki.PathParser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import fitnesse.Responder;
 import fitnesse.http.Request;
 import fitnesse.responders.editing.AddChildPageResponder;

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -14,7 +14,7 @@ import fitnesse.responders.NotFoundResponder;
 import fitnesse.html.template.HtmlPage;
 import fitnesse.html.template.PageTitle;
 import fitnesse.wiki.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/src/fitnesse/responders/editing/SymbolicLinkResponder.java
+++ b/src/fitnesse/responders/editing/SymbolicLinkResponder.java
@@ -11,7 +11,7 @@ import fitnesse.wiki.fs.DiskFileSystem;
 import fitnesse.wiki.fs.FileSystem;
 import fitnesse.wikitext.parser.WikiWordBuilder;
 import fitnesse.wiki.VariableTool;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import fitnesse.FitNesseContext;
 import fitnesse.Responder;
 import fitnesse.http.Request;

--- a/src/fitnesse/testrunner/SuiteFilter.java
+++ b/src/fitnesse/testrunner/SuiteFilter.java
@@ -14,7 +14,7 @@ import fitnesse.wiki.PageData;
 import fitnesse.wiki.PageType;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class SuiteFilter {
   public static final Logger LOG = Logger.getLogger(SuiteFilter.class.getName());

--- a/src/fitnesse/testsystems/ClassPath.java
+++ b/src/fitnesse/testsystems/ClassPath.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class ClassPath {
 

--- a/src/fitnesse/testsystems/CommandRunner.java
+++ b/src/fitnesse/testsystems/CommandRunner.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import static java.util.Arrays.asList;
 

--- a/src/fitnesse/testsystems/fit/CommandRunningFitClient.java
+++ b/src/fitnesse/testsystems/fit/CommandRunningFitClient.java
@@ -14,7 +14,7 @@ import fitnesse.socketservice.SocketService;
 import fitnesse.testsystems.CommandRunner;
 import fitnesse.testsystems.ExecutionLogListener;
 import fitnesse.testsystems.MockCommandRunner;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class CommandRunningFitClient extends FitClient {
   private static final Logger LOG = Logger.getLogger(CommandRunningFitClient.class.getName());

--- a/src/fitnesse/testsystems/slim/SlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/SlimClientBuilder.java
@@ -10,7 +10,7 @@ import fitnesse.testsystems.ClientBuilder;
 import fitnesse.testsystems.CommandRunner;
 import fitnesse.testsystems.Descriptor;
 import fitnesse.testsystems.MockCommandRunner;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class SlimClientBuilder extends ClientBuilder<SlimCommandRunningClient> {
   public static final String SLIM_PORT = "SLIM_PORT";

--- a/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
+++ b/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
@@ -8,8 +8,8 @@ import fitnesse.slim.instructions.*;
 import fitnesse.slim.protocol.SlimDeserializer;
 import fitnesse.slim.protocol.SlimSerializer;
 import fitnesse.testsystems.CommandRunner;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import util.StreamReader;
 
 import java.io.BufferedWriter;

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -20,7 +20,7 @@ import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.results.SlimTestResult;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 public class ScenarioTable extends SlimTable {

--- a/src/fitnesse/wiki/PageData.java
+++ b/src/fitnesse/wiki/PageData.java
@@ -7,8 +7,8 @@ import static fitnesse.wiki.PageType.*;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class PageData implements ReadOnlyPageData, Serializable {
   private static final Logger LOG = Logger.getLogger(PageData.class.getName());

--- a/src/fitnesse/wiki/WikiPagePath.java
+++ b/src/fitnesse/wiki/WikiPagePath.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class WikiPagePath implements Comparable<Object>, Cloneable, Serializable {
   private static final long serialVersionUID = 1L;

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class WikiPageProperty implements Serializable {
   private static final long serialVersionUID = 1L;

--- a/src/fitnesse/wiki/WikiWordReference.java
+++ b/src/fitnesse/wiki/WikiWordReference.java
@@ -1,7 +1,7 @@
 package fitnesse.wiki;
 
 import fitnesse.wikitext.parser.Symbol;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/fitnesse/wikitext/parser/WikiSourcePage.java
+++ b/src/fitnesse/wikitext/parser/WikiSourcePage.java
@@ -1,7 +1,7 @@
 package fitnesse.wikitext.parser;
 
 import fitnesse.wiki.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/fitnesse/wikitext/parser/WikiWordBuilder.java
+++ b/src/fitnesse/wikitext/parser/WikiWordBuilder.java
@@ -4,7 +4,7 @@ import fitnesse.html.HtmlTag;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 

--- a/src/fitnesseMain/ant/ExecuteFitnesseTestsTask.java
+++ b/src/fitnesseMain/ant/ExecuteFitnesseTestsTask.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;

--- a/test/fit/testFxtr/HandleFixtureDoesNotExtendFixtureTest.java
+++ b/test/fit/testFxtr/HandleFixtureDoesNotExtendFixtureTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import fit.Fixture;
 import fit.Parse;

--- a/test/fitnesse/responders/versions/VersionComparerTest.java
+++ b/test/fitnesse/responders/versions/VersionComparerTest.java
@@ -2,7 +2,7 @@ package fitnesse.responders.versions;
 
 import static util.RegexTestCase.assertSubString;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/slim/SlimServiceTestBase.java
+++ b/test/fitnesse/slim/SlimServiceTestBase.java
@@ -9,7 +9,7 @@ import fitnesse.slim.instructions.MakeInstruction;
 import fitnesse.testsystems.CompositeExecutionLogListener;
 import fitnesse.testsystems.MockCommandRunner;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/slim/converters/MapConverterTest.java
+++ b/test/fitnesse/slim/converters/MapConverterTest.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import fitnesse.html.HtmlTag;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/testrunner/ClassPathBuilderTest.java
+++ b/test/fitnesse/testrunner/ClassPathBuilderTest.java
@@ -13,7 +13,7 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import util.FileUtil;

--- a/test/fitnesse/testsystems/ClientBuilderTest.java
+++ b/test/fitnesse/testsystems/ClientBuilderTest.java
@@ -10,7 +10,7 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Switched to newer version of commons-lang, which basically consistet of tweaking the import statements. Apache has a [migration article/release notes for 3.0](http://commons.apache.org/proper/commons-lang/article3_0.html). It made some backwards-incompatible changes, most of which doesn't seem to affect FitNesse. 

The only one point I spotted was that `StringUtils.isNumeric` will now return false instead of true on empty Strings. I don't know whether the usage of isNumeric in FitNesse has made any assumptions regarding the old behaviour.

I have run `ant` and all tests are still passing.

One surprise was when I tried to remove the old commons-lang dependency, I noticed it was still fetched because velocity depends on it. (Found this through reading `ant dependencies` report.) Due to this I put it back, which means it will still be possible to use in the source code. I realize it's not ideal to have both in parallell, so I wonder if there's a better way to solve this. It might be possible to exclude it from velocity's dependencies, but I haven't tested the consequences of this, nor do I know whether it is a better idea.