### PR TITLE
Prefer isEmpty() when checking for emptiness

### DIFF
--- a/src/fit/RowFixture.java
+++ b/src/fit/RowFixture.java
@@ -142,11 +142,11 @@ abstract public class RowFixture extends ColumnFixture {
   }
 
   protected void check(List<?> eList, List<?> cList) {
-    if (eList.size() == 0) {
+    if (eList.isEmpty()) {
       surplus.addAll(cList);
       return;
     }
-    if (cList.size() == 0) {
+    if (cList.isEmpty()) {
       missing.addAll(eList);
       return;
     }

--- a/src/fitnesse/authentication/PasswordFile.java
+++ b/src/fitnesse/authentication/PasswordFile.java
@@ -62,7 +62,7 @@ public class PasswordFile {
   }
 
   private void loadCipher(LinkedList<String> lines) {
-    if (lines.size() > 0) {
+    if (!lines.isEmpty()) {
       String firstLine = lines.getFirst().toString();
       if (firstLine.startsWith("!")) {
         String cipherClassName = firstLine.substring(1);

--- a/src/fitnesse/fixtures/NullAndBlankFixture.java
+++ b/src/fitnesse/fixtures/NullAndBlankFixture.java
@@ -21,6 +21,6 @@ public class NullAndBlankFixture extends ColumnFixture {
   }
 
   public boolean isBlank() {
-    return blankString.length() == 0;
+    return blankString.isEmpty();
   }
 }

--- a/src/fitnesse/html/HtmlTag.java
+++ b/src/fitnesse/html/HtmlTag.java
@@ -44,7 +44,7 @@ public class HtmlTag extends HtmlElement implements Iterable<HtmlElement> {
   }
 
   private boolean hasChildren() {
-    return childTags.size() > 0;
+    return !childTags.isEmpty();
   }
 
   public void add(String s) {

--- a/src/fitnesse/html/template/PageTitle.java
+++ b/src/fitnesse/html/template/PageTitle.java
@@ -18,11 +18,11 @@ public class PageTitle {
     pagePath = pagePath.copy();
     List<String> names = pagePath.getNames();
     link = PathParser.render(pagePath);
-    if (names.size() > 0) {
+    if (!names.isEmpty()) {
       title = names.get(names.size() - 1);
       
       pagePath.removeNameFromEnd();
-      while (pagePath.getNames().size() > 0) {
+      while (!pagePath.getNames().isEmpty()) {
         names = pagePath.getNames();
         BreadCrumb crumb = new BreadCrumb(names.get(names.size() - 1), PathParser.render(pagePath));
         breadCrumbs.add(crumb);

--- a/src/fitnesse/http/RequestBuilder.java
+++ b/src/fitnesse/http/RequestBuilder.java
@@ -57,7 +57,7 @@ public class RequestBuilder {
     text.append(method).append(" ").append(resource);
     if (isGet()) {
       String inputString = inputString();
-      if (inputString.length() > 0)
+      if (!inputString.isEmpty())
         text.append("?").append(inputString);
     }
     text.append(" HTTP/1.1");

--- a/src/fitnesse/http/UploadedFile.java
+++ b/src/fitnesse/http/UploadedFile.java
@@ -38,7 +38,7 @@ public class UploadedFile {
   }
 
   public boolean isUsable() {
-    return (name != null && name.length() > 0);
+    return (name != null && !name.isEmpty());
   }
 
   public void delete() {

--- a/src/fitnesse/reporting/history/SuiteExecutionReport.java
+++ b/src/fitnesse/reporting/history/SuiteExecutionReport.java
@@ -67,7 +67,7 @@ public class SuiteExecutionReport extends ExecutionReport {
 
   private String pageHistoryReferencesToString() {
     StringBuilder builder = new StringBuilder();
-    if (pageHistoryReferences.size() > 0) {
+    if (!pageHistoryReferences.isEmpty()) {
       for (PageHistoryReference reference : pageHistoryReferences) {
         builder.append(reference.toString());
         builder.append(",");

--- a/src/fitnesse/responders/RssResponder.java
+++ b/src/fitnesse/responders/RssResponder.java
@@ -65,7 +65,7 @@ public class RssResponder implements SecureResponder {
   }
 
   protected static boolean isNeitherNullNorBlank(String string) {
-    return string != null && string.length() > 0;
+    return string != null && !string.isEmpty();
   }
 
   public SecureOperation getSecureOperation() {

--- a/src/fitnesse/responders/WikiPageResponder.java
+++ b/src/fitnesse/responders/WikiPageResponder.java
@@ -50,7 +50,7 @@ public class WikiPageResponder implements SecureResponder {
 
   private boolean dontCreateNonExistentPage(Request request) {
     String dontCreate = request.getInput("dontCreatePage");
-    return dontCreate != null && (dontCreate.length() == 0 || Boolean.parseBoolean(dontCreate));
+    return dontCreate != null && (dontCreate.isEmpty() || Boolean.parseBoolean(dontCreate));
   }
 
   private SimpleResponse makePageResponse(FitNesseContext context, WikiPage page) {

--- a/src/fitnesse/responders/editing/SymbolicLinkResponder.java
+++ b/src/fitnesse/responders/editing/SymbolicLinkResponder.java
@@ -73,7 +73,7 @@ public class SymbolicLinkResponder implements Responder {
     WikiPageProperties properties = data.getProperties();
     WikiPageProperty symLinks = getSymLinkProperty(properties);
     symLinks.remove(linkToRemove);
-    if (symLinks.keySet().size() == 0)
+    if (symLinks.keySet().isEmpty())
       properties.remove(SymbolicPage.PROPERTY_NAME);
     page.commit(data);
     setRedirect(resource);

--- a/src/fitnesse/responders/refactoring/DeletePageResponder.java
+++ b/src/fitnesse/responders/refactoring/DeletePageResponder.java
@@ -64,7 +64,7 @@ public class DeletePageResponder implements SecureResponder {
 
   private void redirect(final WikiPagePath path, final SimpleResponse response) {
     String location = PathParser.render(path);
-    if (location == null || location.length() == 0) {
+    if (location == null || location.isEmpty()) {
       response.redirect(context.contextRoot, "root");
     } else {
       response.redirect(context.contextRoot, location);

--- a/src/fitnesse/responders/refactoring/DeletePageResponder.java
+++ b/src/fitnesse/responders/refactoring/DeletePageResponder.java
@@ -38,7 +38,7 @@ public class DeletePageResponder implements SecureResponder {
   }
 
   private void tryToDeletePage(Request request) {
-    String confirmedString = (String) request.getInput("confirmed");
+    String confirmedString = request.getInput("confirmed");
     if (!"yes".equalsIgnoreCase(confirmedString)) {
       response.setContent(buildConfirmationHtml(context.getRootPage(), qualifiedPageName, context));
     } else {

--- a/src/fitnesse/responders/testHistory/HistoryComparer.java
+++ b/src/fitnesse/responders/testHistory/HistoryComparer.java
@@ -72,7 +72,7 @@ public class HistoryComparer {
   }
 
   private boolean thereAreEnoughMatches() {
-    return matchedTables.size() != 0 && matchedTables.size() == firstTableResults.size();
+    return !matchedTables.isEmpty() && matchedTables.size() == firstTableResults.size();
   }
 
   private boolean allMatchScoresAreHigh() {

--- a/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
+++ b/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
@@ -231,7 +231,7 @@ public class SuiteOverviewTree {
         else {
           String branchName = itemPath[currentIndex];
           String branchFullName = fullName;
-          branchFullName += (fullName.length() > 0) ? "." + branchName : branchName;
+          branchFullName += (!fullName.isEmpty()) ? "." + branchName : branchName;
           TreeItem branch = new TreeItem(branchName, branchFullName);
           branches.add(branch);
           branch.addItem(itemPath, ++currentIndex);
@@ -244,7 +244,7 @@ public class SuiteOverviewTree {
     }
     
     public boolean isTest() {
-      return (branches.size() == 0);
+      return (branches.isEmpty());
     }
     
     public String getCssClass() {

--- a/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
+++ b/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
@@ -231,7 +231,7 @@ public class SuiteOverviewTree {
         else {
           String branchName = itemPath[currentIndex];
           String branchFullName = fullName;
-          branchFullName += (!fullName.isEmpty()) ? "." + branchName : branchName;
+          branchFullName += fullName.isEmpty() ? branchName : "." + branchName;
           TreeItem branch = new TreeItem(branchName, branchFullName);
           branches.add(branch);
           branch.addItem(itemPath, ++currentIndex);

--- a/src/fitnesse/slim/SlimException.java
+++ b/src/fitnesse/slim/SlimException.java
@@ -89,12 +89,12 @@ public class SlimException extends Exception {
       sb.append(PRETTY_PRINT_TAG_START);
     }
 
-    if (tag != null && tag.length() > 0) {
+    if (tag != null && !tag.isEmpty()) {
       sb.append(tag).append(" ");
     }
 
     String msg = getMessage();
-    if (msg != null && msg.length() > 0) {
+    if (msg != null && !msg.isEmpty()) {
       sb.append(msg);
     }
     if (this.prettyPrint) {

--- a/src/fitnesse/slim/StackTraceEnricher.java
+++ b/src/fitnesse/slim/StackTraceEnricher.java
@@ -135,7 +135,7 @@ public class StackTraceEnricher {
     }
 
     private static Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
-      if (className == null || className.length() == 0) {
+      if (className == null || className.isEmpty()) {
         throw new ClassNotFoundException("Unable to load a class with an empty or null name.");
       }
       Class<?> resolvedClass = null;

--- a/src/fitnesse/slim/protocol/SlimDeserializer.java
+++ b/src/fitnesse/slim/protocol/SlimDeserializer.java
@@ -36,7 +36,7 @@ public class SlimDeserializer {
   private void checkSerializedStringIsValid() {
     if (serialized == null)
       throw new SyntaxError("Can't deserialize null");
-    else if (serialized.length() == 0)
+    else if (serialized.isEmpty())
       throw new SyntaxError("Can't deserialize empty string");
   }
 

--- a/src/fitnesse/socketservice/SocketService.java
+++ b/src/fitnesse/socketservice/SocketService.java
@@ -86,7 +86,7 @@ public class SocketService {
   }
 
   private void waitForServerThreads() throws InterruptedException {
-    while (threads.size() > 0) {
+    while (!threads.isEmpty()) {
       Thread t;
       synchronized (threads) {
         if (threads.size() < 1)

--- a/src/fitnesse/testrunner/PagesByTestSystem.java
+++ b/src/fitnesse/testrunner/PagesByTestSystem.java
@@ -50,7 +50,7 @@ public class PagesByTestSystem {
   private Map<WikiPageIdentity, List<TestPage>> addSuiteSetUpAndTearDownToAllTestSystems(Map<WikiPageIdentity, List<WikiPage>> pagesByTestSystem) {
     Map<WikiPageIdentity, List<TestPage>> orderedPagesByTestSystem = new HashMap<WikiPageIdentity, List<TestPage>>(pagesByTestSystem.size());
 
-    if (pagesByTestSystem.size() > 0) {
+    if (!pagesByTestSystem.isEmpty()) {
       PageListSetUpTearDownSurrounder surrounder = new PageListSetUpTearDownSurrounder(root);
 
       for (Map.Entry<WikiPageIdentity, List<WikiPage>> pages : pagesByTestSystem.entrySet())

--- a/src/fitnesse/testsystems/fit/FitTestSystem.java
+++ b/src/fitnesse/testsystems/fit/FitTestSystem.java
@@ -44,7 +44,7 @@ public class FitTestSystem implements TestSystem, FitClientListener {
     processingQueue.addLast(pageToTest);
     String html = pageToTest.getHtml();
     try {
-      if (html.length() == 0)
+      if (html.isEmpty())
         client.send(EMPTY_PAGE_CONTENT);
       else
         client.send(html);

--- a/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
@@ -35,7 +35,7 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
   protected void processAllTablesOnPage(TestPage pageToTest) throws IOException {
     List<SlimTable> allTables = createSlimTables(pageToTest);
 
-    if (allTables.size() == 0) {
+    if (allTables.isEmpty()) {
       String html = createHtmlResults(START_OF_TEST, END_OF_TEST);
       testOutputChunk(html);
     } else {

--- a/src/fitnesse/testsystems/slim/HtmlTable.java
+++ b/src/fitnesse/testsystems/slim/HtmlTable.java
@@ -158,7 +158,7 @@ public class HtmlTable implements Table {
 
     rowNodes.add(childRow.rowNode);
 
-    while (tempStack.size() > 0) {
+    while (!tempStack.isEmpty()) {
       rowNodes.add(tempStack.pop());
     }
   }

--- a/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
+++ b/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
@@ -127,7 +127,7 @@ public class SlimCommandRunningClient implements SlimClient {
 
   @Override
   public Map<String, Object> invokeAndGetResponse(List<Instruction> statements) throws IOException {
-    if (statements.size() == 0)
+    if (statements.isEmpty())
       return new HashMap<String, Object>();
     String instructions = SlimSerializer.serialize(toList(statements));
     writeString(instructions);

--- a/src/fitnesse/testsystems/slim/tables/ImportTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ImportTable.java
@@ -28,7 +28,7 @@ public class ImportTable extends SlimTable {
 
     for (int row = 1; row < rows; row++) {
       String importString = table.getCellContents(0, row);
-      if (importString.length() > 0) {
+      if (!importString.isEmpty()) {
         Instruction importInstruction = new ImportInstruction(makeInstructionTag(), importString);
         instructions.add(makeAssertion(importInstruction, new ImportExpectation(0, row)));
       }

--- a/src/fitnesse/testsystems/slim/tables/LibraryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/LibraryTable.java
@@ -19,7 +19,7 @@ public class LibraryTable extends SlimTable {
     List<SlimAssertion> instructions = new ArrayList<SlimAssertion>();
     for (int row = 1; row < table.getRowCount(); row++) {
       String disgracedClassName = Disgracer.disgraceClassName(table.getCellContents(0, row));
-      if (disgracedClassName.length() > 0) {
+      if (!disgracedClassName.isEmpty()) {
         instructions.add(constructInstance("library" + row, disgracedClassName, 0, row));
       }
     }

--- a/src/fitnesse/testsystems/slim/tables/OrderedQueryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/OrderedQueryTable.java
@@ -32,7 +32,7 @@ public class OrderedQueryTable extends QueryTable {
 
     markSurplusRows(queryResults, unmatchedResultRows);
 
-    return unmatchedResultRows.size() > 0 ? ExecutionResult.FAIL : ExecutionResult.PASS;
+    return !unmatchedResultRows.isEmpty() ? ExecutionResult.FAIL : ExecutionResult.PASS;
   }
 
   private MatchedResult takeBestMatch(Iterable<MatchedResult> potentialMatchesByScore, int tableRow) {

--- a/src/fitnesse/testsystems/slim/tables/QueryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/QueryTable.java
@@ -113,7 +113,7 @@ public class QueryTable extends SlimTable {
     markMissingRows(unmatchedTableRows);
     markSurplusRows(queryResults, unmatchedResultRows);
 
-    return unmatchedTableRows.size() > 0 || unmatchedResultRows.size() > 0 ? ExecutionResult.FAIL : ExecutionResult.PASS;
+    return !unmatchedTableRows.isEmpty() || !unmatchedResultRows.isEmpty() ? ExecutionResult.FAIL : ExecutionResult.PASS;
   }
 
   protected MatchedResult takeBestMatch(Iterable<MatchedResult> potentialMatchesByScore) {
@@ -210,7 +210,7 @@ public class QueryTable extends SlimTable {
       testResult = SlimTestResult.plain();
     else if (actualValue == null)
       testResult = SlimTestResult.fail(String.format("field %s not present", fieldName), expectedValue);
-    else if (expectedValue == null || expectedValue.length() == 0)
+    else if (expectedValue == null || expectedValue.isEmpty())
       testResult = SlimTestResult.ignore(actualValue);
     else {
       String symbolName = ifSymbolAssignment(expectedValue);

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -223,7 +223,7 @@ private void splitInputAndOutputArguments(String argName) {
 
     if (parameterized) {
       parameterizedName = table.getCellContents(1, 0);
-    } else if (this.inputs.size() > 0) {
+    } else if (!this.inputs.isEmpty()) {
       StringBuilder nameBuffer = new StringBuilder();
 
       for (int nameCol = 1; nameCol < colsInHeader; nameCol += 2)

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -116,7 +116,7 @@ public class ScriptTable extends SlimTable {
       assertions = note(row);
     else if ((match = ifSymbolAssignment(0, row)) != null)
       assertions = actionAndAssign(match, row);
-    else if (firstCell.length() == 0)
+    else if (firstCell.isEmpty())
       assertions = note(row);
     else if (firstCell.trim().startsWith("#") || firstCell.trim().startsWith("*"))
       assertions = note(row);

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -502,7 +502,7 @@ public abstract class SlimTable {
         testResult = SlimTestResult.fail("null", replacedExpected); //todo can't be right message.
       else if (actual.equals(replacedExpected))
         testResult = SlimTestResult.pass(announceBlank(replaceSymbolsWithFullExpansion(expected)));
-      else if (replacedExpected.length() == 0)
+      else if (replacedExpected.isEmpty())
         testResult = SlimTestResult.ignore(actual);
       else {
         testResult = new Comparator(replacedExpected, actual, expected).evaluate();
@@ -514,7 +514,7 @@ public abstract class SlimTable {
     }
 
     private String announceBlank(String originalValue) {
-      return originalValue.length() == 0 ? "BLANK" : originalValue;
+      return originalValue.isEmpty() ? "BLANK" : originalValue;
     }
 
   }

--- a/src/fitnesse/testsystems/slim/tables/TableTable.java
+++ b/src/fitnesse/testsystems/slim/tables/TableTable.java
@@ -108,7 +108,7 @@ public class TableTable extends SlimTable {
 
   private SlimTestResult getTestResult(String message, String content) {
     SlimTestResult result;
-    if (message.equalsIgnoreCase("no change") || message.length() == 0)
+    if (message.equalsIgnoreCase("no change") || message.isEmpty())
       result = SlimTestResult.plain(content);
     else if (message.equalsIgnoreCase("pass"))
       result = SlimTestResult.pass(content);

--- a/src/fitnesse/updates/UpdateFileList.java
+++ b/src/fitnesse/updates/UpdateFileList.java
@@ -127,7 +127,7 @@ private void addFilePathToAppropriateList(String directoryPath, File childFile) 
   }
 
   private String makePathLine(String path) {
-    if (baseDirectory != null && baseDirectory.length() > 0 && path.startsWith(baseDirectory))
+    if (baseDirectory != null && !baseDirectory.isEmpty() && path.startsWith(baseDirectory))
       path = path.replace(baseDirectory, "");
     if (path.startsWith("/"))
       path = path.substring(1);

--- a/src/fitnesse/util/Expression.java
+++ b/src/fitnesse/util/Expression.java
@@ -160,16 +160,14 @@ public class Expression {
    */
   private double mul() {
     double ans = trig();
-    if (!s.isEmpty()) {
-      while (!s.isEmpty()) {
-        if (s.charAt(0) == '*') {
-          advance();
-          ans *= trig();
-        } else if (s.charAt(0) == '/') {
-          advance();
-          ans /= trig();
-        } else break;
-      }
+    while (!s.isEmpty()) {
+      if (s.charAt(0) == '*') {
+        advance();
+        ans *= trig();
+      } else if (s.charAt(0) == '/') {
+        advance();
+        ans /= trig();
+      } else break;
     }
     return ans;
   }

--- a/src/fitnesse/util/Expression.java
+++ b/src/fitnesse/util/Expression.java
@@ -17,24 +17,24 @@ public class Expression {
   private double term() {
     double ans = 0;
     StringBuffer temp = new StringBuffer();
-    while (s.length() > 0 && Character.isDigit(s.charAt(0))) {
+    while (!s.isEmpty() && Character.isDigit(s.charAt(0))) {
       temp.append(Integer.parseInt("" + s.charAt(0)));
       advance();
     }
-    if (s.length() > 0 && s.charAt(0) == '.') {
+    if (!s.isEmpty() && s.charAt(0) == '.') {
       temp.append('.');
       advance();
-      while (s.length() > 0 && Character.isDigit(s.charAt(0))) {
+      while (!s.isEmpty() && Character.isDigit(s.charAt(0))) {
         temp.append(Integer.parseInt("" + s.charAt(0)));
         advance();
       }
     }
-    if (s.length() > 0 && (s.charAt(0) == 'e' || s.charAt(0) == 'E')) {
+    if (!s.isEmpty() && (s.charAt(0) == 'e' || s.charAt(0) == 'E')) {
       temp.append('e');
       advance();
       temp.append(s.charAt(0));
       advance();
-      while (s.length() > 0 && Character.isDigit(s.charAt(0))) {
+      while (!s.isEmpty() && Character.isDigit(s.charAt(0))) {
         temp.append(Integer.parseInt("" + s.charAt(0)));
         advance();
       }
@@ -73,7 +73,7 @@ public class Expression {
       advance();
     }
     double result = paren();
-    while (s.length() > 0) {
+    while (!s.isEmpty()) {
       if (s.charAt(0) == '^') {
         result = exponentiate(result);
       } else
@@ -160,8 +160,8 @@ public class Expression {
    */
   private double mul() {
     double ans = trig();
-    if (s.length() > 0) {
-      while (s.length() > 0) {
+    if (!s.isEmpty()) {
+      while (!s.isEmpty()) {
         if (s.charAt(0) == '*') {
           advance();
           ans *= trig();
@@ -179,7 +179,7 @@ public class Expression {
    */
   private double add() {
     double ans = mul();
-    while (s.length() > 0) {
+    while (!s.isEmpty()) {
       if (s.charAt(0) == '+') {
         advance();
         ans += mul();

--- a/src/fitnesse/util/XmlUtil.java
+++ b/src/fitnesse/util/XmlUtil.java
@@ -98,7 +98,7 @@ public class XmlUtil {
       return null;
     }
     String text = namedElement.getTextContent();
-    return (text.length() == 0) ? null : text;
+    return (text.isEmpty()) ? null : text;
   }
 
   public static void addTextNode(Element element, String tagName, String value) {

--- a/src/fitnesse/wiki/PageData.java
+++ b/src/fitnesse/wiki/PageData.java
@@ -123,6 +123,6 @@ public class PageData implements ReadOnlyPageData, Serializable {
   }
 
   public boolean isEmpty() {
-    return getContent() == null || getContent().length() == 0;
+    return getContent() == null || getContent().isEmpty();
   }
 }

--- a/src/fitnesse/wiki/WikiPagePath.java
+++ b/src/fitnesse/wiki/WikiPagePath.java
@@ -76,11 +76,11 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
   }
 
   public boolean isEmpty() {
-    return names.size() == 0;
+    return names.isEmpty();
   }
 
   public String last() {
-    return (names.size() == 0 ? null : names.get(names.size() - 1));
+    return (names.isEmpty() ? null : names.get(names.size() - 1));
   }
 
   public List<String> getNames() {
@@ -99,7 +99,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
   }
 
   public void removeNameFromEnd() {
-    if (names.size() > 0)
+    if (!names.isEmpty())
       names.removeLast();
   }
 

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -97,7 +97,7 @@ public class WikiPageProperty implements Serializable {
   }
 
   public boolean hasChildren() {
-    return children != null && children.size() > 0;
+    return children != null && !children.isEmpty();
   }
 
   private static ThreadLocal<DateFormat> timeFormat = new ThreadLocal<DateFormat>();

--- a/src/fitnesse/wiki/WikiPageUtil.java
+++ b/src/fitnesse/wiki/WikiPageUtil.java
@@ -60,7 +60,7 @@ public class WikiPageUtil {
       current = context.addChildPage(first);
     } else
       current = context.getChildPage(first);
-    if (rest.size() == 0)
+    if (rest.isEmpty())
       return current;
     return getOrMakePage(current, rest);
   }

--- a/src/fitnesse/wiki/WikiWordReference.java
+++ b/src/fitnesse/wiki/WikiWordReference.java
@@ -50,7 +50,7 @@ public class WikiWordReference {
       if (refersTo(reference, QualifiedNameOfPageToBeMoved)) {
         String referenceTail = reference.substring(QualifiedNameOfPageToBeMoved.length());
         String childPortionOfReference = pageToBeMoved.getName();
-        if (referenceTail.length() > 0)
+        if (!referenceTail.isEmpty())
           childPortionOfReference += referenceTail;
         String newQualifiedName;
         if ("".equals(newParentName))

--- a/src/fitnesse/wiki/fs/ZipFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/ZipFileVersionsController.java
@@ -215,7 +215,7 @@ public class ZipFileVersionsController implements VersionsController {
 
   private void pruneVersions(Collection<ZipFileVersionInfo> versions) {
     List<ZipFileVersionInfo> versionsList = makeSortedVersionList(versions);
-    if (versions.size() > 0) {
+    if (!versions.isEmpty()) {
       VersionInfo lastVersion = versionsList.get(versionsList.size() - 1);
       Date expirationDate = makeVersionExpirationDate(lastVersion);
       for (ZipFileVersionInfo version : versionsList) {

--- a/src/fitnesse/wikitext/parser/AnchorName.java
+++ b/src/fitnesse/wikitext/parser/AnchorName.java
@@ -13,7 +13,7 @@ public class AnchorName extends SymbolType implements Rule {
 
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         List<Symbol> tokens = parser.moveNext(new SymbolType[] {SymbolType.Whitespace, SymbolType.Text});
-        if (tokens.size() == 0) return Symbol.nothing;
+        if (tokens.isEmpty()) return Symbol.nothing;
 
         String anchor = tokens.get(1).getContent();
         if (!ScanString.isWord(anchor)) return Symbol.nothing;

--- a/src/fitnesse/wikitext/parser/AnchorReference.java
+++ b/src/fitnesse/wikitext/parser/AnchorReference.java
@@ -14,7 +14,7 @@ public class AnchorReference extends SymbolType implements Rule, Translation {
 
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         List<Symbol> tokens = parser.moveNext(new SymbolType[] {SymbolType.Text});
-        if (tokens.size() == 0) return Symbol.nothing;
+        if (tokens.isEmpty()) return Symbol.nothing;
 
         String anchor = tokens.get(0).getContent();
         if (!ScanString.isWord(anchor)) return Symbol.nothing;

--- a/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
@@ -37,7 +37,7 @@ public class ContentsItemBuilder {
 
     private HtmlTag buildListItem(SourcePage child) {
         HtmlTag listItem = buildItem(child);
-        if (child.getChildren().size() > 0) {
+        if (!child.getChildren().isEmpty()) {
             if (level < getRecursionLimit()) {
                 listItem.add(new ContentsItemBuilder(contents, level + 1, child).buildLevel(child));
             }
@@ -61,7 +61,7 @@ public class ContentsItemBuilder {
         link.addAttribute("class", getBooleanPropertiesClasses(page));
         listItem.add(link);
         String help = page.getProperty(PageData.PropertyHELP);
-        if (help.length() > 0) {
+        if (!help.isEmpty()) {
             if (hasOption("-h", Contents.HELP_TOC)) {
                 listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + help));
             }
@@ -82,12 +82,12 @@ public class ContentsItemBuilder {
 
         if (hasOption("-p", Contents.PROPERTY_TOC)) {
             String properties = getBooleanProperties(page);
-            if (properties.length() > 0) itemText += " " + properties;
+            if (!properties.isEmpty()) itemText += " " + properties;
         }
 
         if (hasOption("-f", Contents.FILTER_TOC)) {
             String filters = page.getProperty(PageData.PropertySUITES);
-            if (filters.length() > 0) itemText += " (" + filters + ")";
+            if (!filters.isEmpty()) itemText += " (" + filters + ")";
         }
         
         return itemText;
@@ -101,7 +101,7 @@ public class ContentsItemBuilder {
         for (Symbol child: contents.getChildren()) {
             if (!child.getContent().startsWith("-R")) continue;
             String level = child.getContent().substring(2);
-            if (level.length() == 0) return Integer.MAX_VALUE;
+            if (level.isEmpty()) return Integer.MAX_VALUE;
             try {
               return Integer.parseInt(level);
             }
@@ -116,7 +116,7 @@ public class ContentsItemBuilder {
         for (Symbol child: contents.getChildren()) {
            if (child.getContent().equals(option)) return true;
         }
-        return variableName.length() > 0
+        return !variableName.isEmpty()
                 && contents.getVariable(variableName, "").equals("true");
     }
 

--- a/src/fitnesse/wikitext/parser/EqualPairRule.java
+++ b/src/fitnesse/wikitext/parser/EqualPairRule.java
@@ -3,7 +3,7 @@ package fitnesse.wikitext.parser;
 public class EqualPairRule implements Rule {
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         Symbol body = parser.parseToIgnoreFirst(current.getType());
-        if (body.getChildren().size() == 0)  return Symbol.nothing;
+        if (body.getChildren().isEmpty())  return Symbol.nothing;
         if (!parser.getCurrent().isType(current.getType())) return Symbol.nothing;
 
         return new Maybe<Symbol>(current.add(body));

--- a/src/fitnesse/wikitext/parser/FormattedExpression.java
+++ b/src/fitnesse/wikitext/parser/FormattedExpression.java
@@ -19,7 +19,7 @@ public class FormattedExpression {
 
     public Maybe<String> evaluate() {
         parseFormat();
-        return expression.length() > 0 ? evaluateAndFormat() : new Maybe<String>("");
+        return !expression.isEmpty() ? evaluateAndFormat() : new Maybe<String>("");
     }
 
     private void parseFormat() {

--- a/src/fitnesse/wikitext/parser/HashTable.java
+++ b/src/fitnesse/wikitext/parser/HashTable.java
@@ -17,7 +17,7 @@ public class HashTable extends SymbolType implements Rule, Translation {
             current.add(row);
             for (int i = 0; i < 2; i++) {
                 Symbol cell = parser.parseToIgnoreFirst(terminators);
-                if (parser.atEnd() || cell.getChildren().size() == 0) return Symbol.nothing;
+                if (parser.atEnd() || cell.getChildren().isEmpty()) return Symbol.nothing;
                 row.add(cell);
             }
             if (parser.getCurrent().isType(SymbolType.CloseBrace)) break;

--- a/src/fitnesse/wikitext/parser/Help.java
+++ b/src/fitnesse/wikitext/parser/Help.java
@@ -28,7 +28,7 @@ public class Help extends SymbolType implements Rule, Translation {
 
     public String toTarget(Translator translator, Symbol symbol) {
         String helpText = translator.getPage().getProperty(PageData.PropertyHELP);
-        String editText = !helpText.isEmpty() ? "edit" : "edit help text";
+        String editText = helpText.isEmpty() ? "edit help text" : "edit";
         if (symbol.hasProperty(editableOption)) {
           helpText += " <a href=\"" + translator.getPage().getFullPath() + "?properties\">(" + editText + ")</a>";
         }

--- a/src/fitnesse/wikitext/parser/Help.java
+++ b/src/fitnesse/wikitext/parser/Help.java
@@ -16,7 +16,7 @@ public class Help extends SymbolType implements Rule, Translation {
     
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         List<Symbol> lookAhead = parser.peek(new SymbolType[] {SymbolType.Whitespace, SymbolType.Text});
-        if (lookAhead.size() != 0 ) {
+        if (!lookAhead.isEmpty()) {
             String option = lookAhead.get(1).getContent();
             if (option.equals(editableOption)) {
                 current.putProperty(editableOption, "");
@@ -28,7 +28,7 @@ public class Help extends SymbolType implements Rule, Translation {
 
     public String toTarget(Translator translator, Symbol symbol) {
         String helpText = translator.getPage().getProperty(PageData.PropertyHELP);
-        String editText = helpText.length() > 0 ? "edit" : "edit help text";
+        String editText = !helpText.isEmpty() ? "edit" : "edit help text";
         if (symbol.hasProperty(editableOption)) {
           helpText += " <a href=\"" + translator.getPage().getFullPath() + "?properties\">(" + editText + ")</a>";
         }

--- a/src/fitnesse/wikitext/parser/LastModified.java
+++ b/src/fitnesse/wikitext/parser/LastModified.java
@@ -20,13 +20,13 @@ public class LastModified extends SymbolType implements Translation {
         String date = translator.getPage().getProperty(PageData.PropertyLAST_MODIFIED);
         return translator.formatMessage(
                 "Last modified " +
-                (user.length() > 0 ? "by " + user : "anonymously") +
+                (!user.isEmpty() ? "by " + user : "anonymously") +
                 " on " + formatDate(date));
     }
 
     private String formatDate(String dateString) {
         Date date;
-        if (dateString.length() == 0) date = Clock.currentDate();
+        if (dateString.isEmpty()) date = Clock.currentDate();
         else {
             try {
                 date = WikiPageProperties.getTimeFormat().parse(dateString);

--- a/src/fitnesse/wikitext/parser/Link.java
+++ b/src/fitnesse/wikitext/parser/Link.java
@@ -37,11 +37,11 @@ public class Link extends SymbolType implements Rule, Translation {
             tag = new HtmlTag("img");
             tag.addAttribute("src", reference.makeUrl(prefix));
             String imageClass = link.getProperty(Link.ImageProperty);
-            if (imageClass.length() > 0) tag.addAttribute("class", imageClass);
+            if (!imageClass.isEmpty()) tag.addAttribute("class", imageClass);
             String width = link.getProperty(Link.WidthProperty);
-            if (width.length() > 0) tag.addAttribute("width", width);
+            if (!width.isEmpty()) tag.addAttribute("width", width);
             String style = link.getProperty(Link.StyleProperty);
-            if (style.length() > 0) tag.addAttribute("style", style);
+            if (!style.isEmpty()) tag.addAttribute("style", style);
         }
         else {
             tag = new HtmlTag("a", body);

--- a/src/fitnesse/wikitext/parser/ListRule.java
+++ b/src/fitnesse/wikitext/parser/ListRule.java
@@ -30,7 +30,7 @@ public class ListRule implements Rule {
     }
 
     private Symbol makeListBody(Parser parser) {
-        while (parser.peek(new SymbolType[] {SymbolType.Whitespace}).size() > 0) {
+        while (!parser.peek(new SymbolType[]{SymbolType.Whitespace}).isEmpty()) {
             parser.moveNext(1);
         }
         return parser.parseTo(SymbolType.Newline, 1);

--- a/src/fitnesse/wikitext/parser/ScanString.java
+++ b/src/fitnesse/wikitext/parser/ScanString.java
@@ -24,7 +24,7 @@ public class ScanString {
     public void markStart(int markStartOffset) { this.markStartOffset = markStartOffset; }
 
     public boolean matches(String match, int startsAt) {
-        if (match.length() == 0) return false;
+        if (match.isEmpty()) return false;
         if (offset + startsAt + match.length() > input.length()) return false;
         return input.regionMatches(offset + startsAt, match, 0, match.length());
     }

--- a/src/fitnesse/wikitext/parser/Today.java
+++ b/src/fitnesse/wikitext/parser/Today.java
@@ -26,7 +26,7 @@ public class Today extends SymbolType implements Rule, Translation {
 
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         List<Symbol> lookAhead = parser.peek(new SymbolType[] {SymbolType.Whitespace, SymbolType.DateFormatOption});
-        if (lookAhead.size() != 0 ) {
+        if (!lookAhead.isEmpty()) {
             String option = lookAhead.get(1).getContent();
             if (isDateFormatOption(option)) {
                 current.putProperty(Today.Format, option);
@@ -35,7 +35,7 @@ public class Today extends SymbolType implements Rule, Translation {
         }
         else {
             lookAhead = parser.peek(new SymbolType[] {SymbolType.Whitespace, SymbolType.OpenParenthesis});
-            if (lookAhead.size() != 0) {
+            if (!lookAhead.isEmpty()) {
                 parser.moveNext(2);
                 Maybe<String> format = parser.parseToAsString(SymbolType.CloseParenthesis);
                 if (format.isNothing())  return Symbol.nothing;
@@ -43,7 +43,7 @@ public class Today extends SymbolType implements Rule, Translation {
             }
         }
         lookAhead = parser.peek(new SymbolType[] {SymbolType.Whitespace, SymbolType.Delta});
-        if (lookAhead.size() != 0) {
+        if (!lookAhead.isEmpty()) {
             String increment = lookAhead.get(1).getContent();
             current.putProperty(Increment, increment);
             parser.moveNext(2);
@@ -77,7 +77,7 @@ public class Today extends SymbolType implements Rule, Translation {
         return
             format.equals("-t") ? "dd MMM, yyyy HH:mm" :
             format.equals("-xml") ? "yyyy-MM-dd'T'HH:mm:ss" :
-            format.length() == 0 ? "dd MMM, yyyy" :
+                    format.isEmpty() ? "dd MMM, yyyy" :
                 format;
     }
 }

--- a/src/fitnesse/wikitext/parser/Variable.java
+++ b/src/fitnesse/wikitext/parser/Variable.java
@@ -12,7 +12,7 @@ public class Variable extends SymbolType implements Rule, Translation {
     
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         Maybe<String> name = parser.parseToAsString(SymbolType.CloseBrace);
-        if (name.isNothing() || name.getValue().length() == 0) return Symbol.nothing;
+        if (name.isNothing() || name.getValue().isEmpty()) return Symbol.nothing;
         String variableName = name.getValue();
         if (!ScanString.isVariableName(variableName)) return Symbol.nothing;
 

--- a/src/util/CommandLine.java
+++ b/src/util/CommandLine.java
@@ -113,7 +113,7 @@ class Option {
     List<String> usableTokens = new LinkedList<String>();
     for (int i = 0; i < tokens.length; i++) {
       String token = tokens[i];
-      if (token.length() > 0)
+      if (!token.isEmpty())
         usableTokens.add(token);
     }
     return usableTokens.toArray(new String[]{});

--- a/src/util/CommandLine.java
+++ b/src/util/CommandLine.java
@@ -111,8 +111,7 @@ class Option {
   protected String[] split(String value) {
     String[] tokens = value.split(" ");
     List<String> usableTokens = new LinkedList<String>();
-    for (int i = 0; i < tokens.length; i++) {
-      String token = tokens[i];
+    for (String token : tokens) {
       if (!token.isEmpty())
         usableTokens.add(token);
     }

--- a/src/util/GracefulNamer.java
+++ b/src/util/GracefulNamer.java
@@ -39,7 +39,7 @@ public class GracefulNamer {
     final char separator = '.';
     char c = '?';
     GracefulNamer namer = new GracefulNamer();
-    if (disgracefulName.length() > 0)
+    if (!disgracefulName.isEmpty())
       namer.finalName.append(c = disgracefulName.charAt(0));
 
     boolean isGrabbingDigits = false;

--- a/test/fit/FitServerTest.java
+++ b/test/fit/FitServerTest.java
@@ -318,7 +318,7 @@ public class FitServerTest {
   private String readWholeResponse() throws Exception {
     StringBuffer buffer = new StringBuffer();
     String block = readFromFitServer();
-    while (block.length() > 0) {
+    while (!block.isEmpty()) {
       buffer.append(block);
       block = readFromFitServer();
     }

--- a/test/fitnesse/wikitext/parser/ParserTestHelper.java
+++ b/test/fitnesse/wikitext/parser/ParserTestHelper.java
@@ -39,7 +39,7 @@ public class ParserTestHelper {
       String name = current.getType().toString();
       result.append(name);
       String content = current.getContent();
-      if (content.length() > 0) result.append("=").append(content);
+      if (!content.isEmpty()) result.append("=").append(content);
     }
     assertEquals(expected, result.toString());
   }


### PR DESCRIPTION
Converts various instances of (!)size > 0 to use isEmpty instead. In most cases, it's more readable, it doesn't need to count all the elements like length() so there's a (probably not noticable) performance gain and it's one step closer to a happy SonarQube.

At the same time I did some simplifications and minor fixes in related parts of the code. See individual commits for details.