### PR TITLE
Remove unused imports

### DIFF
--- a/src/fitnesse/ContextConfigurator.java
+++ b/src/fitnesse/ContextConfigurator.java
@@ -1,6 +1,5 @@
 package fitnesse;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
@@ -15,8 +14,6 @@ import fitnesse.testsystems.slim.CustomComparatorRegistry;
 import fitnesse.testsystems.slim.tables.SlimTableFactory;
 import fitnesse.wiki.RecentChanges;
 import fitnesse.wiki.RecentChangesWikiPage;
-import fitnesse.wiki.SystemVariableSource;
-import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wiki.WikiPageFactoryRegistry;
 import fitnesse.wiki.fs.FileSystemPageFactory;

--- a/src/fitnesse/fixtures/FitnesseFixtureContext.java
+++ b/src/fitnesse/fixtures/FitnesseFixtureContext.java
@@ -6,7 +6,6 @@ import fitnesse.FitNesseContext;
 import fitnesse.authentication.Authenticator;
 import fitnesse.http.MockResponseSender;
 import fitnesse.http.Response;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.WikiPage;
 
 public class FitnesseFixtureContext {

--- a/src/fitnesse/fixtures/SetUp.java
+++ b/src/fitnesse/fixtures/SetUp.java
@@ -13,7 +13,6 @@ import fit.Fixture;
 import fitnesse.authentication.Authenticator;
 import fitnesse.responders.editing.SaveRecorder;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 public class SetUp extends Fixture {
   public SetUp() throws Exception {

--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -18,7 +18,6 @@ import fitnesse.PluginException;
 import fitnesse.testrunner.MultipleTestsRunner;
 import fitnesse.testrunner.PagesByTestSystem;
 import fitnesse.testrunner.SuiteContentsFinder;
-import fitnesse.testrunner.SuiteFilter;
 import fitnesse.testsystems.ConsoleExecutionLogListener;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.wiki.PageCrawler;

--- a/src/fitnesse/responders/WikiPageResponder.java
+++ b/src/fitnesse/responders/WikiPageResponder.java
@@ -3,7 +3,6 @@
 package fitnesse.responders;
 
 import java.util.Map;
-import java.util.Properties;
 
 import fitnesse.FitNesseContext;
 import fitnesse.authentication.SecureOperation;

--- a/src/fitnesse/responders/files/FileResponder.java
+++ b/src/fitnesse/responders/files/FileResponder.java
@@ -13,13 +13,11 @@ import java.net.URLDecoder;
 import java.text.ParseException;
 import java.util.Date;
 
-import fitnesse.authentication.AlwaysSecureOperation;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureResponder;
 import fitnesse.util.Clock;
 import util.StreamReader;
 import fitnesse.FitNesseContext;
-import fitnesse.Responder;
 import fitnesse.http.InputStreamResponse;
 import fitnesse.http.Request;
 import fitnesse.http.Response;

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -45,7 +45,6 @@ import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PageType;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.UrlPathVariableSource;
 import fitnesse.wiki.WikiImportProperty;
 import fitnesse.wiki.WikiPage;
 import fitnesse.responders.WikiPageActions;

--- a/src/fitnesse/responders/versions/VersionComparerResponder.java
+++ b/src/fitnesse/responders/versions/VersionComparerResponder.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import fitnesse.FitNesseContext;

--- a/src/fitnesse/responders/versions/VersionResponder.java
+++ b/src/fitnesse/responders/versions/VersionResponder.java
@@ -22,7 +22,6 @@ import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.UrlPathVariableSource;
 import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;

--- a/src/fitnesse/testrunner/PagesByTestSystem.java
+++ b/src/fitnesse/testrunner/PagesByTestSystem.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import fitnesse.testsystems.TestPage;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wikitext.parser.VariableSource;
 
 /**
  * Organize pages by test system in an appropriate order.

--- a/src/fitnesse/testrunner/TestPageWithSuiteSetUpAndTearDown.java
+++ b/src/fitnesse/testrunner/TestPageWithSuiteSetUpAndTearDown.java
@@ -3,7 +3,6 @@ package fitnesse.testrunner;
 import fitnesse.testrunner.WikiTestPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wikitext.parser.VariableSource;
 
 public class TestPageWithSuiteSetUpAndTearDown extends WikiTestPage {
 

--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -16,7 +16,6 @@ import fitnesse.wikitext.parser.HtmlTranslator;
 import fitnesse.wikitext.parser.Parser;
 import fitnesse.wikitext.parser.ParsingPage;
 import fitnesse.wikitext.parser.Symbol;
-import fitnesse.wikitext.parser.VariableSource;
 import fitnesse.wikitext.parser.WikiSourcePage;
 
 public class WikiTestPage implements TestPage {

--- a/src/fitnesse/testrunner/WikiTestPageUtil.java
+++ b/src/fitnesse/testrunner/WikiTestPageUtil.java
@@ -1,6 +1,5 @@
 package fitnesse.testrunner;
 
-import fitnesse.http.Request;
 import fitnesse.wiki.WikiPageUtil;
 
 public class WikiTestPageUtil {

--- a/src/fitnesse/testutil/FitNesseUtil.java
+++ b/src/fitnesse/testutil/FitNesseUtil.java
@@ -9,15 +9,10 @@ import fitnesse.PluginException;
 import fitnesse.authentication.Authenticator;
 import fitnesse.authentication.PromiscuousAuthenticator;
 import fitnesse.wiki.RecentChangesWikiPage;
-import fitnesse.wiki.SystemVariableSource;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wiki.fs.FileSystem;
-import fitnesse.wiki.fs.FileSystemPageFactory;
-import fitnesse.wiki.fs.MemoryFileSystem;
 import fitnesse.wiki.fs.ZipFileVersionsController;
 import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wikitext.parser.VariableSource;
 import util.FileUtil;
 
 import java.io.File;

--- a/src/fitnesse/wiki/WikiPageProperties.java
+++ b/src/fitnesse/wiki/WikiPageProperties.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Logger;
 
-import fitnesse.html.HtmlUtil;
 import fitnesse.util.XmlUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/src/fitnesse/wiki/fs/GitFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/GitFileVersionsController.java
@@ -1,7 +1,6 @@
 package fitnesse.wiki.fs;
 
 import fitnesse.FitNesseContext;
-import fitnesse.components.ComponentFactory;
 import fitnesse.wiki.*;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.Git;

--- a/src/fitnesse/wikitext/parser/WikiSourcePage.java
+++ b/src/fitnesse/wikitext/parser/WikiSourcePage.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang.StringUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.logging.Logger;
 
 public class WikiSourcePage implements SourcePage {
     private WikiPage page;

--- a/test/fitnesse/FitNesseExpediterTest.java
+++ b/test/fitnesse/FitNesseExpediterTest.java
@@ -18,7 +18,6 @@ import fitnesse.http.ResponseParser;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.util.MockSocket;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/authentication/AuthenticatorTest.java
+++ b/test/fitnesse/authentication/AuthenticatorTest.java
@@ -11,7 +11,6 @@ import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.testutil.SimpleAuthenticator;
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 import org.junit.Before;

--- a/test/fitnesse/authentication/SecureOperationTest.java
+++ b/test/fitnesse/authentication/SecureOperationTest.java
@@ -9,7 +9,6 @@ import fitnesse.wiki.*;
 import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/components/ComponentFactoryTest.java
+++ b/test/fitnesse/components/ComponentFactoryTest.java
@@ -2,7 +2,6 @@ package fitnesse.components;
 
 import java.util.Properties;
 
-import fitnesse.ConfigurationParameter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/test/fitnesse/fixtures/PageCreatorTest.java
+++ b/test/fitnesse/fixtures/PageCreatorTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 import org.junit.After;

--- a/test/fitnesse/html/HtmlUtilTest.java
+++ b/test/fitnesse/html/HtmlUtilTest.java
@@ -9,10 +9,8 @@ import fitnesse.FitNesseContext;
 import fitnesse.html.template.HtmlPage;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.WikiPage;
 import fitnesse.responders.WikiPageActions;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/http/ExposeThreadingIssueInMockResponseTest.java
+++ b/test/fitnesse/http/ExposeThreadingIssueInMockResponseTest.java
@@ -11,7 +11,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/reporting/CompositeExecutionLogTest.java
+++ b/test/fitnesse/reporting/CompositeExecutionLogTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 
 import fitnesse.FitNesseContext;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;

--- a/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
@@ -19,7 +19,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wikitext.parser.VariableSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/reporting/history/ExecutionReportTest.java
+++ b/test/fitnesse/reporting/history/ExecutionReportTest.java
@@ -22,8 +22,6 @@ import fitnesse.util.TimeMeasurement;
 import fitnesse.FitNesseContext;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
 
 public class ExecutionReportTest {
   private FitNesseContext context;

--- a/test/fitnesse/reporting/history/SuiteHistoryFormatterTest.java
+++ b/test/fitnesse/reporting/history/SuiteHistoryFormatterTest.java
@@ -6,7 +6,6 @@ import fitnesse.reporting.history.SuiteExecutionReport.PageHistoryReference;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.WikiPage;
 
 import static org.junit.Assert.assertEquals;

--- a/test/fitnesse/reporting/history/TestExecutionReportTest.java
+++ b/test/fitnesse/reporting/history/TestExecutionReportTest.java
@@ -17,7 +17,6 @@ import fitnesse.reporting.history.TestExecutionReport.InstructionResult;
 import fitnesse.reporting.history.TestExecutionReport.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 public class TestExecutionReportTest {
   private TestExecutionReport expected;

--- a/test/fitnesse/responders/ImportAndViewResponderTest.java
+++ b/test/fitnesse/responders/ImportAndViewResponderTest.java
@@ -4,7 +4,6 @@ package fitnesse.responders;
 
 import static org.junit.Assert.assertEquals;
 
-import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
 import fitnesse.http.Response;
 import fitnesse.testutil.FitNesseUtil;

--- a/test/fitnesse/responders/NameWikiPageResponderTest.java
+++ b/test/fitnesse/responders/NameWikiPageResponderTest.java
@@ -8,7 +8,7 @@ import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.*;
-import fitnesse.wiki.fs.InMemoryPage;
+
 import static org.junit.Assert.assertEquals;
 import org.json.JSONArray;
 import org.junit.Before;

--- a/test/fitnesse/responders/NotFoundResponderTest.java
+++ b/test/fitnesse/responders/NotFoundResponderTest.java
@@ -10,8 +10,6 @@ import fitnesse.Responder;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/PacketResponderTest.java
+++ b/test/fitnesse/responders/PacketResponderTest.java
@@ -13,7 +13,6 @@ import fitnesse.Responder;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 

--- a/test/fitnesse/responders/PageDataWikiPageResponderTest.java
+++ b/test/fitnesse/responders/PageDataWikiPageResponderTest.java
@@ -12,7 +12,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/ResponderTestCase.java
+++ b/test/fitnesse/responders/ResponderTestCase.java
@@ -7,7 +7,6 @@ import fitnesse.Responder;
 import fitnesse.http.MockRequest;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 
 public abstract class ResponderTestCase {

--- a/test/fitnesse/responders/SerializedPageResponderTest.java
+++ b/test/fitnesse/responders/SerializedPageResponderTest.java
@@ -24,7 +24,6 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/WikiImportingResponderAuthenticationTest.java
+++ b/test/fitnesse/responders/WikiImportingResponderAuthenticationTest.java
@@ -4,7 +4,6 @@ import static util.RegexTestCase.assertHasRegexp;
 import static util.RegexTestCase.assertNotSubString;
 import static util.RegexTestCase.assertSubString;
 
-import fitnesse.FitNesseContext;
 import fitnesse.authentication.OneUserAuthenticator;
 import fitnesse.http.ChunkedResponse;
 import fitnesse.http.MockChunkedDataProvider;

--- a/test/fitnesse/responders/WikiPageResponderTest.java
+++ b/test/fitnesse/responders/WikiPageResponderTest.java
@@ -26,7 +26,6 @@ import fitnesse.wiki.WikiImportProperty;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/editing/AddChildPageResponderTest.java
+++ b/test/fitnesse/responders/editing/AddChildPageResponderTest.java
@@ -14,7 +14,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/editing/EditResponderTest.java
+++ b/test/fitnesse/responders/editing/EditResponderTest.java
@@ -17,7 +17,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/editing/MergeResponderTest.java
+++ b/test/fitnesse/responders/editing/MergeResponderTest.java
@@ -12,7 +12,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/editing/NewPageResponderTest.java
+++ b/test/fitnesse/responders/editing/NewPageResponderTest.java
@@ -10,7 +10,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/editing/PropertiesResponderTest.java
+++ b/test/fitnesse/responders/editing/PropertiesResponderTest.java
@@ -27,7 +27,6 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;

--- a/test/fitnesse/responders/editing/SavePropertiesResponderTest.java
+++ b/test/fitnesse/responders/editing/SavePropertiesResponderTest.java
@@ -17,7 +17,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/editing/SaveResponderTest.java
+++ b/test/fitnesse/responders/editing/SaveResponderTest.java
@@ -16,7 +16,6 @@ import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/editing/SymbolicLinkResponderTest.java
+++ b/test/fitnesse/responders/editing/SymbolicLinkResponderTest.java
@@ -21,7 +21,6 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.FileSystemPage;
-import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.fs.MemoryFileSystem;
 import org.junit.After;
 import org.junit.Before;

--- a/test/fitnesse/responders/editing/TemplateUtilTest.java
+++ b/test/fitnesse/responders/editing/TemplateUtilTest.java
@@ -10,8 +10,6 @@ import fitnesse.wiki.WikiPageUtil;
 import org.junit.Before;
 import org.junit.Test;
 
-import fitnesse.http.MockRequest;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;

--- a/test/fitnesse/responders/files/FileResponderTest.java
+++ b/test/fitnesse/responders/files/FileResponderTest.java
@@ -15,13 +15,11 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 
 import fitnesse.FitNesseContext;
-import fitnesse.Responder;
 import fitnesse.http.InputStreamResponse;
 import fitnesse.http.MockRequest;
 import fitnesse.http.MockResponseSender;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
-import fitnesse.responders.ErrorResponder;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.testutil.SampleFileUtility;
 import org.junit.After;

--- a/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
@@ -15,7 +15,6 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ResponderTestCase;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;

--- a/test/fitnesse/responders/refactoring/MovePageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/MovePageResponderTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import fitnesse.Responder;
 import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ResponderTestCase;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;

--- a/test/fitnesse/responders/refactoring/RefactorPageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/RefactorPageResponderTest.java
@@ -6,14 +6,10 @@ import static org.junit.Assert.assertEquals;
 import static util.RegexTestCase.assertSubString;
 
 import fitnesse.Responder;
-import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ResponderTestCase;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/refactoring/RenamePageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/RenamePageResponderTest.java
@@ -13,7 +13,6 @@ import fitnesse.Responder;
 import fitnesse.http.MockResponseSender;
 import fitnesse.http.Response;
 import fitnesse.responders.ResponderTestCase;
-import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/refactoring/SearchReplaceResponderTest.java
+++ b/test/fitnesse/responders/refactoring/SearchReplaceResponderTest.java
@@ -6,15 +6,11 @@ import static org.hamcrest.Matchers.*;
 import fitnesse.Responder;
 import fitnesse.responders.ResponderTestCase;
 import fitnesse.wiki.*;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 
-import fitnesse.FitNesseContext;
-import fitnesse.http.MockRequest;
 import fitnesse.http.MockResponseSender;
 import fitnesse.http.Response;
-import fitnesse.testutil.FitNesseUtil;
 
 public class SearchReplaceResponderTest extends ResponderTestCase {
   private WikiPagePath pagePath;

--- a/test/fitnesse/responders/run/StopTestResponderTest.java
+++ b/test/fitnesse/responders/run/StopTestResponderTest.java
@@ -14,7 +14,6 @@ import fitnesse.http.MockResponseSender;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 
 public class StopTestResponderTest {

--- a/test/fitnesse/responders/run/SuiteResponderTest.java
+++ b/test/fitnesse/responders/run/SuiteResponderTest.java
@@ -4,7 +4,6 @@ package fitnesse.responders.run;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.util.Properties;
 
 import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
@@ -17,7 +16,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/run/TestResponderTest.java
+++ b/test/fitnesse/responders/run/TestResponderTest.java
@@ -25,7 +25,6 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
+++ b/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
@@ -9,11 +9,9 @@ import fitnesse.FitNesseContext;
 import fitnesse.html.HtmlUtil;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
-import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.testsystems.slim.*;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.*;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/search/ExecuteSearchPropertiesResponderTest.java
+++ b/test/fitnesse/responders/search/ExecuteSearchPropertiesResponderTest.java
@@ -28,7 +28,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/search/SearchFormResponderTest.java
+++ b/test/fitnesse/responders/search/SearchFormResponderTest.java
@@ -11,8 +11,6 @@ import org.junit.Test;
 
 import fitnesse.FitNesseContext;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 

--- a/test/fitnesse/responders/search/SearchResponderTest.java
+++ b/test/fitnesse/responders/search/SearchResponderTest.java
@@ -12,9 +12,7 @@ import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/search/WhereUsedResponderTest.java
+++ b/test/fitnesse/responders/search/WhereUsedResponderTest.java
@@ -13,7 +13,6 @@ import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/testHistory/HistoryComparerResponderTest.java
+++ b/test/fitnesse/responders/testHistory/HistoryComparerResponderTest.java
@@ -18,8 +18,6 @@ import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
 
 public class HistoryComparerResponderTest {
   public HistoryComparerResponder responder;

--- a/test/fitnesse/responders/testHistory/HistoryComparerTest.java
+++ b/test/fitnesse/responders/testHistory/HistoryComparerTest.java
@@ -20,7 +20,6 @@ import util.FileUtil;
 import fitnesse.FitNesseContext;
 import fitnesse.reporting.history.TestExecutionReport;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 
 public class HistoryComparerTest {
   private HistoryComparer comparer;

--- a/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
@@ -35,8 +35,6 @@ import fitnesse.reporting.history.SuiteExecutionReport;
 import fitnesse.reporting.history.TestExecutionReport;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
 
 public class PageHistoryResponderTest {
   private File resultsDirectory;

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -28,8 +28,6 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import fitnesse.wiki.WikiPage;
 import util.FileUtil;
 
 public class TestHistoryResponderTest {

--- a/test/fitnesse/responders/versions/RollbackResponderTest.java
+++ b/test/fitnesse/responders/versions/RollbackResponderTest.java
@@ -16,8 +16,6 @@ import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import org.junit.Before;
 import org.junit.Test;
 
 public class RollbackResponderTest {

--- a/test/fitnesse/responders/versions/VersionComparerResponderTest.java
+++ b/test/fitnesse/responders/versions/VersionComparerResponderTest.java
@@ -9,7 +9,6 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.*;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/responders/versions/VersionResponderTest.java
+++ b/test/fitnesse/responders/versions/VersionResponderTest.java
@@ -20,7 +20,6 @@ import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Test;
 
 public class VersionResponderTest {

--- a/test/fitnesse/responders/versions/VersionSelectionResponderTest.java
+++ b/test/fitnesse/responders/versions/VersionSelectionResponderTest.java
@@ -15,7 +15,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/slim/instructions/CallInstructionTest.java
+++ b/test/fitnesse/slim/instructions/CallInstructionTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.*;
 
 public class CallInstructionTest {

--- a/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
+++ b/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
@@ -14,7 +14,6 @@ import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;

--- a/test/fitnesse/testrunner/PagesByTestSystemTest.java
+++ b/test/fitnesse/testrunner/PagesByTestSystemTest.java
@@ -11,7 +11,6 @@ import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/testrunner/WikiTestPageTest.java
+++ b/test/fitnesse/testrunner/WikiTestPageTest.java
@@ -12,7 +12,6 @@ import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wikitext.parser.VariableSource;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/test/fitnesse/updates/UpdateFileListTest.java
+++ b/test/fitnesse/updates/UpdateFileListTest.java
@@ -1,8 +1,7 @@
 package fitnesse.updates;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
 import org.junit.After;
 
 import static org.junit.Assert.*;

--- a/test/fitnesse/updates/UpdaterImplementationTest.java
+++ b/test/fitnesse/updates/UpdaterImplementationTest.java
@@ -9,9 +9,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 
 import fitnesse.FitNesseContext;
-import fitnesse.authentication.PromiscuousAuthenticator;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.SystemVariableSource;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.fs.FileSystemPageFactory;
 import org.junit.After;

--- a/test/fitnesse/wiki/fs/FileSystemPageTest.java
+++ b/test/fitnesse/wiki/fs/FileSystemPageTest.java
@@ -16,8 +16,6 @@ import java.util.Date;
 import java.util.List;
 
 import static fitnesse.wiki.PageData.*;
-import static fitnesse.wiki.PageData.PropertyFILES;
-import static fitnesse.wiki.PageData.PropertyVERSIONS;
 import static fitnesse.wiki.PageType.SUITE;
 import static fitnesse.wiki.PageType.TEST;
 import static org.junit.Assert.*;

--- a/test/fitnesse/wikitext/PerformanceTest.java
+++ b/test/fitnesse/wikitext/PerformanceTest.java
@@ -9,7 +9,6 @@ import fitnesse.slim.protocol.SlimSerializer;
 
 import fitnesse.wiki.WikiPage;
 import fitnesse.wikitext.parser.*;
-import fitnesse.wikitext.parser.TestRoot;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Removed imports which were marked as unused. Didn't see any errors or warnings when removing them and all tests are still passing when running `ant`.