### PR TITLE
More consistent (with input) implementation of output arguments

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -104,6 +104,10 @@ private void splitInputAndOutputArguments(String argName) {
     inputs.add(argument);
   }
 
+  protected void addOutput(String argument) {
+    outputs.add(argument);
+  }
+
   public String getScenarioName() {
     if (parameterized) {
       String parameterizedName = table.getCellContents(1, 0);
@@ -151,7 +155,7 @@ private void splitInputAndOutputArguments(String argName) {
   }
 
   public Set<String> getOutputs() {
-    return outputs;
+    return new HashSet<String>(outputs);
   }
 
   public List<SlimAssertion> call(final Map<String, String> scenarioArguments,

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
@@ -134,6 +134,35 @@ public class ScenarioAndDecisionTableTest {
   }
 
   @Test
+  public void simpleInputAndOutputArgPassing() throws Exception {
+    SlimTestContextImpl testContext = makeTables(
+            "!|scenario|echo|input|giving|output?|\n" +
+                    "|$output=|echo|@input|\n" +
+                    "\n" +
+                    "!|DT:EchoGiving|\n" +
+                    "|input|output?|\n" +
+                    "|7|7|\n"
+    );
+    Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
+            asList(asList("decisionTable_did_0/scriptTable_s_id_0", "7"))
+    );
+    SlimAssertion.evaluateExpectations(assertions, pseudoResults);
+
+    String scriptTable = dt.getChildren().get(0).getTable().toString();
+    String expectedScript =
+            "[[scenario, echo, input, giving, output?], [$output<-[7], echo, 7]]";
+    assertEquals(expectedScript, scriptTable);
+
+    String dtHtml = dt.getTable().toString();
+    assertEquals("[[DT:EchoGiving], [input, output?], [7, pass(7)]]", dtHtml);
+
+    assertEquals(1, testContext.getTestSummary().getRight());
+    assertEquals(0, testContext.getTestSummary().getWrong());
+    assertEquals(0, testContext.getTestSummary().getIgnores());
+    assertEquals(0, testContext.getTestSummary().getExceptions());
+  }
+
+  @Test
   public void simpleInputAndOutputFailing() throws Exception {
     SlimTestContextImpl testContext = makeTables(
             "!|scenario|echo|input|giving|output|\n" +

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
@@ -163,6 +163,37 @@ public class ScenarioAndDecisionTableTest {
   }
 
   @Test
+  public void simpleInputAndMultipleOutputArgPassing() throws Exception {
+    SlimTestContextImpl testContext = makeTables(
+            "!|scenario|echo|input|giving|output?|and|outp2?|\n" +
+                    "|$output=|echo|@input|\n" +
+                    "|$outp2=|echo|@input|\n" +
+                    "\n" +
+                    "!|DT:EchoGivingAnd|\n" +
+                    "|input|output?|outp2?|\n" +
+                    "|7|7|7|\n"
+    );
+    Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
+            asList(asList("decisionTable_did_0/scriptTable_s_id_0", "7"),
+                    asList("decisionTable_did_0/scriptTable_s_id_1", "7"))
+    );
+    SlimAssertion.evaluateExpectations(assertions, pseudoResults);
+
+    String scriptTable = dt.getChildren().get(0).getTable().toString();
+    String expectedScript =
+            "[[scenario, echo, input, giving, output?, and, outp2?], [$output<-[7], echo, 7], [$outp2<-[7], echo, 7]]";
+    assertEquals(expectedScript, scriptTable);
+
+    String dtHtml = dt.getTable().toString();
+    assertEquals("[[DT:EchoGivingAnd], [input, output?, outp2?], [7, pass(7), pass(7)]]", dtHtml);
+
+    assertEquals(2, testContext.getTestSummary().getRight());
+    assertEquals(0, testContext.getTestSummary().getWrong());
+    assertEquals(0, testContext.getTestSummary().getIgnores());
+    assertEquals(0, testContext.getTestSummary().getExceptions());
+  }
+
+  @Test
   public void simpleInputAndOutputFailing() throws Exception {
     SlimTestContextImpl testContext = makeTables(
             "!|scenario|echo|input|giving|output|\n" +

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
@@ -82,6 +82,22 @@ public class ScenarioTableExtensionTest {
   }
 
   @Test
+  public void parameterizedNameWithOutputArg() throws Exception {
+    makeScenarioTable("login user|\n|enter|@{name}|for|login|\n|enter|@{password}|for|secret|\n|$myName=|current user");
+    assertEquals("LoginUser", st.getName());
+
+    Set<String> inputs = st.getInputs();
+    assertEquals(2, inputs.size());
+    assertTrue(inputs.contains("name"));
+    assertTrue(inputs.contains("password"));
+    assertTrue(st.isParameterized());
+
+    Set<String> outputs = st.getOutputs();
+    assertEquals(1, outputs.size());
+    assertTrue(outputs.contains("myName"));
+  }
+
+  @Test
   public void parameterizedNameWithOneArgAndWordWithEmbeddedUnderscore()
       throws Exception {
     makeScenarioTable("login user_name|\n|enter|@{name}|for|login|\n|enter|bla|for|secret");
@@ -123,8 +139,10 @@ public class ScenarioTableExtensionTest {
    */
   public static class AutoArgScenarioTable extends ScenarioTable {
     private final static Pattern ARG_PATTERN = Pattern.compile("@\\{(.+?)\\}");
+    private static final Pattern OUT_PATTERN = Pattern.compile("\\$(.+?)=");
 
     private Set<String> inputs;
+    private Set<String> outputs;
 
     public AutoArgScenarioTable(Table table, String tableId, SlimTestContext testContext) {
       super(table, tableId, testContext);
@@ -132,7 +150,8 @@ public class ScenarioTableExtensionTest {
 
     @Override
     public List<SlimAssertion> getAssertions() throws SyntaxError {
-      inputs = findInputs();
+      inputs = findArguments(ARG_PATTERN);
+      outputs = findArguments(OUT_PATTERN);
       return super.getAssertions();
     }
 
@@ -146,16 +165,19 @@ public class ScenarioTableExtensionTest {
       for (String input : inputs) {
         addInput(input);
       }
+      for (String output : outputs) {
+        addOutput(output);
+      }
     }
 
-    private Set<String> findInputs() {
+    private Set<String> findArguments(Pattern pattern) {
       Set<String> found = new LinkedHashSet<String>();
       int rowCount = table.getRowCount();
       for (int row = 0; row < rowCount; row++) {
         int columnCount = table.getColumnCountInRow(row);
         for (int column = 0; column < columnCount; column++) {
           String cellContent = table.getCellContents(column, row);
-          Matcher m = ARG_PATTERN.matcher(cellContent);
+          Matcher m = pattern.matcher(cellContent);
           while (m.find()) {
             String input = m.group(1);
             found.add(input);


### PR DESCRIPTION
ScenarioTable's handling of output arguments was handled a bit different from input handling. This aims at making that more consistent.
Furthermore I added some tests to ScenarioTable's unit tests dealing with out parameters