### PR TITLE
And some more SonarQube issues

### DIFF
--- a/src/eg/triviaGameExample/Game.java
+++ b/src/eg/triviaGameExample/Game.java
@@ -1,9 +1,10 @@
 package eg.triviaGameExample;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 public class Game {
-  private ArrayList<Player> players;
+  private Collection<Player> players;
   private boolean gameHasStarted = false;
 
   public Game() {

--- a/src/fit/ActionFixture.java
+++ b/src/fit/ActionFixture.java
@@ -13,10 +13,12 @@ import fit.exception.NoSuchMethodFitFailureException;
 public class ActionFixture extends Fixture {
   protected Parse cells;
   private Fixture actor;
+  //TODO(code review): Would placing the array designator on the type make this harder or easier to read?
   protected static final Class<?> empty[] = {};
 
   // Traversal ////////////////////////////////
 
+  @Override
   public void doCells(Parse cells) {
     this.cells = cells;
     try {
@@ -91,10 +93,9 @@ public class ActionFixture extends Fixture {
   protected Method method(String test, int args) throws NoSuchMethodException {
     if (actor == null)
       throw new FitFailureException("You must start a fixture using the 'start' keyword.");
-    Method methods[] = actor.getClass().getMethods();
+    Method[] methods = actor.getClass().getMethods();
     Method result = null;
-    for (int i = 0; i < methods.length; i++) {
-      Method m = methods[i];
+    for (Method m : methods) {
       if (m.getName().equals(test) && m.getParameterTypes().length == args) {
         if (result == null) {
           result = m;

--- a/src/fit/ColumnFixture.java
+++ b/src/fit/ColumnFixture.java
@@ -8,16 +8,18 @@ package fit;
 
 public class ColumnFixture extends Fixture {
 
-  protected Binding columnBindings[];
+  protected Binding[] columnBindings;
   protected boolean hasExecuted = false;
 
   // Traversal ////////////////////////////////
 
+  @Override
   public void doRows(Parse rows) {
     bind(rows.parts);
     super.doRows(rows.more);
   }
 
+  @Override
   public void doRow(Parse row) {
     hasExecuted = false;
     try {
@@ -32,6 +34,7 @@ public class ColumnFixture extends Fixture {
     }
   }
 
+  @Override
   public void doCell(Parse cell, int column) {
     try {
       columnBindings[column].doCell(this, cell);

--- a/src/fit/FileRunner.java
+++ b/src/fit/FileRunner.java
@@ -21,11 +21,11 @@ public class FileRunner {
   public Fixture fixture = new Fixture();
   public PrintWriter output;
 
-  public static void main(String argv[]) {
+  public static void main(String[] argv) {
     new FileRunner().run(argv);
   }
 
-  public void run(String argv[]) {
+  public void run(String[] argv) {
     args(argv);
     process();
     exit();
@@ -61,7 +61,7 @@ public class FileRunner {
   }
 
   protected String read(File input) throws IOException {
-    char chars[] = new char[(int) (input.length())];
+    char[] chars = new char[(int) (input.length())];
     FileReader in = new FileReader(input);
     in.read(chars);
     in.close();

--- a/src/fit/FitServer.java
+++ b/src/fit/FitServer.java
@@ -36,14 +36,14 @@ public class FitServer {
   public FitServer() {
   }
 
-  public static void main(String argv[]) throws Exception {
+  public static void main(String[] argv) throws Exception {
     FitServer fitServer = new FitServer();
     fitServer.run(argv);
     if (!fitServer.noExit)
       System.exit(fitServer.exitCode());
   }
 
-  public void run(String argv[]) throws Exception {
+  public void run(String[] argv) throws Exception {
     args(argv);
     File sentinelFile = null;
     if (sentinel) {

--- a/src/fit/Parse.java
+++ b/src/fit/Parse.java
@@ -31,17 +31,17 @@ public class Parse {
     this.more = more;
   }
 
-  public static final String tags[] = {"table", "tr", "td"};
+  public static final String[] tags = {"table", "tr", "td"};
 
   public Parse(String text) throws FitParseException {
     this(text, tags, 0, 0);
   }
 
-  public Parse(String text, String tags[]) throws FitParseException {
+  public Parse(String text, String[] tags) throws FitParseException {
     this(text, tags, 0, 0);
   }
 
-  public Parse(String text, String tags[], int level, int offset) throws FitParseException {
+  public Parse(String text, String[] tags, int level, int offset) throws FitParseException {
     String lc = text.toLowerCase();
     int startTag = lc.indexOf("<" + tags[level]);
     int endTag = lc.indexOf(">", startTag) + 1;
@@ -142,24 +142,6 @@ public class Parse {
     }
     return s;
   }
-
-//	public static String unescape(String s)
-//	{
-//		int i = -1, j;
-//		while((i = s.indexOf('&', i + 1)) >= 0)
-//		{
-//			if((j = s.indexOf(';', i + 1)) > 0)
-//			{
-//				String from = s.substring(i + 1, j).toLowerCase();
-//				String to = null;
-//				if((to = replacement(from)) != null)
-//				{
-//					s = s.substring(0, i) + to + s.substring(j + 1);
-//				}
-//			}
-//		}
-//		return s;
-//	}
 
   public static String unescape(String s) {
     StringBuilder sb = new StringBuilder(s);

--- a/src/fit/RowFixture.java
+++ b/src/fit/RowFixture.java
@@ -7,6 +7,7 @@
 package fit;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -17,10 +18,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 abstract public class RowFixture extends ColumnFixture {
 
-  public Object results[];
+  public Object[] results;
   public List<Object> missing = new LinkedList<Object>();
   public List<Object> surplus = new LinkedList<Object>();
 
+  @Override
   public void doRows(Parse rows) {
     try {
       bind(rows.parts);
@@ -49,8 +51,7 @@ abstract public class RowFixture extends ColumnFixture {
       Map<Object, Object> eMap = eSort(expected, col);
       Map<Object, Object> cMap = cSort(computed, col);
       Set<Object> keys = union(eMap.keySet(), cMap.keySet());
-      for (Iterator<Object> i = keys.iterator(); i.hasNext();) {
-        Object key = i.next();
+      for (Object key : keys) {
         List<?> eList = (List<?>) eMap.get(key);
         List<?> cList = (List<?>) cMap.get(key);
         if (eList == null) {
@@ -77,17 +78,15 @@ abstract public class RowFixture extends ColumnFixture {
 
   protected List<Object> list(Object[] rows) {
     List<Object> result = new LinkedList<Object>();
-    for (int i = 0; i < rows.length; i++) {
-      result.add(rows[i]);
-    }
+    Collections.addAll(result, rows);
     return result;
   }
 
   protected Map<Object, Object> eSort(List<?> list, int col) {
     TypeAdapter a = columnBindings[col].adapter;
     Map<Object, Object> result = new ConcurrentHashMap<Object, Object>(list.size());
-    for (Iterator<?> i = list.iterator(); i.hasNext();) {
-      Parse row = (Parse) i.next();
+    for (Object o : list) {
+      Parse row = (Parse) o;
       Parse cell = row.parts.at(col);
       try {
         Object key = a.parse(cell.text());
@@ -106,8 +105,7 @@ abstract public class RowFixture extends ColumnFixture {
   protected Map<Object, Object> cSort(List<?> list, int col) {
     TypeAdapter a = columnBindings[col].adapter;
     Map<Object, Object> result = new ConcurrentHashMap<Object, Object>(list.size());
-    for (Iterator<?> i = list.iterator(); i.hasNext();) {
-      Object row = i.next();
+    for (Object row : list) {
       try {
         a.target = row;
         Object key = a.get();
@@ -185,8 +183,8 @@ abstract public class RowFixture extends ColumnFixture {
   protected Parse buildRows(Object[] rows) {
     Parse root = new Parse(null, null, null, null);
     Parse next = root;
-    for (int i = 0; i < rows.length; i++) {
-      next = next.more = new Parse("tr", null, buildCells(rows[i]), null);
+    for (Object row : rows) {
+      next = next.more = new Parse("tr", null, buildCells(row), null);
     }
     return root.more;
   }
@@ -199,9 +197,9 @@ abstract public class RowFixture extends ColumnFixture {
     }
     Parse root = new Parse(null, null, null, null);
     Parse next = root;
-    for (int i = 0; i < columnBindings.length; i++) {
+    for (Binding columnBinding : columnBindings) {
       next = next.more = new Parse("td", "&nbsp;", null, null);
-      TypeAdapter a = columnBindings[i].adapter;
+      TypeAdapter a = columnBinding.adapter;
       if (a == null) {
         ignore(next);
       } else {

--- a/src/fit/TypeAdapter.java
+++ b/src/fit/TypeAdapter.java
@@ -104,8 +104,7 @@ public class TypeAdapter {
   }
 
   public Object invoke() throws IllegalAccessException, InvocationTargetException {
-    Object params[] =
-      {};
+    Object[] params = {};
     return method.invoke(target, params);
   }
 
@@ -170,36 +169,42 @@ public class TypeAdapter {
   // Subclasses ///////////////////////////////
 
   static class ByteAdapter extends ClassByteAdapter {
+    @Override
     public void set(Object i) throws IllegalAccessException {
       field.setByte(target, ((Byte) i).byteValue());
     }
   }
 
   static class ClassByteAdapter extends TypeAdapter {
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Byte(Byte.parseByte(s));
     }
   }
 
   static class ShortAdapter extends ClassShortAdapter {
+    @Override
     public void set(Object i) throws IllegalAccessException {
       field.setShort(target, ((Short) i).shortValue());
     }
   }
 
   static class ClassShortAdapter extends TypeAdapter {
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Short(Short.parseShort(s));
     }
   }
 
   static class IntAdapter extends ClassIntegerAdapter {
+    @Override
     public void set(Object i) throws IllegalAccessException {
       field.setInt(target, ((Integer) i).intValue());
     }
   }
 
   static class ClassIntegerAdapter extends TypeAdapter {
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Integer(Integer.parseInt(s));
     }
@@ -212,22 +217,26 @@ public class TypeAdapter {
   }
 
   static class ClassLongAdapter extends TypeAdapter {
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Long(Long.parseLong(s));
     }
   }
 
   static class FloatAdapter extends ClassFloatAdapter {
+    @Override
     public void set(Object i) throws IllegalAccessException {
       field.setFloat(target, ((Number) i).floatValue());
     }
 
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Float(Float.parseFloat(s));
     }
   }
 
   static class ClassFloatAdapter extends TypeAdapter {
+    @Override
     public Object parse(String s) {
       return ("null".equals(s)) ? null : new Float(Float.parseFloat(s));
     }

--- a/src/fit/WikiRunner.java
+++ b/src/fit/WikiRunner.java
@@ -9,13 +9,14 @@ package fit;
 
 public class WikiRunner extends FileRunner {
 
-  public static void main(String argv[]) {
+  public static void main(String[] argv) {
     new WikiRunner().run(argv);
   }
 
+  @Override
   public void process() {
+    String[] tags = {"wiki", "table", "tr", "td"};
     try {
-      String tags[] = {"wiki", "table", "tr", "td"};
       tables = new Parse(input, tags);    // look for wiki tag enclosing tables
       fixture.doTables(tables.parts);     // only do tables within that tag
     } catch (Exception e) {

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -172,7 +172,7 @@ public class PageDriver {
     if (textPosition == -1)
       return -1;
     String priorToContent = content.substring(0, textPosition);
-    String lines[] = priorToContent.split("\n");
+    String[] lines = priorToContent.split("\n");
     return lines.length;
   }
 
@@ -204,7 +204,7 @@ public class PageDriver {
                     new HasAttributePrefixFilter("id", parentIdPrefix))
     );
 
-    NodeFilter predicates[] = {
+    NodeFilter[] predicates = {
             new TagNameFilter(childTag),
             new HasAttributeFilter("class", tagClass)
     };

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -35,7 +35,6 @@ public class PageDriver {
   private PageCreator creator = new PageCreator();
   private ResponseRequester requester = new ResponseRequester();
   private ResponseExaminer examiner = new ResponseExaminer();
-  private Map<String, String> hash;
 
   public void createPageWithContent(String pageName, String content) throws Exception {
     creator.pageName = pageName;

--- a/src/fitnesse/fixtures/PagesRunInSuite.java
+++ b/src/fitnesse/fixtures/PagesRunInSuite.java
@@ -25,7 +25,7 @@ public class PagesRunInSuite {
     if (content.contains("Testing was interrupted and results are incomplete.")) {
       throw new Exception("Test result page says: Testing was interrupted and results are incomplete.");
     }
-    String testSystems[] = content.split("slim:");
+    String[] testSystems = content.split("slim:");
     for (String testSystem : testSystems) {
       addPagesForThisTestSystem(testPages, testSystem);
     }
@@ -34,7 +34,7 @@ public class PagesRunInSuite {
 
   private void addPagesForThisTestSystem(List<String> testPages, String testSystem) {
     if (testSystem.startsWith(testSystemID)) {
-      String pageString[] = testSystem.split("test_name\">");
+      String[] pageString = testSystem.split("test_name\">");
       addPages(testPages, pageString);
     }
   }
@@ -51,9 +51,9 @@ public class PagesRunInSuite {
 
   private List<Object> buildQueryResponse(List<String> testPages) {
     List<Object> rows = new ArrayList<Object>();
-    for (int i = 0; i < testPages.size(); i++) {
+    for (String testPage : testPages) {
       List<Object> columns = new ArrayList<Object>();
-      List<String> pageNameCell = Arrays.asList("page name", testPages.get(i));
+      List<String> pageNameCell = Arrays.asList("page name", testPage);
       columns.add(pageNameCell);
       rows.add(columns);
     }

--- a/src/fitnesse/fixtures/PrimeFactorsFixture.java
+++ b/src/fitnesse/fixtures/PrimeFactorsFixture.java
@@ -3,6 +3,7 @@
 package fitnesse.fixtures;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 import fit.RowFixture;
 
@@ -17,7 +18,7 @@ public class PrimeFactorsFixture extends RowFixture {
 
   public Object[] query() {
     int n = Integer.parseInt(args[0]);
-    ArrayList<Factor> factors = new ArrayList<Factor>();
+    Collection<Factor> factors = new ArrayList<Factor>();
     for (int f = 2; n > 1; f++)
       for (; n % f == 0; n /= f)
         factors.add(new Factor(f));

--- a/src/fitnesse/fixtures/SplitFixture.java
+++ b/src/fitnesse/fixtures/SplitFixture.java
@@ -15,7 +15,7 @@ public class SplitFixture {
     List<Object> table = new ArrayList<Object>();
     for (String lineContent : lines) {
       List<Object> line = new ArrayList<Object>();
-      String words[] = lineContent.split(",");
+      String[] words = lineContent.split(",");
       for (int i = 0; i < words.length; i++) {
         String word = words[i];
         line.add(Arrays.asList(Integer.toString(i+1), word));

--- a/src/fitnesse/reporting/history/PageHistory.java
+++ b/src/fitnesse/reporting/history/PageHistory.java
@@ -16,8 +16,8 @@ public class PageHistory extends PageHistoryReader{
   private int maxAssertions = 0;
   private BarGraph barGraph;
   private String fullPageName;
-  private final HashMap<Date, TestResultRecord> testResultMap = new HashMap<Date, TestResultRecord>();
-  private HashMap<Date, File> pageFiles = new HashMap<Date,File>();
+  private final Map<Date, TestResultRecord> testResultMap = new HashMap<Date, TestResultRecord>();
+  private Map<Date, File> pageFiles = new HashMap<Date,File>();
 
   public PageHistory(File pageDirectory) {
     fullPageName = pageDirectory.getName();

--- a/src/fitnesse/reporting/history/PageHistoryReader.java
+++ b/src/fitnesse/reporting/history/PageHistoryReader.java
@@ -42,7 +42,7 @@ public class PageHistoryReader {
   }
   
   private TestResultRecord buildTestResultRecord(File file) throws ParseException {
-    String parts[] = file.getName().split("_|\\.");
+    String[] parts = file.getName().split("_|\\.");
     Date date = dateFormat.parse(parts[0]);
     TestResultRecord testResultRecord = new TestResultRecord(
       file,

--- a/src/fitnesse/slim/MethodExecutor.java
+++ b/src/fitnesse/slim/MethodExecutor.java
@@ -14,7 +14,7 @@ public abstract class MethodExecutor {
   public abstract MethodExecutionResult execute(String instanceName, String methodName, Object[] args) throws Throwable;
 
   protected Method findMatchingMethod(String methodName, Class<?> k, int nArgs) {
-    Method methods[] = k.getMethods();
+    Method[] methods = k.getMethods();
 
     for (Method method : methods) {
       boolean hasMatchingName = method.getName().equals(methodName);
@@ -27,13 +27,13 @@ public abstract class MethodExecutor {
   }
 
   protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {
-    Object convertedArgs[] = convertArgs(method, args);
+    Object[] convertedArgs = convertArgs(method, args);
     Object retval = callMethod(instance, method, convertedArgs);
     Class<?> retType = method.getReturnType();
     return new MethodExecutionResult(retval, retType);
   }
 
-  protected Object[] convertArgs(Method method, Object args[]) {
+  protected Object[] convertArgs(Method method, Object[] args) {
     Type[] argumentParameterTypes = method.getGenericParameterTypes();
     return ConverterSupport.convertArgs(args, argumentParameterTypes);
   }

--- a/src/fitnesse/slim/VariableStore.java
+++ b/src/fitnesse/slim/VariableStore.java
@@ -33,7 +33,7 @@ public class VariableStore {
   }
 
   public Object[] replaceSymbols(Object[] args) {
-    Object result[] = new Object[args.length];
+    Object[] result = new Object[args.length];
     for (int i = 0; i < args.length; i++)
       result[i] = replaceSymbol(args[i]);
 

--- a/src/fitnesse/slim/converters/MapEditor.java
+++ b/src/fitnesse/slim/converters/MapEditor.java
@@ -56,7 +56,7 @@ public class MapEditor extends PropertyEditorSupport {
   }
 
   public Object fromString(String possibleTable) {
-    HashMap<String, String> map = new HashMap<String, String>();
+    Map<String, String> map = new HashMap<String, String>();
     if (tableIsValid(possibleTable))
       extractRowsIntoMap(map, tables);
 
@@ -82,23 +82,23 @@ public class MapEditor extends PropertyEditorSupport {
     return nodes != null;
   }
 
-  private void extractRowsIntoMap(HashMap<String, String> map, NodeList tables) {
+  private void extractRowsIntoMap(Map<String, String> map, NodeList tables) {
     extractRows(map, getRows(tables));
   }
 
-  private void extractRows(HashMap<String, String> map, NodeList rows) {
+  private void extractRows(Map<String, String> map, NodeList rows) {
     for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
       extractRow(map, rows, rowIndex);
     }
   }
 
-  private void extractRow(HashMap<String, String> map, NodeList rows, int rowIndex) {
+  private void extractRow(Map<String, String> map, NodeList rows, int rowIndex) {
     Node row = rows.elementAt(rowIndex);
     if (row != null)
       extractColumns(map, row);
   }
 
-  private void extractColumns(HashMap<String, String> map, Node row) {
+  private void extractColumns(Map<String, String> map, Node row) {
     TagNameFilter tdFilter = new TagNameFilter("td");
     if (row.getChildren() != null) {
       NodeList cols = row.getChildren().extractAllNodesThatMatch(tdFilter);
@@ -107,7 +107,7 @@ public class MapEditor extends PropertyEditorSupport {
     }
   }
 
-  private void addColsToMap(HashMap<String, String> map, NodeList cols) {
+  private void addColsToMap(Map<String, String> map, NodeList cols) {
     String key = getText(cols.elementAt(0));
     String value = getText(cols.elementAt(1));
     map.put(key, value);

--- a/src/fitnesse/slim/protocol/SlimDeserializer.java
+++ b/src/fitnesse/slim/protocol/SlimDeserializer.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 
 public class SlimDeserializer {
-  private ArrayList<Object> result;
+  private List<Object> result;
 
   public static List<Object> deserialize(String serialized) {
     return new SlimDeserializer(serialized).deserialize();

--- a/src/fitnesse/slim/test/Bowling.java
+++ b/src/fitnesse/slim/test/Bowling.java
@@ -73,7 +73,7 @@ public class Bowling {
   }
 
   private class Game {
-    int rolls[] = new int[21];
+    int[] rolls = new int[21];
     int currentRoll = 0;
 
     public void roll(int pins) {

--- a/src/fitnesse/slim/test/ZorkEditor.java
+++ b/src/fitnesse/slim/test/ZorkEditor.java
@@ -5,7 +5,7 @@ import java.beans.PropertyEditorSupport;
 public class ZorkEditor extends PropertyEditorSupport {
   @Override
   public void setAsText(String text) throws IllegalArgumentException {
-    String tokens[] = text.split("_");
+    String[] tokens = text.split("_");
     setValue(new Zork(Integer.parseInt(tokens[1])));
   }
 

--- a/src/fitnesse/testrunner/MultipleTestsRunner.java
+++ b/src/fitnesse/testrunner/MultipleTestsRunner.java
@@ -122,7 +122,7 @@ public class MultipleTestsRunner implements Stoppable {
       @Override
       public ClassPath getClassPath() {
         if (classPath == null) {
-          ArrayList<ClassPath> paths = new ArrayList<ClassPath>();
+          List<ClassPath> paths = new ArrayList<ClassPath>();
           for (TestPage testPage: testPages) {
             paths.add(testPage.getClassPath());
           }

--- a/src/fitnesse/testrunner/SuiteFilter.java
+++ b/src/fitnesse/testrunner/SuiteFilter.java
@@ -24,6 +24,7 @@ public class SuiteFilter {
   final private String startWithTest;
   
   public static final SuiteFilter NO_MATCHING = new SuiteFilter(null, null, null, null) {
+    @Override
     public boolean isMatchingTest(WikiPage testPage) {
       return false;
     }
@@ -148,7 +149,7 @@ public class SuiteFilter {
     }
 
     private boolean testTagsMatchQueryTags(String testTagString) {
-      String testTags[] = testTagString.trim().split(LIST_SEPARATOR);
+      String[] testTags = testTagString.trim().split(LIST_SEPARATOR);
       if(andStrategy){
         return checkIfAllQueryTagsExist(testTags);
       } else {

--- a/src/fitnesse/testsystems/fit/FitTestSystem.java
+++ b/src/fitnesse/testsystems/fit/FitTestSystem.java
@@ -3,6 +3,7 @@
 package fitnesse.testsystems.fit;
 
 import java.io.IOException;
+import java.util.Deque;
 import java.util.LinkedList;
 
 import fitnesse.testsystems.CompositeTestSystemListener;
@@ -17,7 +18,7 @@ public class FitTestSystem implements TestSystem, FitClientListener {
   private final CompositeTestSystemListener testSystemListener;
   private final String testSystemName;
   private final CommandRunningFitClient client;
-  private LinkedList<TestPage> processingQueue = new LinkedList<TestPage>();
+  private Deque<TestPage> processingQueue = new LinkedList<TestPage>();
   private TestPage currentTestPage;
 
   public FitTestSystem(String testSystemName, CommandRunningFitClient fitClient) {

--- a/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
+++ b/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
@@ -74,7 +74,7 @@ public class SlimExceptionResult implements ExceptionResult {
   }
 
   private String translateExceptionMessage(String exceptionMessage) {
-    String tokens[] = exceptionMessage.split(" ");
+    String[] tokens = exceptionMessage.split(" ");
     if (tokens[0].equals(COULD_NOT_INVOKE_CONSTRUCTOR))
       return "Could not invoke constructor for " + tokens[1];
     else if (tokens[0].equals(NO_METHOD_IN_CLASS))

--- a/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
@@ -35,7 +35,7 @@ public class SlimTableFactory {
     addTableType("library", LibraryTable.class);
   }
 
-  protected SlimTableFactory(HashMap<String, Class<? extends SlimTable>> tableTypes, HashMap<String, String> tableTypeArrays) {
+  protected SlimTableFactory(Map<String, Class<? extends SlimTable>> tableTypes, Map<String, String> tableTypeArrays) {
     this.tableTypes = tableTypes;
     this.tableTypeArrays = tableTypeArrays;
   }

--- a/src/fitnesse/updates/UpdateFileList.java
+++ b/src/fitnesse/updates/UpdateFileList.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 public class UpdateFileList {
@@ -14,7 +15,7 @@ public class UpdateFileList {
   private List<String> mainDirectories;
   private String updateListContent;
   private String updateDoNotCopyOverContent;
-  private HashSet<String> doNotReplaceFiles = new HashSet<String>();
+  private Set<String> doNotReplaceFiles = new HashSet<String>();
   private String baseDirectory = "";
   private String outputDirectory = "";
   static UpdateFileList testUpdater = null;

--- a/src/fitnesse/updates/UpdaterImplementation.java
+++ b/src/fitnesse/updates/UpdaterImplementation.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 public class UpdaterImplementation extends UpdaterBase {
 
-  private ArrayList<String> updateDoNotCopyOver = new ArrayList<String>();
-  private ArrayList<String> updateList = new ArrayList<String>();
+  private List<String> updateDoNotCopyOver = new ArrayList<String>();
+  private List<String> updateList = new ArrayList<String>();
   private String fitNesseVersion;
 
   public UpdaterImplementation(FitNesseContext context) throws IOException {
@@ -73,7 +73,7 @@ public class UpdaterImplementation extends UpdaterBase {
     update.doUpdate();
   }
 
-  public void tryToParseTheFileIntoTheList(File updateFileList, ArrayList<String> list) {
+  public void tryToParseTheFileIntoTheList(File updateFileList, List<String> list) {
     if (!updateFileList.exists())
       throw new RuntimeException("Could Not Find UpdateList");
 
@@ -85,7 +85,7 @@ public class UpdaterImplementation extends UpdaterBase {
 
   }
 
-  private void parseTheFileContentToAList(File updateFileList, ArrayList<String> list) throws IOException {
+  private void parseTheFileContentToAList(File updateFileList, List<String> list) throws IOException {
     String content = FileUtil.getFileContent(updateFileList);
     String[] filePaths = content.split("\n");
     for (String path : filePaths)
@@ -93,6 +93,7 @@ public class UpdaterImplementation extends UpdaterBase {
 
   }
 
+  @Override
   public boolean update() throws IOException {
     if (shouldUpdate()) {
       LOG.info("Unpacking new version of FitNesse resources. Please be patient...");

--- a/src/fitnesse/wiki/WikiPagePath.java
+++ b/src/fitnesse/wiki/WikiPagePath.java
@@ -8,6 +8,7 @@ import static fitnesse.wiki.WikiPagePath.Mode.RELATIVE;
 import static fitnesse.wiki.WikiPagePath.Mode.SUB_PAGE;
 
 import java.io.Serializable;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,8 +29,9 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
   }
 
   public WikiPagePath(String[] names) {
-    for (int i = 0; i < names.length; i++)
-      addNameToEnd(names[i]);
+    for (String name : names) {
+      addNameToEnd(name);
+    }
   }
 
   public WikiPagePath copy() {
@@ -57,7 +59,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
   }
 
   public String getFirst() {
-    return isEmpty() ? null : (String) names.get(0);
+    return isEmpty() ? null : names.get(0);
   }
 
   public WikiPagePath addNameToEnd(String name) {
@@ -87,6 +89,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
     return names;
   }
 
+  @Override
   public String toString() {
     String prefix = "";
     if (mode == ABSOLUTE)
@@ -118,6 +121,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
     mode = ABSOLUTE;
   }
 
+  @Override
   public int hashCode() {
     return StringUtils.join(names, "").hashCode();
   }
@@ -131,6 +135,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
       return this;
   }
 
+  @Override
   public int compareTo(Object o) {
     if (o instanceof WikiPagePath) {
       WikiPagePath p = (WikiPagePath) o;
@@ -141,6 +146,7 @@ public class WikiPagePath implements Comparable<Object>, Serializable {
     return 1; // we are greater because we are the right type.
   }
 
+  @Override
   public boolean equals(Object o) {
     if (o instanceof WikiPagePath) {
       WikiPagePath that = (WikiPagePath) o;

--- a/src/fitnesse/wiki/WikiPageUtil.java
+++ b/src/fitnesse/wiki/WikiPageUtil.java
@@ -90,7 +90,7 @@ public class WikiPageUtil {
 
   public static List<String> getXrefPages(WikiPage page) {
     if (page instanceof WikitextPage) {
-      final ArrayList<String> xrefPages = new ArrayList<String>();
+      final List<String> xrefPages = new ArrayList<String>();
       ((WikitextPage) page).getSyntaxTree().walkPreOrder(new SymbolTreeWalker() {
         @Override
         public boolean visit(Symbol node) {

--- a/src/fitnesse/wiki/fs/MemoryFileSystem.java
+++ b/src/fitnesse/wiki/fs/MemoryFileSystem.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -53,7 +54,7 @@ public class MemoryFileSystem implements FileSystem {
     @Override
     public String[] list(File file) {
         String path = file.getPath();
-        ArrayList<String> result = new ArrayList<String>();
+        Collection<String> result = new ArrayList<String>();
         for (String filePath: files.keySet()) {
             if (!filePath.startsWith(path)) continue;
             if (filePath.equals(path)) continue;

--- a/src/fitnesse/wiki/fs/MemoryVersionsController.java
+++ b/src/fitnesse/wiki/fs/MemoryVersionsController.java
@@ -11,10 +11,6 @@ import java.util.TreeMap;
 
 import fitnesse.wiki.NoSuchVersionException;
 import fitnesse.wiki.VersionInfo;
-import fitnesse.wiki.fs.FileSystem;
-import fitnesse.wiki.fs.FileVersion;
-import fitnesse.wiki.fs.SimpleFileVersionsController;
-import fitnesse.wiki.fs.VersionsController;
 
 public class MemoryVersionsController implements VersionsController {
 
@@ -89,7 +85,7 @@ public class MemoryVersionsController implements VersionsController {
     }
 
     public Collection<VersionInfo> history() {
-      LinkedList<VersionInfo> set = new LinkedList<VersionInfo>();
+      Collection<VersionInfo> set = new LinkedList<VersionInfo>();
       for (Map.Entry<String, FileVersion[]> entry : versions.entrySet()) {
         set.add(makeVersionInfo(entry.getValue()[0], entry.getKey()));
       }

--- a/src/fitnesse/wikitext/parser/SymbolProvider.java
+++ b/src/fitnesse/wikitext/parser/SymbolProvider.java
@@ -50,10 +50,10 @@ public class SymbolProvider {
     static final SymbolProvider preformatProvider = new SymbolProvider(
           new SymbolType[] {SymbolType.ClosePreformat, SymbolType.CloseBrace, SymbolType.CloseLiteral, Literal.symbolType, Variable.symbolType});
 
-  private static final char defaultMatch = '\0';
+    private static final char defaultMatch = '\0';
 
-  private HashMap<Character, ArrayList<Matchable>> currentDispatch;
-    private ArrayList<SymbolType> symbolTypes;
+    private Map<Character, ArrayList<Matchable>> currentDispatch;
+    private Collection<SymbolType> symbolTypes;
     private SymbolProvider parent = null;
 
     public SymbolProvider(Iterable<SymbolType> types) {
@@ -93,7 +93,7 @@ public class SymbolProvider {
         return this;
     }
 
-    private ArrayList<Matchable> getMatchTypes(Character match) {
+    private List<Matchable> getMatchTypes(Character match) {
         if (currentDispatch.containsKey(match)) return currentDispatch.get(match);
         return currentDispatch.get(defaultMatch);
     }

--- a/src/fitnesse/wikitext/parser/SymbolType.java
+++ b/src/fitnesse/wikitext/parser/SymbolType.java
@@ -98,7 +98,7 @@ public class SymbolType implements Matchable {
             .wikiMatcher(new Matcher().whitespace());
 
     private String name;
-    private ArrayList<Matcher> wikiMatchers =  new ArrayList<Matcher>(1);
+    private List<Matcher> wikiMatchers =  new ArrayList<Matcher>(1);
     private Rule wikiRule = defaultRule;
     private Translation htmlTranslation = null;
 

--- a/src/fitnesse/wikitext/parser/WikiBuilder.java
+++ b/src/fitnesse/wikitext/parser/WikiBuilder.java
@@ -1,13 +1,14 @@
 package fitnesse.wikitext.parser;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 public class WikiBuilder implements Translation {
     private interface WikiStringBuilder {
         void build(Translator translator, Symbol symbol, StringBuilder wikiString);
     }
 
-    private ArrayList<WikiStringBuilder> builders = new ArrayList<WikiStringBuilder>();
+    private Collection<WikiStringBuilder> builders = new ArrayList<WikiStringBuilder>();
 
     public WikiBuilder content() {
         builders.add(new WikiStringBuilder() {

--- a/src/fitnesse/wikitext/parser/WikiTranslator.java
+++ b/src/fitnesse/wikitext/parser/WikiTranslator.java
@@ -1,9 +1,10 @@
 package fitnesse.wikitext.parser;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class WikiTranslator extends Translator {
-    private static final HashMap<SymbolType, Translation> translations;
+    private static final Map<SymbolType, Translation> translations;
 
     static {
         translations = new HashMap<SymbolType, Translation>();


### PR DESCRIPTION
This mainly focuses on:
A) Array designator should be on the type, not the variable.
B) Prefer interfaces over concrete classes for collections.

Also sprinkled with some Override annotations and various other fixes at the same time.

When it comes to use of interfaces in B, I've fixed most of the instances regarding either internal usage or parameters coming from the outside. I don't see any regression potential in the former and for the latter a parameter which accepts HashMaps can be generalized to accept Maps because any HashMap will also be a Map. However, I have not touched return types for public methods. A method returning a LinkedList could potentially return a Collection, but since it is part of the public API I have no control over what people have built around and used the return value for. Changing this could potentially break code on the outside, so I've left them alone for now.

There were also a couple of places which specify a LinkedList as the type and are using methods from both List and Deque, so I wasn't able to reduce the type to a single interface.