### PR TITLE
Make decision table use last scriptTable class in scenarios

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 public class ScenarioTable extends SlimTable {
   private static final String instancePrefix = "scenarioTable";
   private static final String underscorePattern = "\\W_(?=\\W|$)";
+  private static Class<? extends ScriptTable> defaultChildClass = ScriptTable.class;
   private String name;
   private List<String> inputs = new ArrayList<String>();
   private Set<String> outputs = new HashSet<String>();
@@ -186,22 +187,33 @@ private void splitInputAndOutputArguments(String argName) {
 
   protected ScriptTable createChild(ScenarioTestContext testContext, SlimTable parentTable, Table newTable) {
     ScriptTable scriptTable;
-    if (parentTable instanceof ScriptTable && !parentTable.getClass().equals(ScriptTable.class)) {
+    if (parentTable instanceof ScriptTable) {
       scriptTable = createChild((ScriptTable) parentTable, newTable, testContext);
     } else {
-      scriptTable = new ScriptTable(newTable, id, testContext);
+      scriptTable = createChild(defaultChildClass, newTable, testContext);
     }
     scriptTable.setCustomComparatorRegistry(customComparatorRegistry);
     return scriptTable;
   }
 
   protected ScriptTable createChild(ScriptTable parentScriptTable, Table newTable, SlimTestContext testContext) {
-    Class<? extends ScriptTable> parentTableClass = parentScriptTable.getClass();
+    return createChild(parentScriptTable.getClass(), newTable, testContext);
+  }
+
+  protected ScriptTable createChild(Class<? extends ScriptTable> parentTableClass, Table newTable, SlimTestContext testContext) {
     try {
       return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
     } catch (Exception e) {
       throw new RuntimeException("Unable to create child table of type: " + parentTableClass.getName(), e);
     }
+  }
+
+  public static void setDefaultChildClass(Class<? extends ScriptTable> defaultChildClass) {
+    ScenarioTable.defaultChildClass = defaultChildClass;
+  }
+
+  public static Class<? extends ScriptTable> getDefaultChildClass() {
+    return defaultChildClass;
   }
 
   public List<SlimAssertion> call(String[] args, ScriptTable parentTable, int row) throws SyntaxError {

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -20,7 +20,6 @@ public class ScriptTable extends SlimTable {
 
   public ScriptTable(Table table, String tableId, SlimTestContext context) {
     super(table, tableId, context);
-    ScenarioTable.setDefaultChildClass(getClass());
   }
 
   protected String getTableType() {
@@ -85,6 +84,7 @@ public class ScriptTable extends SlimTable {
 
   public List<SlimAssertion> getAssertions() throws SyntaxError {
     List<SlimAssertion> assertions = new ArrayList<SlimAssertion>();
+    ScenarioTable.setDefaultChildClass(getClass());
     if (table.getCellContents(0, 0).toLowerCase().startsWith(getTableKeyword())) {
       List<SlimAssertion> createAssertions = startActor();
       if (createAssertions != null) {

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -20,6 +20,7 @@ public class ScriptTable extends SlimTable {
 
   public ScriptTable(Table table, String tableId, SlimTestContext context) {
     super(table, tableId, context);
+    ScenarioTable.setDefaultChildClass(getClass());
   }
 
   protected String getTableType() {

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
@@ -23,9 +23,9 @@ import org.junit.Test;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
-public class ScenarioAndDecisionTableExtensionTest {
-  private static final String SCEN_EXTENSION_NAME = "diffScriptScenario";
-  private static final String SCRIPT_EXTENSION_NAME = "diffScript";
+public class ScenarioAndDecisionTableScriptOnlyExtensionTest {
+  private static final String SCRIPT_EXTENSION_NAME = "diffScript2";
+  private static final String DIFF_SCRIPT_TABLE2_TYPE = "diffScriptTable2";
 
   private WikiPage root;
   private List<SlimAssertion> assertions;
@@ -38,25 +38,28 @@ public class ScenarioAndDecisionTableExtensionTest {
   @Before
   public void setUp() throws Exception {
     SlimTableFactory slimTableFactory = new SlimTableFactory();
-    slimTableFactory.addTableType(SCEN_EXTENSION_NAME, ScenarioTableWithDifferentScript.class);
-    slimTableFactory.addTableType(SCRIPT_EXTENSION_NAME, DiffScriptTable.class);
+    slimTableFactory.addTableType(SCRIPT_EXTENSION_NAME, DiffScriptTable2.class);
     root = InMemoryPage.makeRoot("root");
     assertions = new ArrayList<SlimAssertion>();
-    ScenarioTable.setDefaultChildClass(ScriptTable.class);
   }
 
   private SlimTestContextImpl makeTables(String scenarioText, String scriptText) throws Exception {
     SlimTestContextImpl testContext = new SlimTestContextImpl();
-    String tableText = "!|" + SCEN_EXTENSION_NAME + "|" + scenarioText + "|\n"
+    String tableText = "!|scenario|" + scenarioText + "|\n"
+            + "\n"
+            + "!|" + SCRIPT_EXTENSION_NAME + "|\n"
             + "\n"
             + "!|DT:" + scriptText + "|\n";
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    ScenarioTable st = new ScenarioTableWithDifferentScript(t, "s_id", testContext);
+    ScenarioTable st = new ScenarioTable(t, "s_id", testContext);
     t = ts.getTable(1);
+    DiffScriptTable2 dst = new DiffScriptTable2(t, "ds_id", testContext);
+    t = ts.getTable(2);
     dt = new DecisionTable(t, "did", testContext);
     assertions.addAll(st.getAssertions());
+    assertions.addAll(dst.getAssertions());
     assertions.addAll(dt.getAssertions());
     return testContext;
   }
@@ -72,14 +75,14 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
             asList(
-                    asList("decisionTable_did_0/diffScriptTable_s_id_0", "7")
+                    asList("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", "7")
             )
     );
     SlimAssertion.evaluateExpectations(assertions, pseudoResults);
 
     String scriptTable = dt.getChildren().get(0).getTable().toString();
     String expectedScript =
-      "[[diffScriptScenario, echo, user, giving, user_old], [check, echo, 7, pass(7)]]";
+      "[[scenario, echo, user, giving, user_old], [check, echo, 7, pass(7)]]";
     assertEquals(expectedScript, scriptTable);
     assertEquals(1, testContext.getTestSummary().getRight());
     assertEquals(0, testContext.getTestSummary().getWrong());
@@ -98,7 +101,7 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("decisionTable_did_0/diffScriptTable_s_id_0", "diffScriptTableActor", "function", new Object[]{"7"})
+              new CallInstruction("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "function", new Object[]{"7"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -116,10 +119,10 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("decisionTable_did_0/diffScriptTable_s_id_0", "diffScriptTableActor", "loginWithPasswordAndPin", new Object[]{"bob", "xyzzy", "7734"}),
-              new CallInstruction("decisionTable_did_0/diffScriptTable_s_id_1", "diffScriptTableActor", "currentUserProfileUrl", new Object[0]),
-              new CallInstruction("decisionTable_did_1/diffScriptTable_s_id_0", "diffScriptTableActor", "loginWithPasswordAndPin", new Object[]{"bill", "yabba", "8892"}),
-              new CallInstruction("decisionTable_did_1/diffScriptTable_s_id_1", "diffScriptTableActor", "currentUserProfileUrl", new Object[0])
+              new CallInstruction("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "loginWithPasswordAndPin", new Object[]{"bob", "xyzzy", "7734"}),
+              new CallInstruction("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_1", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "currentUserProfileUrl", new Object[0]),
+              new CallInstruction("decisionTable_did_1/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "loginWithPasswordAndPin", new Object[]{"bill", "yabba", "8892"}),
+              new CallInstruction("decisionTable_did_1/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_1", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "currentUserProfileUrl", new Object[0])
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -135,14 +138,14 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
             asList(
-                    asList("decisionTable_did_0/diffScriptTable_s_id_0", "7")
+                    asList("decisionTable_did_0/" + DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", "7")
             )
     );
     SlimAssertion.evaluateExpectations(assertions, pseudoResults);
 
     String scriptTable = dt.getChildren().get(0).getTable().toString();
     String expectedScript =
-      "[[diffScriptScenario, echo, input, giving, output], [check, echo, 7, pass(7)]]";
+      "[[scenario, echo, input, giving, output], [check, echo, 7, pass(7)]]";
     assertEquals(expectedScript, scriptTable);
     assertEquals(1, testContext.getTestSummary().getRight());
     assertEquals(0, testContext.getTestSummary().getWrong());
@@ -161,14 +164,14 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
             asList(
-                    asList("decisionTable_did_0/diffScriptTable_s_id_0", "7")
+                    asList("decisionTable_did_0/" + DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", "7")
             )
     );
     SlimAssertion.evaluateExpectations(assertions, pseudoResults);
 
     String scriptTable = dt.getChildren().get(0).getTable().toString();
     String expectedScript =
-      "[[diffScriptScenario, echo, input, giving, output], [check, echo, 7, fail(a=7;e=8)]]";
+      "[[scenario, echo, input, giving, output], [check, echo, 7, fail(a=7;e=8)]]";
     assertEquals(expectedScript, scriptTable);
     assertEquals(0, testContext.getTestSummary().getRight());
     assertEquals(1, testContext.getTestSummary().getWrong());
@@ -198,42 +201,27 @@ public class ScenarioAndDecisionTableExtensionTest {
     );
     Map<String, Object> pseudoResults = SlimCommandRunningClient.resultToMap(
             asList(
-                    asList("decisionTable_did_0/diffScriptTable_s_id_0", "7")
+                    asList("decisionTable_did_0/" + DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", "7")
             )
     );
     SlimAssertion.evaluateExpectations(assertions, pseudoResults);
 
     String scriptTable = dt.getChildren().get(0).getTable().toString();
     String expectedScript =
-      "[[diffScriptScenario, echo, input, giving, output, , output2], [check, echo, 7, pass(7)]]";
+      "[[scenario, echo, input, giving, output, , output2], [check, echo, 7, pass(7)]]";
     assertEquals(expectedScript, scriptTable);
-  }
-
-  /**
-   * ScenarioTable that does not make ScriptTables, but DiffScriptTables.
-   */
-  public static class ScenarioTableWithDifferentScript extends ScenarioTable {
-
-    public ScenarioTableWithDifferentScript(Table table, String tableId, SlimTestContext testContext) {
-      super(table, tableId, testContext);
-    }
-
-    @Override
-    protected ScriptTable createChild(ScenarioTestContext testContext, SlimTable parentTable, Table newTable) {
-      return new DiffScriptTable(newTable, id, testContext);
-    }
   }
 
   /**
    * Special script table.
    */
-  public static class DiffScriptTable extends ScriptTable {
+  public static class DiffScriptTable2 extends ScriptTable {
 
-    public DiffScriptTable(Table table, String tableId, SlimTestContext context) {
+    public DiffScriptTable2(Table table, String tableId, SlimTestContext context) {
       super(table, tableId, context);
     }
     protected String getTableType() {
-      return "diffScriptTable";
+      return DIFF_SCRIPT_TABLE2_TYPE;
     }
 
   }

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
@@ -101,8 +101,53 @@ public class ScenarioAndDecisionTableScriptOnlyExtensionTest {
     );
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "function", new Object[]{"7"})
+              new CallInstruction("decisionTable_did_0/" + DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "function", new Object[]{"7"})
       );
+    assertEquals(expectedInstructions, instructions());
+  }
+
+  @Test
+  public void twoDecisionTablesDifferentScripts() throws Exception {
+    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    String tableText = "!|scenario|myScenario|input|\n"
+            + "|function|@input|\n"
+            + "\n"
+            + "!|" + SCRIPT_EXTENSION_NAME + "|\n"
+            + "\n"
+            + "!|DT:myScenario|\n"
+            + "|input|\n"
+            + "|7|\n"
+            + "\n"
+            + "!|script|\n"
+            + "\n"
+            + "!|DT:myScenario|\n"
+            + "|input|\n"
+            + "|6|\n";
+    WikiPageUtil.setPageContents(root, tableText);
+    TableScanner ts = new HtmlTableScanner(root.getHtml());
+    Table t = ts.getTable(0);
+    ScenarioTable st = new ScenarioTable(t, "s_id", testContext);
+    t = ts.getTable(1);
+    DiffScriptTable2 dst = new DiffScriptTable2(t, "ds_id", testContext);
+    t = ts.getTable(2);
+    dt = new DecisionTable(t, "did", testContext);
+
+    t = ts.getTable(3);
+    ScriptTable sct = new ScriptTable(t, "sct_id", testContext);
+    t = ts.getTable(4);
+    DecisionTable dt2 = new DecisionTable(t, "did2", testContext);
+
+    assertions.addAll(st.getAssertions());
+    assertions.addAll(dst.getAssertions());
+    assertions.addAll(dt.getAssertions());
+    assertions.addAll(sct.getAssertions());
+    assertions.addAll(dt2.getAssertions());
+
+    List<CallInstruction> expectedInstructions =
+            asList(
+                    new CallInstruction("decisionTable_did_0/"+ DIFF_SCRIPT_TABLE2_TYPE + "_s_id_0", DIFF_SCRIPT_TABLE2_TYPE + "Actor", "function", new Object[]{"7"}),
+                    new CallInstruction("decisionTable_did2_0/scriptTable_s_id_0", "scriptTableActor", "function", new Object[]{"6"})
+            );
     assertEquals(expectedInstructions, instructions());
   }
 

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
@@ -35,6 +35,7 @@ public class ScenarioAndDecisionTableTest {
   public void setUp() throws Exception {
     root = InMemoryPage.makeRoot("root");
     assertions = new ArrayList<SlimAssertion>();
+    ScenarioTable.setDefaultChildClass(ScriptTable.class);
   }
 
   private SlimTestContextImpl makeTables(String tableText) throws Exception {

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndScriptTableTest.java
@@ -31,6 +31,7 @@ public class ScenarioAndScriptTableTest {
   public void setUp() throws Exception {
     root = InMemoryPage.makeRoot("root");
     assertions = new ArrayList<SlimAssertion>();
+    ScenarioTable.setDefaultChildClass(ScriptTable.class);
   }
 
   private SlimTestContextImpl makeTables(String tableText) throws Exception {


### PR DESCRIPTION
Previously when you had your own scriptTable subclass and you wanted a decisionTable calling a scenario to use that scriptTable subclass you had to define your own scenarioTable subclass.
With this change that is no longer needed. A 'standard' scenario called by a decisionTable will use the last-used scriptTable class for its children.