### PR TITLE
Do not filter when suiteFilter argument is empty string

### DIFF
--- a/src/fitnesse/testrunner/SuiteFilter.java
+++ b/src/fitnesse/testrunner/SuiteFilter.java
@@ -115,7 +115,7 @@ public class SuiteFilter {
 
     public SuiteTagMatcher(String suiteTags, boolean matchIfNoTags, boolean andStrategy) {
       tagString = suiteTags;
-      if (suiteTags != null) {
+      if (StringUtils.isNotBlank(suiteTags)) {
         tags = Arrays.asList(suiteTags.split(LIST_SEPARATOR));
       }
       else {

--- a/test/fitnesse/responders/run/SuiteResponderTest.java
+++ b/test/fitnesse/responders/run/SuiteResponderTest.java
@@ -246,6 +246,15 @@ public class SuiteResponderTest {
   }
 
   @Test
+  public void testEmptySuiteFilter() throws Exception {
+    addTestPagesWithSuiteProperty();
+    request.setQueryString("suiteFilter=");
+    String results = runSuite();
+    assertSubString("href=\\\"#TestTwo3\\\"", results);
+    assertSubString("href=\\\"#TestThree2\\\"", results);
+  }
+
+  @Test
   public void testSecondMatchingSuiteQuery() throws Exception {
     addTestPagesWithSuiteProperty();
     request.setQueryString("suiteFilter=smoke");


### PR DESCRIPTION
Fixes #624 (with @jessevanbekkum)

When `suiteFilter` argument is empty string, it will not create any `tags` to look for (while filtering).

This Pull Request adds a test for this scenario and the expectation. I have also tested this after building against my own product and saw the expected behavior. I don't expect much of any side effect. 

The use case for this is that we sometimes execute fitnesse with `-c` but with a fixed (string interpolated) command. So this means we have some `suiteName?suiteFilter={{something you can give}}`. However, sometimes the `suiteFilter` can be empty because the user does not provide anything. 

Although we could fix this on our end by going through the command string before passing it to Fitnesse, I do think that giving a program a `filter` argument without providing what to filter should default its behavior to not to filter anything.