### PR TITLE
quick fix for javadoc errors in java8

### DIFF
--- a/src/fit/testFxtr/WouldBeFixture.java
+++ b/src/fit/testFxtr/WouldBeFixture.java
@@ -6,7 +6,7 @@ package fit.testFxtr;
  * This "fixture" intentionally does not extend a Fixture class.
  *
  * @author jbrains
- * @see HandleFixtureDoesNotExtendFixtureTest
+ * see test/fit/testFxtr/HandleFixtureDoesNotExtendFixtureTest
  */
 public class WouldBeFixture {
   public String go() {

--- a/src/fitnesse/authentication/NegotiateAuthenticator.java
+++ b/src/fitnesse/authentication/NegotiateAuthenticator.java
@@ -15,17 +15,17 @@ import java.io.UnsupportedEncodingException;
 
 /**
  * HTTP SPNEGO (GSSAPI Negotiate) authenticator.
- * <p/>
+ * <p>
  * <strong>How to enable for Kerberos/Active Directory</strong>
- * <p/>
+ * <p>
  * Enable this plugin by editing plugins.properties and adding the line:
- * <p/>
+ * <p>
  * <pre>
  * Authenticator = fitnesse.authentication.NegotiateAuthenticator
  * </pre>
- * <p/>
+ * <p>
  * If using Kerberos on Unix, create a jaas-krb5.conf file with these contents:
- * <p/>
+ * <p>
  * <pre>
  * com.sun.security.jgss.accept  {
  *       com.sun.security.auth.module.Krb5LoginModule required
@@ -37,15 +37,15 @@ import java.io.UnsupportedEncodingException;
  *       ;
  *    };
  * </pre>
- * <p/>
+ * <p>
  * Next, define these system properties when running the FitNesse server:
- * <p/>
+ * <p>
  * <pre>
  * -Djavax.security.auth.useSubjectCredsOnly=false
  * -Djava.security.auth.login.config=/path/to/jaas-krb5.conf
  * -Dsun.security.krb5.debug=true
  * </pre>
- * <p/>
+ * <p>
  * You can remove the krb5.debug property later, when you know it's working.
  *
  * @author David Leonard Released into the Public domain, 2009. No warranty:

--- a/src/fitnesse/slim/protocol/SlimSerializer.java
+++ b/src/fitnesse/slim/protocol/SlimSerializer.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Packs up a list into a serialized string using a special format.  The list items must be strings, or lists.
  * They will be recursively serialized.
- * <p/>
+ * <p>
  * Format:  [iiiiii:llllll:item...]
  * All lists (including lists within lists) begin with [ and end with ].  After the [ is the 6 digit number of items
  * in the list followed by a :.  Then comes each item which is composed of a 6 digit length a : and then the value

--- a/src/fitnesse/testsystems/slim/CustomComparator.java
+++ b/src/fitnesse/testsystems/slim/CustomComparator.java
@@ -11,8 +11,6 @@ public interface CustomComparator {
    * @param actual String representation of the actual result
    * @param expected String representation of the expected result
    * @return true if they match, false if they don't match
-   * @throws Throwable if an exception or error is thrown, the throwable message is appended
-   * to the failure output
    */
   boolean matches(String actual, String expected);
 

--- a/src/fitnesseMain/ant/ExecuteFitnesseTestsTask.java
+++ b/src/fitnesseMain/ant/ExecuteFitnesseTestsTask.java
@@ -18,7 +18,6 @@ import org.apache.tools.ant.types.Reference;
 
 /**
  * Task to run fit tests. This task runs fitnesse tests and publishes the results.
- * <p/>
  * <pre>
  * Usage:
  * &lt;taskdef name=&quot;execute-fitnesse-tests&quot;
@@ -27,7 +26,7 @@ import org.apache.tools.ant.types.Reference;
  * OR
  * &lt;taskdef classpathref=&quot;classpath&quot;
  *             resource=&quot;tasks.properties&quot; /&gt;
- * <p/>
+ *
  * &lt;execute-fitnesse-tests
  *     suitepage=&quot;FitNesse.SuiteAcceptanceTests&quot;
  *     fitnesseport=&quot;8082&quot;

--- a/src/fitnesseMain/ant/StartFitnesseTask.java
+++ b/src/fitnesseMain/ant/StartFitnesseTask.java
@@ -9,13 +9,12 @@ import fitnesseMain.FitNesseMain;
 
 /**
  * Task to start fitnesse.
- * <p/>
  * <pre>
  *    Usage:
  *    &lt;taskdef name=&quot;start-fitnesse&quot; classname=&quot;fitnesse.ant.StartFitnesseTask&quot; classpathref=&quot;classpath&quot; /&gt;
  *    OR
  *    &lt;taskdef classpathref=&quot;classpath&quot; resource=&quot;tasks.properties&quot; /&gt;
- * <p/>
+ *
  *    &lt;start-fitnesse wikidirectoryrootpath=&quot;.&quot; fitnesseport=&quot;8082&quot; /&gt;
  * </pre>
  */

--- a/src/fitnesseMain/ant/StopFitnesseTask.java
+++ b/src/fitnesseMain/ant/StopFitnesseTask.java
@@ -11,13 +11,12 @@ import fitnesse.testutil.FitNesseUtil;
 
 /**
  * Task to stop fitnesse.
- * <p/>
  * <pre>
  * Usage:
  * &lt;taskdef name=&quot;stop-fitnesse&quot; classname=&quot;fitnesse.ant.StopFitnesseTask&quot; classpathref=&quot;classpath&quot; /&gt;
  * OR
  * &lt;taskdef classpathref=&quot;classpath&quot; resource=&quot;tasks.properties&quot; /&gt;
- * <p/>
+ *
  * &lt;stop-fitnesse fitnesseport=&quot;8082&quot; /&gt;
  * </pre>
  */


### PR DESCRIPTION
Java 8 is very strict on javadoc usage of HTML. This pull request fixes most of the errors, and some warnings.