### PR TITLE
Prevent port conflicts for Slim runner (when in-process)

### DIFF
--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -2,9 +2,6 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
-import fitnesse.slim.fixtureInteraction.DefaultInteraction;
-import util.CommandLine;
-
 import java.io.IOException;
 import java.net.BindException;
 import java.net.ServerSocket;
@@ -13,7 +10,9 @@ import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import fitnesse.slim.fixtureInteraction.DefaultInteraction;
 import fitnesse.socketservice.SocketFactory;
+import util.CommandLine;
 
 import static fitnesse.slim.JavaSlimFactory.createJavaSlimFactory;
 
@@ -67,13 +66,14 @@ public class SlimService {
   }
 
   // For testing only -- for now
-  public static synchronized void startWithFactoryAsync(SlimFactory slimFactory, Options options) throws IOException {
+  public static synchronized int startWithFactoryAsync(SlimFactory slimFactory, Options options) throws IOException {
     if (service != null && service.isAlive()) {
       System.err.println("Already an in-process server running: " + service.getName() + " (alive=" + service.isAlive() + ")");
       service.interrupt();
       throw new RuntimeException("Already an in-process server running: " + service.getName() + " (alive=" + service.isAlive() + ")");
     }
     final SlimService slimservice = new SlimService(slimFactory.getSlimServer(options.verbose), options.port, options.interactionClass, options.daemon);
+    int actualPort = slimservice.getPort();
     service = new Thread() {
       public void run() {
         try {
@@ -84,6 +84,7 @@ public class SlimService {
       }
     };
     service.start();
+    return actualPort;
   }
 
   // For testing, mainly.
@@ -128,6 +129,10 @@ public class SlimService {
       e.printStackTrace();
       throw e;
     }
+  }
+
+  public int getPort() {
+    return serverSocket.getLocalPort();
   }
 
   public void accept() throws IOException {

--- a/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
@@ -29,6 +29,11 @@ public class InProcessSlimClientBuilder extends SlimClientBuilder {
     return new SlimCommandRunningClient(commandRunner, determineSlimHost(), getSlimPort(), determineTimeout(), getSlimVersion());
   }
 
+  @Override
+  protected int getNextSlimPort() {
+    return 0;
+  }
+
   void createSlimService(String[] args) throws IOException {
     while (!tryCreateSlimService(args))
       try {
@@ -41,7 +46,8 @@ public class InProcessSlimClientBuilder extends SlimClientBuilder {
   private boolean tryCreateSlimService(String[] args) throws IOException {
     try {
       SlimService.Options options = SlimService.parseCommandLine(args);
-      SlimService.startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
+      int actualPort = SlimService.startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
+      setSlimPort(actualPort);
       return true;
     } catch (IOException e) {
       throw e;

--- a/src/fitnesse/testsystems/slim/SlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/SlimClientBuilder.java
@@ -21,7 +21,7 @@ public class SlimClientBuilder extends ClientBuilder<SlimCommandRunningClient> {
 
   private static final AtomicInteger slimPortOffset = new AtomicInteger(0);
 
-  private final int slimPort;
+  private int slimPort;
 
   public SlimClientBuilder(Descriptor descriptor) {
     super(descriptor);
@@ -77,6 +77,10 @@ public class SlimClientBuilder extends ClientBuilder<SlimCommandRunningClient> {
     return slimPort;
   }
 
+  protected void setSlimPort(int slimPort) {
+    this.slimPort = slimPort;
+  }
+
   private int findFreePort() {
     int port;
     try {
@@ -89,7 +93,7 @@ public class SlimClientBuilder extends ClientBuilder<SlimCommandRunningClient> {
     return port;
   }
 
-  private int getNextSlimPort() {
+  protected int getNextSlimPort() {
     final int base = getSlimPortBase();
     final int poolSize = getSlimPortPoolSize();
 


### PR DESCRIPTION
Find a free port for in process server, and hang on to it (instead of releasing first and trying to re-acquire later)