### PR TITLE
Expose table of symbols to TableTable fixtures

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/TestKnownLimitations/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/TestKnownLimitations/content.txt
@@ -1,0 +1,27 @@
+|import|
+|fitnesse.slim.test|
+
+
+!1 FitNesse do not take into account assignments to known symbols
+
+|script|test slim|
+|$X=|echo int|99|
+
+|table: Table Table Inc First Col Statement Executor Consumer |
+|$X|$X=| Here FitNesse knows $X before the table and as a result won't take into account the new assignment to $X. It means that although in the SUT $X is known to have the value 100, in the Wiki side of things it is believed to be 99. $X is then replaced greedily in the next table by 99 instead of using $X which would be resolved by the SUT as 100. |
+
+|script|test slim|$X|
+|check|return Constructor Arg|100|
+
+
+!1 FitNesse replaces symbols too greedily
+
+|script|test slim|
+|$X=|echo int|99|
+
+|table: Table Table Inc First Col Statement Executor Consumer |
+|$X|$X=|
+|$X|$Y=| Here FitNesse knows $X before the table and thus replaces it greedily when passing the table to the fixture. The fixture does not even know that the first cell contained $X in the first place, the Slim code passes 99 instead of $X. Hence 100 is assigned to $Y instead of 101. |
+
+|script|test slim|$Y|
+|check|return Constructor Arg|101|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/TestKnownLimitations/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/TestKnownLimitations/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+  <Edit/>
+  <Files/>
+  <Properties/>
+  <Prune/>
+  <RecentChanges/>
+  <Refactor/>
+  <Search/>
+  <Test/>
+  <Versions/>
+  <WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/content.txt
@@ -1,0 +1,32 @@
+!path fitnesse-slimtest.jar
+
+|import|
+|fitnesse.slim.test|
+
+!1 Make a table table define a new symbol and use this symbol in subsequent rows
+
+|script|test slim|
+|$X=|echo int|99|
+
+|table: Table Table Inc First Col Statement Executor Consumer |
+|$X|$Y=|
+|$Y|$Z=|
+
+|script|test slim|$Y|
+|check|return Constructor Arg|100|
+
+|script|test slim|$Z|
+|check|return Constructor Arg|101|
+
+!1 Make a table table use a symbol, assign into another one and use this symbol in subsequent rows
+
+|script|test slim|
+|$X=|echo int|99|
+|$Y=|echo int|44|
+
+|table: Table Table Inc First Col Statement Executor Consumer |
+|$X|$Y=|
+|$Y|$Z=|
+
+|script|test slim|$Z|
+|check|return Constructor Arg|101|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/content.txt
@@ -1,5 +1,3 @@
-!path fitnesse-slimtest.jar
-
 |import|
 |fitnesse.slim.test|
 
@@ -30,3 +28,7 @@
 
 |script|test slim|$Z|
 |check|return Constructor Arg|101|
+
+!1 Known Limitations
+
+See sub-page about [[known limitations][TestTableTableImplementingStatementExecutorConsumer.TestKnownLimitations]].

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/TestTableTableImplementingStatementExecutorConsumer/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+  <Edit>true</Edit>
+  <Files>true</Files>
+  <Properties>true</Properties>
+  <RecentChanges>true</RecentChanges>
+  <Refactor>true</Refactor>
+  <Search>true</Search>
+  <Test>true</Test>
+  <Versions>true</Versions>
+  <WhereUsed>true</WhereUsed>
+</properties>

--- a/src/fitnesse/slim/SlimExecutionContext.java
+++ b/src/fitnesse/slim/SlimExecutionContext.java
@@ -27,6 +27,10 @@ public class SlimExecutionContext {
         variables.setSymbol(name, value);
     }
 
+    public MethodExecutionResult getVariable(String name) {
+        return variables.getSymbol(name);
+    }
+    
     public void setVariable(String name, Object value) {
         setVariable(name, new MethodExecutionResult(value, Object.class));
     }

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -73,7 +73,10 @@ public class StatementExecutor implements StatementExecutorInterface {
   
   @Override
   public Object getSymbol(String symbolName) {
-	MethodExecutionResult result = context.getVariable(symbolName);
+    MethodExecutionResult result = context.getVariable(symbolName);
+    if (result == null) {
+      return null;
+    }
     return result.returnValue();
   }
 

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -70,6 +70,12 @@ public class StatementExecutor implements StatementExecutorInterface {
   public void assign(String name, Object value) {
     context.setVariable(name, value);
   }
+  
+  @Override
+  public Object getSymbol(String symbolName) {
+	MethodExecutionResult result = context.getVariable(symbolName);
+    return result.returnValue();
+  }
 
   @Override
   public void create(String instanceName, String className, Object... args) throws SlimException {

--- a/src/fitnesse/slim/StatementExecutorInterface.java
+++ b/src/fitnesse/slim/StatementExecutorInterface.java
@@ -4,6 +4,14 @@ import fitnesse.slim.instructions.InstructionExecutor;
 
 public interface StatementExecutorInterface extends InstructionExecutor {
 
+  /*
+   * This method can be used by TableTable custom fixtures to have access
+   * to the table of symbols. This enables elaborate fixtures that can
+   * both assign and resolve any symbols on their own.
+   * 
+   * Have a look to this FitNesse page for some examples:
+   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
+   */
   public abstract Object getSymbol(String symbolName);
 	
   public abstract Object getInstance(String instanceName);

--- a/src/fitnesse/slim/StatementExecutorInterface.java
+++ b/src/fitnesse/slim/StatementExecutorInterface.java
@@ -4,6 +4,8 @@ import fitnesse.slim.instructions.InstructionExecutor;
 
 public interface StatementExecutorInterface extends InstructionExecutor {
 
+  public abstract Object getSymbol(String symbolName);
+	
   public abstract Object getInstance(String instanceName);
 
   public abstract boolean stopHasBeenRequested();

--- a/src/fitnesse/slim/StatementTimeoutExecutor.java
+++ b/src/fitnesse/slim/StatementTimeoutExecutor.java
@@ -28,6 +28,11 @@ public class StatementTimeoutExecutor implements StatementExecutorInterface {
   public void assign(final String name, final Object value) {
     inner.assign(name, value);
   }
+  
+  @Override
+  public Object getSymbol(String symbolName) {
+    return inner.getSymbol(symbolName);
+  }
 
   @Override
   public Object getInstance(String instanceName) {

--- a/src/fitnesse/slim/VariableStore.java
+++ b/src/fitnesse/slim/VariableStore.java
@@ -16,6 +16,10 @@ public class VariableStore {
     variables.put(name, value);
   }
 
+  public MethodExecutionResult getSymbol(String name) {
+	return variables.get(name);
+  }
+  
   public Object getStored(String nameWithDollar) {
     if (nameWithDollar == null || !nameWithDollar.startsWith("$"))
       return null;

--- a/src/fitnesse/slim/test/TableTableIncFirstColStatementExecutorConsumer.java
+++ b/src/fitnesse/slim/test/TableTableIncFirstColStatementExecutorConsumer.java
@@ -1,0 +1,84 @@
+package fitnesse.slim.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import fitnesse.slim.StatementExecutorConsumer;
+import fitnesse.slim.StatementExecutorInterface;
+
+public class TableTableIncFirstColStatementExecutorConsumer implements StatementExecutorConsumer {
+
+  private static final Pattern SYMBOL_ASSIGNMENT_PATTERN = Pattern.compile("\\A\\s*\\$(\\w+)\\s*=\\s*\\Z");
+  private static final Pattern SYMBOL_PATTERN = Pattern.compile("\\$([A-Za-z]\\w*)");
+  
+  private StatementExecutorInterface context;
+
+  /*
+   * (non-Javadoc)
+   * @see fitnesse.slim.StatementExecutorConsumer#setStatementExecutor(fitnesse.slim.StatementExecutorInterface)
+   */
+  public void setStatementExecutor(StatementExecutorInterface statementExecutor) {
+    this.context = statementExecutor;
+  }
+
+  public List<List<String>> doTable(List<List<?>> table) {
+    List<List<String>> ret = new ArrayList<List<String>>();
+
+    for (List<?> line : table) {
+      List<String> retLine = new ArrayList<String>();
+      ret.add(retLine);
+
+      retLine.add("no change");
+      String oldValue = replaceSymbolsInString(line.get(0).toString());
+	  int newValue = Integer.parseInt(oldValue) + 1;
+	  assignSymbolIfApplicable(line.get(1).toString(), newValue);
+	  retLine.add("pass:" + newValue);
+    }
+
+    return ret;
+  }
+
+  private String replaceSymbolsInString(String arg) {
+    int startingPosition = 0;
+    while (true) {
+      if ("".equals(arg) || null == arg) {
+        break;
+      }
+      Matcher symbolMatcher = SYMBOL_PATTERN.matcher(arg);
+      if (symbolMatcher.find(startingPosition)) {
+        String symbolName = symbolMatcher.group(1);
+        arg = replaceSymbolInArg(symbolMatcher, arg, symbolName);
+        startingPosition = symbolMatcher.start(1);
+      } else {
+        break;
+      }
+    }
+    return arg;
+  }
+  
+  private String replaceSymbolInArg(Matcher symbolMatcher, String arg, String symbolName) {
+    String replacement = "null";
+    Object value = context.getSymbol(symbolName);
+    if (value != null) {
+    	replacement = value.toString();
+    }
+    arg = arg.substring(0, symbolMatcher.start()) + replacement
+        + arg.substring(symbolMatcher.end());
+    return arg;
+  }
+  
+  private void assignSymbolIfApplicable(String text, int value) {
+    String symbol = ifSymbolAssignment(text);
+    if (symbol != null) {
+      context.assign(symbol, value);
+    }
+  }
+  
+  private String ifSymbolAssignment(String expected) {
+    Matcher matcher = SYMBOL_ASSIGNMENT_PATTERN.matcher(expected);
+    return matcher.find() ? matcher.group(1) : null;
+  }
+  
+}

--- a/test/fitnesse/slim/SlimGetSymbolTest.java
+++ b/test/fitnesse/slim/SlimGetSymbolTest.java
@@ -1,0 +1,15 @@
+// Copyright (C) 2003-2009 by Object Mentor, Inc. All rights reserved.
+// Released under the terms of the CPL Common Public License version 1.0.
+package fitnesse.slim;
+
+import org.junit.Before;
+
+public class SlimGetSymbolTest extends SlimGetSymbolTestBase {
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    caller = new StatementExecutor();
+  }
+
+}

--- a/test/fitnesse/slim/SlimGetSymbolTestBase.java
+++ b/test/fitnesse/slim/SlimGetSymbolTestBase.java
@@ -1,0 +1,32 @@
+// Copyright (C) 2003-2009 by Object Mentor, Inc. All rights reserved.
+// Released under the terms of the CPL Common Public License version 1.0.
+package fitnesse.slim;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+// Extracted Test class to be implemented by all Java based Slim ports
+
+abstract public class SlimGetSymbolTestBase {
+  protected StatementExecutorInterface caller;
+
+  @Before
+  public abstract void setUp() throws Exception;
+
+  @Test
+  public void getUnsetSymbol() throws Exception {
+    Object symbol = caller.getSymbol("vavavar");
+    assertNull(symbol);
+  }
+
+  @Test
+  public void getSetSymbol() throws Exception {
+    caller.assign("vavavar", "thisisassigned");
+    Object symbol = caller.getSymbol("vavavar");
+    assertEquals("thisisassigned", symbol);
+  }
+
+}


### PR DESCRIPTION
TableTable fixtures can have access to the Slim execution context if they implement StatementExecutorConsumer. However this does not allow them to resolve symbols, making this an unsuitable approach. By adding 'getSymbol' on StatementExecutorInterface, this becomes possible.

This is to follow up issues such as FitNesse's issue #525 or RestFixture's issue 52 https://github.com/smartrics/RestFixture/issues/52