### PR TITLE
Display port of FitNesse-server in test-result-pages

### DIFF
--- a/src/fitnesse/reporting/history/ExecutionReport.java
+++ b/src/fitnesse/reporting/history/ExecutionReport.java
@@ -16,6 +16,7 @@ import fitnesse.util.XmlUtil;
 public abstract class ExecutionReport {
   private String version;
   private String rootPath;
+  private String port;
   private TestSummary finalCounts = new TestSummary(0, 0, 0, 0);
   public Date date;
   private long totalRunTimeInMillis = 0;
@@ -24,9 +25,10 @@ public abstract class ExecutionReport {
     version = new FitNesseVersion().toString();
   }
 
-  public ExecutionReport(FitNesseVersion version, String rootPath) {
+  public ExecutionReport(FitNesseVersion version, String rootPath, String port) {
     this.version = version == null ? "null" : version.toString();
     this.rootPath = rootPath;
+    this.port = port;
   }
 
   public void tallyPageCounts(ExecutionResult result) {
@@ -47,6 +49,8 @@ public abstract class ExecutionReport {
       return false;
     else if (!StringUtils.equals(version, e.version))
       return false;
+    else if (!StringUtils.equals(port, e.port))
+        return false;
     else if (!DateTimeUtil.datesNullOrEqual(date, e.date))
       return false;
     else if(!finalCounts.equals(e.finalCounts))
@@ -69,6 +73,7 @@ public abstract class ExecutionReport {
   }
 
   protected void unpackCommonFields(Element documentElement) {
+    port = XmlUtil.getTextValue(documentElement, "FitNessePort");
     version = XmlUtil.getTextValue(documentElement, "FitNesseVersion");
     rootPath = XmlUtil.getTextValue(documentElement, "rootPath");
     String dateString = XmlUtil.getTextValue(documentElement, "date");
@@ -109,6 +114,10 @@ public abstract class ExecutionReport {
 
   public String getVersion() {
     return version;
+  }
+
+  public String getPort() {
+    return port;
   }
 
   public long getTotalRunTimeInMillis() {

--- a/src/fitnesse/reporting/history/SuiteExecutionReport.java
+++ b/src/fitnesse/reporting/history/SuiteExecutionReport.java
@@ -29,8 +29,8 @@ public class SuiteExecutionReport extends ExecutionReport {
     unpackXml(xmlDocument);
   }
 
-  public SuiteExecutionReport(FitNesseVersion version, String rootPath) {
-    super(version, rootPath);
+  public SuiteExecutionReport(FitNesseVersion version, String rootPath, String port) {
+    super(version, rootPath, port);
   }
 
   @Override

--- a/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
+++ b/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
@@ -35,7 +35,7 @@ public class SuiteHistoryFormatter extends BaseFormatter implements Closeable {
     super(page);
     this.context = context;
     writerFactory = source;
-    suiteExecutionReport = new SuiteExecutionReport(context.version, getPage().getPageCrawler().getFullPath().toString());
+    suiteExecutionReport = new SuiteExecutionReport(context.version, getPage().getPageCrawler().getFullPath().toString(), "" + context.port);
     totalTimeMeasurement = new TimeMeasurement().start();
   }
 

--- a/src/fitnesse/reporting/history/TestExecutionReport.java
+++ b/src/fitnesse/reporting/history/TestExecutionReport.java
@@ -23,8 +23,8 @@ import java.util.List;
 public class TestExecutionReport extends ExecutionReport {
   private List<TestResult> results = new ArrayList<TestResult>();
 
-  public TestExecutionReport(FitNesseVersion version, String rootPath) {
-    super(version, rootPath);
+  public TestExecutionReport(FitNesseVersion version, String rootPath, String port) {
+    super(version, rootPath, port);
   }
 
   public TestExecutionReport(InputStream input) throws IOException, SAXException {

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -41,7 +41,7 @@ public class TestXmlFormatter extends BaseFormatter implements Closeable {
     this.context = context;
     this.writerFactory = writerFactory;
     totalTimeMeasurement = new TimeMeasurement().start();
-    testResponse = new TestExecutionReport(context.version, page.getPageCrawler().getFullPath().toString());
+    testResponse = new TestExecutionReport(context.version, page.getPageCrawler().getFullPath().toString(), "" + context.port);
     resetTimer();
   }
 

--- a/src/fitnesse/resources/templates/suiteExecutionReport.vm
+++ b/src/fitnesse/resources/templates/suiteExecutionReport.vm
@@ -5,6 +5,7 @@
   <tr>
     <td>$suiteExecutionReport.getDate()</td>
     <td class="meta">FitNesse Version: $suiteExecutionReport.Version</td>
+    <td class="meta">FitNesse Port: $suiteExecutionReport.Port</td>
   </tr>
 </table>
 <hr/>

--- a/src/fitnesse/resources/templates/suiteHistoryXML.vm
+++ b/src/fitnesse/resources/templates/suiteHistoryXML.vm
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <suiteResults>
   <FitNesseVersion>$suiteExecutionReport.version</FitNesseVersion>
+  <FitNessePort>$suiteExecutionReport.port</FitNessePort>
   <rootPath>#escape($suiteExecutionReport.rootPath)</rootPath>
   #foreach ($reference in $suiteExecutionReport.pageHistoryReferences)
   <pageHistoryReference>

--- a/src/fitnesse/resources/templates/testExecutionReport.vm
+++ b/src/fitnesse/resources/templates/testExecutionReport.vm
@@ -3,6 +3,7 @@
   <tr>
     <td>$testExecutionReport.Date</td>
     <td class="meta">FitNesse Version: $testExecutionReport.Version</td>
+    <td class="meta">FitNesse Port: $testExecutionReport.Port</td>
   </tr>
 </table>
 

--- a/src/fitnesse/resources/templates/testResults.vm
+++ b/src/fitnesse/resources/templates/testResults.vm
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <testResults>
   <FitNesseVersion>$response.Version</FitNesseVersion>
+  <FitNessePort>$response.Port</FitNessePort>
   <rootPath>$response.RootPath</rootPath>
   #foreach ($result in $response.Results)
   <result>

--- a/test/fitnesse/reporting/history/ExecutionReportTest.java
+++ b/test/fitnesse/reporting/history/ExecutionReportTest.java
@@ -33,7 +33,7 @@ public class ExecutionReportTest {
 
   @Test
   public void canReadTestExecutionReport() throws Exception {
-    TestExecutionReport original = new TestExecutionReport(new FitNesseVersion("version"), "rootPath");
+    TestExecutionReport original = new TestExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
     original.setTotalRunTimeInMillis(totalTimeMeasurementWithElapsedMillis(42));
 
     StringWriter writer = new StringWriter();
@@ -55,7 +55,7 @@ public class ExecutionReportTest {
 
   @Test
   public void canMakeSuiteExecutionReport() throws Exception {
-    SuiteExecutionReport original = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath");
+    SuiteExecutionReport original = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
     original.date = DateTimeUtil.getDateFromString("12/31/1969 18:00:00");
     original.getFinalCounts().add(new TestSummary(1, 2, 3, 4));
     original.setTotalRunTimeInMillis(totalTimeMeasurementWithElapsedMillis(41));
@@ -73,7 +73,7 @@ public class ExecutionReportTest {
   
   @Test
   public void shouldHandleMissingRunTimesGraceFully() throws Exception {
-    TestExecutionReport report = new TestExecutionReport(new FitNesseVersion("version"), "rootPath");
+    TestExecutionReport report = new TestExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
     Element element = mock(Element.class);
     NodeList emptyNodeList = mock(NodeList.class);
     when(element.getElementsByTagName("totalRunTimeInMillis")).thenReturn(emptyNodeList);

--- a/test/fitnesse/reporting/history/SuiteExecutionReportTest.java
+++ b/test/fitnesse/reporting/history/SuiteExecutionReportTest.java
@@ -22,24 +22,24 @@ public class SuiteExecutionReportTest {
 
    @Before
   public void setUp() throws Exception {
-    report1 = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath");
-    report2 = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath");
+    report1 = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
+    report2 = new SuiteExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
   }
 
   @Test
   public void degeneratesShouldBeEqual() throws Exception {
-    assertEquals(new SuiteExecutionReport(new FitNesseVersion("version"), "here"),
-            new SuiteExecutionReport(new FitNesseVersion("version"), "here"));
+    assertEquals(new SuiteExecutionReport(new FitNesseVersion("version"), "here", "port"),
+            new SuiteExecutionReport(new FitNesseVersion("version"), "here", "port"));
   }
   @Test
   public void shouldNotBeEqualIfDifferentTypes() throws Exception {
-    assertFalse(new SuiteExecutionReport(new FitNesseVersion("version"), "here").equals(new Integer(0)));
+    assertFalse(new SuiteExecutionReport(new FitNesseVersion("version"), "here", "port").equals(new Integer(0)));
   }
 
   @Test
   public void shouldNotBeEqualWithDifferentRootPaths()throws Exception  {
-    SuiteExecutionReport report1 = new SuiteExecutionReport(new FitNesseVersion("version"), "here");
-    SuiteExecutionReport report2 = new SuiteExecutionReport(new FitNesseVersion("version"), "there");
+    SuiteExecutionReport report1 = new SuiteExecutionReport(new FitNesseVersion("version"), "here", "port");
+    SuiteExecutionReport report2 = new SuiteExecutionReport(new FitNesseVersion("version"), "there", "port");
     assertFalse(report1.equals(report2));
   }
 
@@ -63,8 +63,8 @@ public class SuiteExecutionReportTest {
 
   @Test
   public void shouldNotBeEqualIfVersionIsDifferent() throws Exception {
-    report1 = new SuiteExecutionReport(new FitNesseVersion("x"), "rootPath");
-    report2 = new SuiteExecutionReport(new FitNesseVersion("y"), "rootPath");
+    report1 = new SuiteExecutionReport(new FitNesseVersion("x"), "rootPath", "port");
+    report2 = new SuiteExecutionReport(new FitNesseVersion("y"), "rootPath", "port");
     assertFalse(report1.equals(report2));
   }
 

--- a/test/fitnesse/reporting/history/TestExecutionReportTest.java
+++ b/test/fitnesse/reporting/history/TestExecutionReportTest.java
@@ -26,7 +26,7 @@ public class TestExecutionReportTest {
 
   @Before
   public void setup() throws Exception {
-    expected = new TestExecutionReport(new FitNesseVersion("version"), "rootPath");
+    expected = new TestExecutionReport(new FitNesseVersion("version"), "rootPath", "port");
     expected.getFinalCounts().add(new TestSummary(1, 2, 3, 4));
     context = FitNesseUtil.makeTestContext();
   }

--- a/test/fitnesse/responders/testHistory/HistoryComparerTest.java
+++ b/test/fitnesse/responders/testHistory/HistoryComparerTest.java
@@ -285,7 +285,7 @@ public class HistoryComparerTest {
   }
 
   private String getContentWith(String passOrFail) throws Exception {
-    TestExecutionReport report = new TestExecutionReport(null, null);
+    TestExecutionReport report = new TestExecutionReport(null, null, null);
     TestExecutionReport.TestResult result = new TestExecutionReport.TestResult();
     result.right = "2";
     result.wrong = "0";

--- a/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PageHistoryResponderTest.java
@@ -335,7 +335,7 @@ public class PageHistoryResponderTest {
   }
 
   private void addDummySuiteResult(File resultFile) throws Exception {
-    SuiteExecutionReport report = new SuiteExecutionReport(fitNesseVersion, "SuitePage");
+    SuiteExecutionReport report = new SuiteExecutionReport(fitNesseVersion, "SuitePage", "port");
     report.date = DateTimeUtil.getDateFromString("12/5/1980 01:19:00");
     report.getFinalCounts().add(new TestSummary(4,5,6,7));
     TimeMeasurement timeMeasurement = mock(TimeMeasurement.class);
@@ -382,7 +382,7 @@ public class PageHistoryResponderTest {
   }
 
   private TestExecutionReport makeDummyTestResponse() {
-    TestExecutionReport testResponse = new TestExecutionReport(fitNesseVersion, "rootPath");
+    TestExecutionReport testResponse = new TestExecutionReport(fitNesseVersion, "rootPath", "port");
     testResponse.getFinalCounts().add(new TestSummary(1, 2, 3, 4));
     TestExecutionReport.TestResult result = new TestExecutionReport.TestResult();
     testResponse.addResult(result);


### PR DESCRIPTION
When running multiple FitNesse-server with different ports on one machine, you need to know, which server created the test-results.