### PR TITLE
Allow for test history cleanup after execution

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SetUp/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SetUp/content.txt
@@ -1,4 +1,12 @@
-!include -c <SuiteAcceptanceTests.SetUp
+!|Import|
+|fitnesse.fixtures|
+
+!define TEST_HISTORY_DAYS {15}
+!| SetUp | test.history.days=${TEST_HISTORY_DAYS} |
+
+|Library|
+|page driver|
+|echo fixture|
 
 !|Library|
 |page driver|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SetUp/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SetUp/properties.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
 </properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/ExecutionLogOfSuitePage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/ExecutionLogOfSuitePage/properties.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Test/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/SuiteExecutionCleansUpHistory/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/SuiteExecutionCleansUpHistory/content.txt
@@ -1,0 +1,60 @@
+!***> Add lots of page history
+
+!| page history |
+| name | date | right | wrong | ignores | exceptions |
+| SuiteOne | 1-May-2009 | 20 | 30 | 0 | 0 |
+| SuiteOne | 2-May-2009 | 20 | 0 | 0 | 0 |
+| SuiteOne | 3-May-2009 | 0 | 0 | 1 | 0 |
+| SuiteOne | 4-May-2009 | 0 | 0 | 0 | 1 |
+| SuiteOne | 5-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 6-May-2009 | 0 | 1 | 0 | 1 |
+| SuiteOne | 7-May-2009 | 0 | 0 | 0 | 0 |
+| SuiteOne | 8-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 9-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 10-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 11-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 12-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 13-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 14-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 15-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 16-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 17-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 18-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 19-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 20-May-2009 | 0 | 1 | 0 | 0 |
+| SuiteOne | 21-May-2009 | 0 | 1 | 0 | 0 |
+
+*!
+!***< hidding defines
+
+!define PASSING_TEST {!|script|fitnesse.slim.test.EchoScript|
+| check | echo | 7 | 7 |
+
+}
+
+!define SUITE_ONE {${SUT_PATH}
+!define TEST_SYSTEM (slim)
+}
+
+*!
+After a test run, the test history is cleaned up. In order to do so, the property ''test.history.days'' has been set to ${TEST_HISTORY_DAYS} days.
+
+Precondition:
+
+!| script |
+| assume time is | 5/22/2009 01:00:00 |
+| given page | SuiteOne | with content | ${SUITE_ONE} |
+| with subpage | TestOne | with content | ${PASSING_TEST} |
+| get history for page | SuiteOne |
+| the number of page histories should be | 21 |
+
+Action:
+
+!| script |
+| run suite | SuiteOne |
+
+Result:
+
+!| script |
+| get history for page | SuiteOne |
+| the number of page histories should be | ${TEST_HISTORY_DAYS} |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/SuiteExecutionCleansUpHistory/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/SuiteExecutionCleansUpHistory/properties.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Properties/>
+<Refactor/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/content.txt
@@ -1,0 +1,1 @@
+!contents -g

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecution/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Suite/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteTopLevelTestHistory/TopLevelHistoryShouldHaveTitle/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteTopLevelTestHistory/TopLevelHistoryShouldHaveTitle/content.txt
@@ -1,13 +1,7 @@
-!|page history|
-|name|date|right|wrong|ignores|exceptions|
-|SuitePage.TestPage|5-May-2009|20|30|0|0|
+!| page history |
+| name | date | right | wrong | ignores | exceptions |
+| SuitePage.TestPage | 5-May-2009 | 20 | 30 | 0 | 0 |
 
-!|script|
-|get top level history|
-|the page title should be|Test History|
-
-
-
-
-
-
+!| script |
+| get top level history |
+| the page title should be | Test history |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteTopLevelTestHistory/TopLevelHistoryShouldHaveTitle/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteTopLevelTestHistory/TopLevelHistoryShouldHaveTitle/properties.xml
@@ -1,14 +1,12 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit/>
-	<Files/>
-	<Help/>
-	<Properties/>
-	<RecentChanges/>
-	<Refactor/>
-	<Search/>
-	<Suites/>
-	<Test/>
-	<Versions/>
-	<WhereUsed/>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
 </properties>

--- a/plugins.properties
+++ b/plugins.properties
@@ -59,3 +59,6 @@ RecentChanges=fitnesse.wiki.fs.GitFileVersionsController
 # Match test output in ways not foreseen.
 #CustomComparators=
 
+##
+# Number of days to keep history
+test.history.days=1

--- a/src/fitnesse/fixtures/ClockFixture.java
+++ b/src/fitnesse/fixtures/ClockFixture.java
@@ -2,12 +2,17 @@ package fitnesse.fixtures;
 
 import java.text.ParseException;
 
+import fitnesse.util.Clock;
 import fitnesse.util.DateAlteringClock;
 import fitnesse.util.DateTimeUtil;
 
 public class ClockFixture {
   public void freezeClockAt(String dateTime) throws ParseException {
+    System.out.println("Freezing time at " + dateTime);
     new DateAlteringClock(DateTimeUtil.getDateFromString(dateTime)).freeze();
   }
-  
+
+  public String simulationDate() {
+    return DateTimeUtil.formatDate(Clock.currentDate());
+  }
 }

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -6,7 +6,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 
-import fitnesse.responders.run.SuiteResponder;
 import org.htmlparser.Node;
 import org.htmlparser.NodeFilter;
 import org.htmlparser.Parser;
@@ -193,7 +192,7 @@ public class PageDriver {
   }
 
   public String pageHistoryDateSignatureOf(Date date) {
-    SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+    SimpleDateFormat dateFormat = new SimpleDateFormat(fitnesse.reporting.history.PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
     return dateFormat.format(date);
   }
 

--- a/src/fitnesse/fixtures/PageHistory.java
+++ b/src/fitnesse/fixtures/PageHistory.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import fitnesse.responders.run.SuiteResponder;
-
 public class PageHistory {
   private String name;
   private Date date;
@@ -16,7 +14,7 @@ public class PageHistory {
   private int wrong;
   private int ignores;
   private int exceptions;
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(fitnesse.reporting.history.PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
 
   public void setName(String name) {
     this.name = name;

--- a/src/fitnesse/reporting/history/HistoryPurger.java
+++ b/src/fitnesse/reporting/history/HistoryPurger.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import fitnesse.responders.run.SuiteResponder;
 import fitnesse.util.Clock;
 import util.FileUtil;
 
@@ -71,7 +70,7 @@ public class HistoryPurger {
   }
 
   private Date tryExtractDateFromTestHistoryName(String testHistoryName) throws ParseException {
-    SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+    SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
     String dateString = testHistoryName.split("_")[0];
     return dateFormat.parse(dateString);
   }

--- a/src/fitnesse/reporting/history/HistoryPurger.java
+++ b/src/fitnesse/reporting/history/HistoryPurger.java
@@ -1,0 +1,78 @@
+package fitnesse.reporting.history;
+
+import java.io.File;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import fitnesse.responders.run.SuiteResponder;
+import fitnesse.util.Clock;
+import util.FileUtil;
+
+import static java.lang.String.format;
+
+public class HistoryPurger {
+  private static final Logger LOG = Logger.getLogger(HistoryPurger.class.getName());
+
+  private final File resultsDirectory;
+
+  public HistoryPurger(File resultsDirectory) {
+    this.resultsDirectory = resultsDirectory;
+  }
+
+  public void deleteTestHistoryOlderThanDays(int days) {
+    Date expirationDate = getDateDaysAgo(days);
+    File[] files = FileUtil.getDirectoryListing(resultsDirectory);
+    deleteExpiredFiles(files, expirationDate);
+  }
+
+  private void deleteExpiredFiles(File[] files, Date expirationDate) {
+    for (File file : files)
+      deleteIfExpired(file, expirationDate);
+  }
+
+  public Date getDateDaysAgo(int days) {
+    long now = Clock.currentTimeInMillis();
+    long millisecondsPerDay = 1000L * 60L * 60L * 24L;
+    Date daysEarlier = new Date(now - (millisecondsPerDay * days));
+    return daysEarlier;
+  }
+
+  private void deleteIfExpired(File file, Date expirationDate) {
+    if (file.isDirectory()) {
+      deleteDirectoryIfExpired(file, expirationDate);
+    } else
+      deleteFileIfExpired(file, expirationDate);
+  }
+
+  private void deleteDirectoryIfExpired(File file, Date expirationDate) {
+    File[] files = FileUtil.getDirectoryListing(file);
+    deleteExpiredFiles(files, expirationDate);
+    if (file.list().length == 0)
+      FileUtil.deleteFileSystemDirectory(file);
+  }
+
+  private void deleteFileIfExpired(File file, Date purgeOlder) {
+    String name = file.getName();
+    Date date = getDateFromPageHistoryFileName(name);
+    if (date.getTime() < purgeOlder.getTime())
+      FileUtil.deleteFile(file);
+  }
+
+  private Date getDateFromPageHistoryFileName(String name) {
+    try {
+      return tryExtractDateFromTestHistoryName(name);
+    } catch (ParseException e) {
+      LOG.log(Level.SEVERE, format("Can not determine date from test history file %s", name));
+      return new Date();
+    }
+  }
+
+  private Date tryExtractDateFromTestHistoryName(String testHistoryName) throws ParseException {
+    SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+    String dateString = testHistoryName.split("_")[0];
+    return dateFormat.parse(dateString);
+  }
+}

--- a/src/fitnesse/reporting/history/PageHistory.java
+++ b/src/fitnesse/reporting/history/PageHistory.java
@@ -5,10 +5,11 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import fitnesse.responders.run.SuiteResponder;
 import fitnesse.testsystems.ExecutionResult;
 
 public class PageHistory extends PageHistoryReader{
+  public static final String TEST_RESULT_FILE_DATE_PATTERN = "yyyyMMddHHmmss";
+
   private int failures = 0;
   private int passes = 0;
   private Date minDate = null;
@@ -177,7 +178,7 @@ public class PageHistory extends PageHistoryReader{
     private ExecutionResult result;
 
     public PassFailReport(Date date, ExecutionResult result) {
-      SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+      SimpleDateFormat dateFormat = new SimpleDateFormat(TEST_RESULT_FILE_DATE_PATTERN);
       this.date = dateFormat.format(date);
       this.result = result;
     }

--- a/src/fitnesse/reporting/history/PageHistoryReader.java
+++ b/src/fitnesse/reporting/history/PageHistoryReader.java
@@ -5,13 +5,11 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import fitnesse.responders.run.SuiteResponder;
-
 import util.FileUtil;
 
 public class PageHistoryReader {
 
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
   public static final String TEST_FILE_FORMAT = "\\A\\d{14}_\\d+_\\d+_\\d+_\\d+(.xml)*\\Z";
   
   void readHistoryFromPageDirectory(File pageDirectory) throws ParseException {

--- a/src/fitnesse/reporting/history/SuiteExecutionReport.java
+++ b/src/fitnesse/reporting/history/SuiteExecutionReport.java
@@ -1,7 +1,6 @@
 package fitnesse.reporting.history;
 
 import fitnesse.FitNesseVersion;
-import fitnesse.responders.run.SuiteResponder;
 import fitnesse.testsystems.TestSummary;
 
 import fitnesse.wiki.PathParser;
@@ -178,7 +177,7 @@ public class SuiteExecutionReport extends ExecutionReport {
     }
 
     public String getResultDate() {
-      SimpleDateFormat pageHistoryFormatter = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+      SimpleDateFormat pageHistoryFormatter = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
       return pageHistoryFormatter.format(new Date(time));
     }
 

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -1,3 +1,4 @@
+<h1>Test history</h1>
 #set($noHistory = true)
 <div>
  <a class="button" href="?responder=overview">View as Overview</a>

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -27,6 +27,7 @@ import fitnesse.reporting.InteractiveFormatter;
 import fitnesse.reporting.PageInProgressFormatter;
 import fitnesse.reporting.SuiteHtmlFormatter;
 import fitnesse.reporting.TestTextFormatter;
+import fitnesse.reporting.history.PageHistory;
 import fitnesse.reporting.history.SuiteHistoryFormatter;
 import fitnesse.reporting.history.SuiteXmlReformatter;
 import fitnesse.reporting.history.TestXmlFormatter;
@@ -57,7 +58,6 @@ import static fitnesse.wiki.WikiImportProperty.isAutoUpdated;
 public class SuiteResponder extends ChunkingResponder implements SecureResponder {
   private final Logger LOG = Logger.getLogger(SuiteResponder.class.getName());
 
-  public static final String TEST_RESULT_FILE_DATE_PATTERN = "yyyyMMddHHmmss";
   private static final String NOT_FILTER_ARG = "excludeSuiteFilter";
   private static final String AND_FILTER_ARG = "runTestsMatchingAllTags";
   private static final String OR_FILTER_ARG_1 = "runTestsMatchingAnyTag";
@@ -405,7 +405,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
   }
 
   public static String makeResultFileName(TestSummary summary, long time) {
-    SimpleDateFormat format = new SimpleDateFormat(TEST_RESULT_FILE_DATE_PATTERN);
+    SimpleDateFormat format = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
     String datePart = format.format(new Date(time));
     return String.format("%s_%d_%d_%d_%d.xml", datePart, summary.getRight(), summary.getWrong(), summary.getIgnores(), summary.getExceptions());
   }

--- a/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
+++ b/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
@@ -8,7 +8,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
-import fitnesse.responders.run.SuiteResponder;
+import fitnesse.reporting.history.PageHistory;
 import org.xml.sax.SAXException;
 
 import fitnesse.FitNesseContext;
@@ -28,7 +28,7 @@ import fitnesse.wiki.WikiPagePath;
 public class HistoryComparerResponder implements Responder {
   public HistoryComparer comparer;
   private SimpleDateFormat dateFormat = new SimpleDateFormat(
-      SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+      PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
   private String firstFileName = "";
   private String secondFileName = "";
   private String firstFilePath;

--- a/src/fitnesse/responders/testHistory/PageHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PageHistoryResponder.java
@@ -9,7 +9,6 @@ import java.util.Date;
 import fitnesse.reporting.history.PageHistory;
 import fitnesse.reporting.history.TestHistory;
 import fitnesse.reporting.history.TestResultRecord;
-import fitnesse.responders.run.SuiteResponder;
 import org.apache.velocity.VelocityContext;
 
 import util.FileUtil;
@@ -36,7 +35,7 @@ import fitnesse.wiki.WikiPagePath;
 
 public class PageHistoryResponder implements SecureResponder {
   private File resultsDirectory;
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
   private SimpleResponse response;
   private PageHistory pageHistory;
   private HtmlPage page;

--- a/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
@@ -48,7 +48,7 @@ public class PurgeHistoryResponder implements SecureResponder {
   }
 
   public void deleteTestHistoryOlderThanDays(int days) {
-    new HistoryPurger(resultsDirectory).deleteTestHistoryOlderThanDays(days);
+    new HistoryPurger(resultsDirectory, days).deleteTestHistoryOlderThanDays();
   }
 
   private Integer getDaysInput(Request request) {

--- a/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
@@ -12,6 +12,7 @@ import fitnesse.authentication.SecureResponder;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
+import fitnesse.reporting.history.HistoryPurger;
 import fitnesse.responders.ErrorResponder;
 import fitnesse.responders.run.SuiteResponder;
 import fitnesse.util.Clock;
@@ -19,8 +20,6 @@ import util.FileUtil;
 
 public class PurgeHistoryResponder implements SecureResponder {
   private File resultsDirectory;
-  private Date todaysDate;
-
 
   public Response makeResponse(FitNesseContext context, Request request) {
     initializeResponder(context);
@@ -35,7 +34,6 @@ public class PurgeHistoryResponder implements SecureResponder {
   private void initializeResponder(FitNesseContext context) {
     if (resultsDirectory == null)
       resultsDirectory = context.getTestHistoryDirectory();
-    todaysDate = Clock.currentDate();
   }
 
   private SimpleResponse makeValidResponse() {
@@ -47,6 +45,10 @@ public class PurgeHistoryResponder implements SecureResponder {
   private void purgeHistory(Request request) {
     int days = getDaysInput(request);
     deleteTestHistoryOlderThanDays(days);
+  }
+
+  public void deleteTestHistoryOlderThanDays(int days) {
+    new HistoryPurger(resultsDirectory).deleteTestHistoryOlderThanDays(days);
   }
 
   private Integer getDaysInput(Request request) {
@@ -75,64 +77,6 @@ public class PurgeHistoryResponder implements SecureResponder {
   public void setResultsDirectory(File directory) {
     resultsDirectory = directory;
   }
-
-  public void setTodaysDate(Date date) {
-    todaysDate = new Date(date.getTime());
-  }
-
-  public void deleteTestHistoryOlderThanDays(int days) {
-    Date expirationDate = getDateDaysAgo(days);
-    File[] files = FileUtil.getDirectoryListing(resultsDirectory);
-    deleteExpiredFiles(files, expirationDate);
-  }
-
-  private void deleteExpiredFiles(File[] files, Date expirationDate) {
-    for (File file : files)
-      deleteIfExpired(file, expirationDate);
-  }
-
-  public Date getDateDaysAgo(int days) {
-    long now = todaysDate.getTime();
-    long millisecondsPerDay = 1000L * 60L * 60L * 24L;
-    Date daysEarlier = new Date(now - (millisecondsPerDay * days));
-    return daysEarlier;
-  }
-
-  private void deleteIfExpired(File file, Date expirationDate) {
-    if (file.isDirectory()) {
-      deleteDirectoryIfExpired(file, expirationDate);
-    } else
-      deleteFileIfExpired(file, expirationDate);
-  }
-
-  private void deleteDirectoryIfExpired(File file, Date expirationDate) {
-    File[] files = FileUtil.getDirectoryListing(file);
-    deleteExpiredFiles(files, expirationDate);
-    if (file.list().length == 0)
-      FileUtil.deleteFileSystemDirectory(file);
-  }
-
-  private void deleteFileIfExpired(File file, Date purgeOlder) {
-    String name = file.getName();
-    Date date = getDateFromPageHistoryFileName(name);
-    if (date.getTime() < purgeOlder.getTime())
-      FileUtil.deleteFile(file);
-  }
-
-  private Date getDateFromPageHistoryFileName(String name) {
-    try {
-      return tryExtractDateFromTestHistoryName(name);
-    } catch (ParseException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private Date tryExtractDateFromTestHistoryName(String testHistoryName) throws ParseException {
-    SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
-    String dateString = testHistoryName.split("_")[0];
-    return dateFormat.parse(dateString);
-  }
-
 
   public SecureOperation getSecureOperation() {
     return new AlwaysSecureOperation();

--- a/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
+++ b/src/fitnesse/responders/testHistory/SuiteOverviewTree.java
@@ -6,8 +6,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import fitnesse.reporting.history.MostRecentPageHistoryReader;
+import fitnesse.reporting.history.PageHistory;
 import fitnesse.reporting.history.TestResultRecord;
-import fitnesse.responders.run.SuiteResponder;
 import fitnesse.wiki.WikiPage;
 import util.GracefulNamer;
 
@@ -85,7 +85,7 @@ public class SuiteOverviewTree {
     
   }
   
-  private SimpleDateFormat dateFormatter = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormatter = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
 
   public class TreeItem
   {

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -3,6 +3,7 @@ package fitnesse.responders.testHistory;
 import java.io.File;
 
 import fitnesse.reporting.history.TestHistory;
+import fitnesse.wiki.PathParser;
 import org.apache.velocity.VelocityContext;
 
 import fitnesse.FitNesseContext;
@@ -37,7 +38,7 @@ public class TestHistoryResponder implements SecureResponder {
   private Response makeTestHistoryResponse(TestHistory testHistory, Request request, String pageName) {
     HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Test History");
-    page.setPageTitle(new PageTitle(makePageTitle(pageName)));
+    page.setPageTitle(new PageTitle(PathParser.parse(pageName)));
     page.setNavTemplate("viewNav");
     page.put("viewLocation", request.getResource());
     page.put("testHistory", testHistory);
@@ -54,12 +55,6 @@ public class TestHistoryResponder implements SecureResponder {
     response.setContentType(Format.XML);
     response.setContent(context.pageFactory.render(velocityContext, "testHistoryXML.vm"));
     return response;
-  }
-  
-  private String makePageTitle(String pageName) {
-    return "".equals(pageName) ?
-      "Test History" :
-      "Test History for " + pageName;
   }
 
   private boolean formatIsXML(Request request) {

--- a/test/fitnesse/reporting/history/HistoryPurgerTest.java
+++ b/test/fitnesse/reporting/history/HistoryPurgerTest.java
@@ -6,7 +6,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import fitnesse.responders.run.SuiteResponder;
 import fitnesse.util.Clock;
 import fitnesse.util.DateAlteringClock;
 import org.junit.After;
@@ -103,7 +102,7 @@ public class HistoryPurgerTest {
   }
 
   private Date makeDate(String dateString) throws ParseException {
-    SimpleDateFormat format = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+    SimpleDateFormat format = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
     Date date = format.parse(dateString);
     return date;
   }

--- a/test/fitnesse/reporting/history/HistoryPurgerTest.java
+++ b/test/fitnesse/reporting/history/HistoryPurgerTest.java
@@ -1,0 +1,111 @@
+package fitnesse.reporting.history;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import fitnesse.responders.run.SuiteResponder;
+import fitnesse.util.Clock;
+import fitnesse.util.DateAlteringClock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.FileUtil;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class HistoryPurgerTest {
+
+
+  private File resultsDirectory;
+  private HistoryPurger historyPurger;
+
+  @Before
+  public void setUp() {
+    resultsDirectory = new File("testHistoryDirectory");
+    removeResultsDirectory();
+    resultsDirectory.mkdir();
+    historyPurger = new HistoryPurger(resultsDirectory);
+  }
+
+  @After
+  public void resetClock() {
+    Clock.restoreDefaultClock();
+  }
+
+  @Test
+  public void shouldBeAbleToSubtractDaysFromDates() throws Exception {
+    Date date = makeDate("20090616171615");
+    new DateAlteringClock(date).freeze();
+    Date resultDate = historyPurger.getDateDaysAgo(10);
+    Date tenDaysEarlier = makeDate("20090606171615");
+    assertEquals(tenDaysEarlier, resultDate);
+  }
+
+  @Test
+  public void shouldBeAbleToDeleteSomeTestHistory() throws Exception {
+    new DateAlteringClock(makeDate("20090616000000")).freeze();
+    File pageDirectory = addPageDirectory("SomePage");
+    addTestResult(pageDirectory, "20090614000000_1_0_0_0");
+    addTestResult(pageDirectory, "20090615000000_1_0_0_0");
+
+    TestHistory history = new TestHistory();
+    history.readHistoryDirectory(resultsDirectory);
+    PageHistory pageHistory = history.getPageHistory("SomePage");
+    assertEquals(2, pageHistory.size());
+    historyPurger.deleteTestHistoryOlderThanDays(1);
+    history.readHistoryDirectory(resultsDirectory);
+    pageHistory = history.getPageHistory("SomePage");
+    assertEquals(1, pageHistory.size());
+    assertNotNull(pageHistory.get(makeDate("20090615000000")));
+    assertNull(pageHistory.get(makeDate("20090614000000")));
+  }
+
+  @Test
+  public void shouldDeletePageHistoryDirectoryIfEmptiedByPurge() throws Exception {
+    new DateAlteringClock(makeDate("20090616000000")).freeze();
+    File pageDirectory = addPageDirectory("SomePage");
+    addTestResult(pageDirectory, "20090614000000_1_0_0_0");
+    historyPurger.deleteTestHistoryOlderThanDays(1);
+    String[] files = resultsDirectory.list();
+    assertEquals(0, files.length);
+  }
+
+  @Test
+  public void fileWithInvalidDateWillNotBeRemoved() throws Exception {
+    new DateAlteringClock(makeDate("20090616000000")).freeze();
+    File pageDirectory = addPageDirectory("SomePage");
+    addTestResult(pageDirectory, "someFile");
+    historyPurger.deleteTestHistoryOlderThanDays(1);
+    String[] files = new File(resultsDirectory, "SomePage").list();
+    assertEquals(1, files.length);
+    assertEquals("someFile.xml", files[0]);
+  }
+
+  private void removeResultsDirectory() {
+    if (resultsDirectory.exists())
+      FileUtil.deleteFileSystemDirectory(resultsDirectory);
+  }
+
+  private File addTestResult(File pageDirectory, String testResultFileName) throws IOException {
+    File testResultFile = new File(pageDirectory, testResultFileName + ".xml");
+    testResultFile.createNewFile();
+    return testResultFile;
+  }
+
+  private File addPageDirectory(String pageName) {
+    File pageDirectory = new File(resultsDirectory, pageName);
+    pageDirectory.mkdir();
+    return pageDirectory;
+  }
+
+  private Date makeDate(String dateString) throws ParseException {
+    SimpleDateFormat format = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+    Date date = format.parse(dateString);
+    return date;
+  }
+
+}

--- a/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
@@ -16,7 +16,6 @@ import java.util.SortedSet;
 
 import fitnesse.reporting.history.PageHistory;
 import fitnesse.reporting.history.TestHistory;
-import fitnesse.responders.run.SuiteResponder;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.junit.After;
@@ -39,7 +38,7 @@ import fitnesse.testutil.FitNesseUtil;
 public class PageHistoryResponderTest {
   private File resultsDirectory;
   private TestHistory history;
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
   private PageHistoryResponder responder;
   private SimpleResponse response;
   private MockRequest request;

--- a/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
@@ -9,6 +9,7 @@ import fitnesse.reporting.history.TestHistory;
 import fitnesse.responders.run.SuiteResponder;
 import fitnesse.testutil.FitNesseUtil;
 
+import fitnesse.util.DateAlteringClock;
 import org.junit.After;
 import static org.junit.Assert.*;
 import org.junit.Before;
@@ -23,7 +24,6 @@ import java.util.Date;
 
 public class PurgeHistoryResponderTest {
   private File resultsDirectory;
-  private TestHistory history;
   private FitNesseContext context;
   private PurgeHistoryResponder responder;
   private MockRequest request;
@@ -34,7 +34,6 @@ public class PurgeHistoryResponderTest {
     resultsDirectory = new File("testHistoryDirectory");
     removeResultsDirectory();
     resultsDirectory.mkdir();
-    history = new TestHistory();
     responder = new PurgeHistoryResponder();
     responder.setResultsDirectory(resultsDirectory);
     context = FitNesseUtil.makeTestContext();
@@ -50,61 +49,6 @@ public class PurgeHistoryResponderTest {
   private void removeResultsDirectory() {
     if (resultsDirectory.exists())
       FileUtil.deleteFileSystemDirectory(resultsDirectory);
-  }
-
-  private File addTestResult(File pageDirectory, String testResultFileName) throws IOException {
-    File testResultFile = new File(pageDirectory, testResultFileName + ".xml");
-    testResultFile.createNewFile();
-    return testResultFile;
-  }
-
-  private File addPageDirectory(String pageName) {
-    File pageDirectory = new File(resultsDirectory, pageName);
-    pageDirectory.mkdir();
-    return pageDirectory;
-  }
-
-  @Test
-  public void shouldBeAbleToSubtractDaysFromDates() throws Exception {
-    Date date = makeDate("20090616171615");
-    responder.setTodaysDate(date);
-    Date resultDate = responder.getDateDaysAgo(10);
-    Date tenDaysEarlier = makeDate("20090606171615");
-    assertEquals(tenDaysEarlier, resultDate);
-  }
-
-  private Date makeDate(String dateString) throws ParseException {
-    SimpleDateFormat format = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
-    Date date = format.parse(dateString);
-    return date;
-  }
-
-  @Test
-  public void shouldBeAbleToDeleteSomeTestHistory() throws Exception {
-    responder.setTodaysDate(makeDate("20090616000000"));
-    File pageDirectory = addPageDirectory("SomePage");
-    addTestResult(pageDirectory, "20090614000000_1_0_0_0");
-    addTestResult(pageDirectory, "20090615000000_1_0_0_0");
-
-    history.readHistoryDirectory(resultsDirectory);
-    PageHistory pageHistory = history.getPageHistory("SomePage");
-    assertEquals(2, pageHistory.size());
-    responder.deleteTestHistoryOlderThanDays(1);
-    history.readHistoryDirectory(resultsDirectory);
-    pageHistory = history.getPageHistory("SomePage");
-    assertEquals(1, pageHistory.size());
-    assertNotNull(pageHistory.get(makeDate("20090615000000")));
-    assertNull(pageHistory.get(makeDate("20090614000000")));
-  }
-
-  @Test
-  public void shouldDeletePageHistoryDirectoryIfEmptiedByPurge() throws Exception {
-    responder.setTodaysDate(makeDate("20090616000000"));
-    File pageDirectory = addPageDirectory("SomePage");
-    addTestResult(pageDirectory, "20090614000000_1_0_0_0");
-    responder.deleteTestHistoryOlderThanDays(1);
-    String[] files = resultsDirectory.list();
-    assertEquals(0, files.length);
   }
 
   @Test

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import fitnesse.reporting.history.PageHistory;
 import fitnesse.reporting.history.TestHistory;
 import fitnesse.reporting.history.TestResultRecord;
-import fitnesse.responders.run.SuiteResponder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +32,7 @@ import util.FileUtil;
 public class TestHistoryResponderTest {
   private File resultsDirectory;
   private TestHistory history;
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(SuiteResponder.TEST_RESULT_FILE_DATE_PATTERN);
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
   private TestHistoryResponder responder;
   private SimpleResponse response;
   private FitNesseContext context;


### PR DESCRIPTION
Changed the SuiteResponder so it can do (optional) cleanup actions on the
suite's test history. This prevents the test history from filling up the file
system. In the configuration file a property `test.history.days` can be added
and assigned a number, the number of days for which to maintain the history.

Is a request parameter is also desired? It might make it easier from CI's to
execute tests and clean up afterwards.

Also the user manual still needs to be updated.