### PR TITLE
Change See widget to handle aliases

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithAliasedXrefWidget/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithAliasedXrefWidget/content.txt
@@ -1,18 +1,22 @@
 When you execute a suite page, !-FitNesse-! tests all the pages mentioned in !-!see-! cross reference widgets.
-''Note: the classpath for the cross referenced pages is not determined by the referencing page, it is determined by the referenced pages.''
+This test ensures that any !-!see-! cross references that are aliased also work as expected.
 
 ----
-Create a simple test page
+Create a hierarchy of pages
+
+|script|Page Builder|
+|line|Top-level page forming sub-wiki|
+|page|!-TopPage-!|
 
 |script|Page Builder|
 |line|${SUT_PATH}|
 |line|!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
-|page|!-TestPage-!|
+|page|!-TopPage.TestPage-!|
 
 Create a Suite page that mentions the test page in a !-!see-! widget
 
 |script|Page Builder|
-|line|!-!see TestPage-!|
+|line|!-!see [[Test page][.TopPage.TestPage]]-!|
 |page|!-SuitePage-!|
 
 |Response Requester.|
@@ -22,6 +26,12 @@ Create a Suite page that mentions the test page in a !-!see-! widget
 |Response Examiner.|
 |contents?|
 ||
+
+Check the suite page has the !-!see-! reference on it.
+
+|Response Examiner.|
+|type  |pattern|matches?|
+|contents|!-See:.*TopPage\.TestPage.*Test page-!|true|
 
 Now run the suite page.
 
@@ -37,7 +47,7 @@ The suite should report the !-TestPage-! and should show no errors.
 
 |Response Examiner.|
 |type  |pattern|matches?|
-|contents|!-TestPage-!|true|
+|contents|!-TopPage\.TestPage-!|true|
 |contents|Test Pages:.*1 right|true|
 
 The error log page should not have any errors

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithAliasedXrefWidget/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithAliasedXrefWidget/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithSubWikiXrefWidget/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithSubWikiXrefWidget/content.txt
@@ -1,18 +1,22 @@
 When you execute a suite page, !-FitNesse-! tests all the pages mentioned in !-!see-! cross reference widgets.
-''Note: the classpath for the cross referenced pages is not determined by the referencing page, it is determined by the referenced pages.''
+This test ensures that any !-!see-! cross references that are references to test in a different sub-wiki also work as expected.
 
 ----
-Create a simple test page
+Create a hierarchy of pages
+
+|script|Page Builder|
+|line|Top-level page forming sub-wiki|
+|page|!-TopPage-!|
 
 |script|Page Builder|
 |line|${SUT_PATH}|
 |line|!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
-|page|!-TestPage-!|
+|page|!-TopPage.TestPage-!|
 
 Create a Suite page that mentions the test page in a !-!see-! widget
 
 |script|Page Builder|
-|line|!-!see TestPage-!|
+|line|!-!see .TopPage.TestPage-!|
 |page|!-SuitePage-!|
 
 |Response Requester.|
@@ -22,6 +26,12 @@ Create a Suite page that mentions the test page in a !-!see-! widget
 |Response Examiner.|
 |contents?|
 ||
+
+Check the suite page has the !-!see-! reference on it.
+
+|Response Examiner.|
+|type  |pattern|matches?|
+|contents|!-\.TopPage\.TestPage-!|true|
 
 Now run the suite page.
 
@@ -37,7 +47,7 @@ The suite should report the !-TestPage-! and should show no errors.
 
 |Response Examiner.|
 |type  |pattern|matches?|
-|contents|!-TestPage-!|true|
+|contents|!-TopPage\.TestPage-!|true|
 |contents|Test Pages:.*1 right|true|
 
 The error log page should not have any errors

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithSubWikiXrefWidget/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuiteWithSubWikiXrefWidget/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTheXrefWidget/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTheXrefWidget/content.txt
@@ -35,6 +35,34 @@ Make sure the page name is formatted properly
 |contents|<b>See: <a href=.*>SomePage</a></b>|true|
 
 
+Check the !-!see-! widget with decorated !-SubWiki-! markup.
 
+Create another page.
 
+|script|
+|start|Page Builder|
+|line|Dummy Text|
+|page|!-AnotherPage-!|
 
+Create a page with a !-!see-! widget with decorated markup
+
+|script|
+|start|Page Builder|
+|line|!-!see [[another page][.AnotherPage]]-!|
+|page|!-YetAnotherPage-!|
+
+Get the Suite page.
+
+|Response Requester.|
+|uri   |valid?|
+|!-YetAnotherPage-!|true|
+
+|Response Examiner.|
+|contents?|
+||
+
+Make sure the page name is formatted properly
+
+!|Response Examiner.|
+|type  |pattern|matches?|
+|contents|<b>See: <a href=.*>another page</a></b>|true|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTheXrefWidget/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTheXrefWidget/properties.xml
@@ -1,10 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Files/>
-	<LastModified>20081213011505</LastModified>
-	<RecentChanges/>
-	<Test/>
-	<WhereUsed/>
-	<saveId>1229152505066</saveId>
-	<ticketId>7293162177854007306</ticketId>
+<Files/>
+<RecentChanges/>
+<Test/>
+<WhereUsed/>
+<saveId>1229152505066</saveId>
+<ticketId>7293162177854007306</ticketId>
 </properties>

--- a/src/fitnesse/wiki/WikiPageUtil.java
+++ b/src/fitnesse/wiki/WikiPageUtil.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import fitnesse.wikitext.parser.Alias;
 import fitnesse.wikitext.parser.See;
 import fitnesse.wikitext.parser.Symbol;
 import fitnesse.wikitext.parser.SymbolTreeWalker;
@@ -94,7 +95,13 @@ public class WikiPageUtil {
       ((WikitextPage) page).getSyntaxTree().walkPreOrder(new SymbolTreeWalker() {
         @Override
         public boolean visit(Symbol node) {
-          if (node.isType(See.symbolType)) xrefPages.add(node.childAt(0).getContent());
+          if (node.isType(See.symbolType)) {
+            if(node.childAt(0).isType(Alias.symbolType)) {
+              xrefPages.add(node.childAt(0).lastChild().childAt(0).getContent());
+            } else {
+              xrefPages.add(node.childAt(0).getContent());
+            }
+          }
           return true;
         }
 

--- a/src/fitnesse/wikitext/parser/See.java
+++ b/src/fitnesse/wikitext/parser/See.java
@@ -12,8 +12,13 @@ public class See extends SymbolType implements Rule {
     
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
         Symbol next = parser.moveNext(1);
-        if (!next.isType(WikiWord.symbolType)) return Symbol.nothing;
-
-        return new Maybe<Symbol>(current.add(next));
+        if (next.isType(WikiWord.symbolType)) {
+            return new Maybe<Symbol>(current.add(next));
+        }
+        if (next.isType(Alias.symbolType)) {
+            Maybe<Symbol> alias = ((Alias)next.getType()).parse(next, parser);
+            return new Maybe<Symbol>(current.add(alias.getValue()));
+        }
+        return Symbol.nothing;
     }
 }

--- a/src/fitnesse/wikitext/parser/See.java
+++ b/src/fitnesse/wikitext/parser/See.java
@@ -16,9 +16,9 @@ public class See extends SymbolType implements Rule {
             return new Maybe<Symbol>(current.add(next));
         }
         if (next.isType(Alias.symbolType)) {
-            Maybe<Symbol> maybe = next.getType().getWikiRule().parse(next, parser);
-            if (maybe!=null && maybe.getValue()!=null)
-              return new Maybe<Symbol>(current.add(maybe.getValue()));
+            Maybe<Symbol> alias = next.getType().getWikiRule().parse(next, parser);
+            if (!alias.isNothing())
+              return new Maybe<Symbol>(current.add(alias.getValue()));
         }
         return Symbol.nothing;
     }

--- a/src/fitnesse/wikitext/parser/See.java
+++ b/src/fitnesse/wikitext/parser/See.java
@@ -16,8 +16,9 @@ public class See extends SymbolType implements Rule {
             return new Maybe<Symbol>(current.add(next));
         }
         if (next.isType(Alias.symbolType)) {
-            Maybe<Symbol> alias = ((Alias)next.getType()).parse(next, parser);
-            return new Maybe<Symbol>(current.add(alias.getValue()));
+            Maybe<Symbol> maybe = next.getType().getWikiRule().parse(next, parser);
+            if (maybe!=null && maybe.getValue()!=null)
+              return new Maybe<Symbol>(current.add(maybe.getValue()));
         }
         return Symbol.nothing;
     }

--- a/test/fitnesse/wiki/WikiPageUtilTest.java
+++ b/test/fitnesse/wiki/WikiPageUtilTest.java
@@ -47,4 +47,12 @@ public class WikiPageUtilTest {
     assertEquals("XrefPage", xrefs.get(0));
   }
 
+  @Test
+  public void testGetCrossReferencesWithMalformedAlias() throws Exception {
+    WikiPage root = InMemoryPage.makeRoot("RooT");
+    WikiPage page = WikiPageUtil.addPage(root, PathParser.parse("PageName"), "!see [[starts like alias but is not\r\n");
+    List<?> xrefs = WikiPageUtil.getXrefPages(page);
+    assertEquals(0, xrefs.size());
+  }
+
 }

--- a/test/fitnesse/wiki/WikiPageUtilTest.java
+++ b/test/fitnesse/wiki/WikiPageUtilTest.java
@@ -31,11 +31,18 @@ public class WikiPageUtilTest {
     assertThat(WikiPageUtil.resolveFileUri("jiberish:/tmp/someFile", new File(".")), equalTo(new File (new File(".").getCanonicalFile(), "/tmp/someFile")));
   }
 
-
   @Test
   public void testGetCrossReferences() throws Exception {
     WikiPage root = InMemoryPage.makeRoot("RooT");
     WikiPage page = WikiPageUtil.addPage(root, PathParser.parse("PageName"), "!see XrefPage\r\n");
+    List<?> xrefs = WikiPageUtil.getXrefPages(page);
+    assertEquals("XrefPage", xrefs.get(0));
+  }
+
+  @Test
+  public void testGetCrossReferencesWithAlias() throws Exception {
+    WikiPage root = InMemoryPage.makeRoot("RooT");
+    WikiPage page = WikiPageUtil.addPage(root, PathParser.parse("PageName"), "!see [[xref page][XrefPage]]\r\n");
     List<?> xrefs = WikiPageUtil.getXrefPages(page);
     assertEquals("XrefPage", xrefs.get(0));
   }

--- a/test/fitnesse/wikitext/parser/SeeTest.java
+++ b/test/fitnesse/wikitext/parser/SeeTest.java
@@ -13,15 +13,25 @@ public class SeeTest {
         ParserTestHelper.assertScansTokenType("!note !see Stuff", "See", true);
     }
 
-    @Test public void parsesSees() throws Exception {
+    @Test
+	public void parsesSees() throws Exception {
         ParserTestHelper.assertParses("!see SomeStuff", "SymbolList[See[WikiWord]]");
         ParserTestHelper.assertParses("!see ya", "SymbolList[Text, Whitespace, Text]");
     }
 
-    @Test public void translatesSees() throws Exception{
+    @Test
+	public void translatesSees() throws Exception {
         TestRoot root = new TestRoot();
         WikiPage page = root.makePage("PageOne", "!see PageTwo");
         root.makePage("PageTwo", "hi");
         ParserTestHelper.assertTranslatesTo(page, "<b>See: <a href=\"PageTwo\">PageTwo</a></b>");
     }
+	
+	@Test
+	public void handlesAlias() throws Exception {
+        TestRoot root = new TestRoot();
+        WikiPage page = root.makePage("PageOne", "!see [[page 2][PageTwo]]");
+        root.makePage("PageTwo", "hi");
+        ParserTestHelper.assertTranslatesTo(page, "<b>See: <a href=\"PageTwo\">page 2</a></b>");
+	}
 }

--- a/test/fitnesse/wikitext/parser/SeeTest.java
+++ b/test/fitnesse/wikitext/parser/SeeTest.java
@@ -34,4 +34,12 @@ public class SeeTest {
         root.makePage("PageTwo", "hi");
         ParserTestHelper.assertTranslatesTo(page, "<b>See: <a href=\"PageTwo\">page 2</a></b>");
 	}
+
+  @Test
+  public void handlesMalformedAlias() throws Exception {
+        TestRoot root = new TestRoot();
+        WikiPage page = root.makePage("PageOne", "!see [[looks like alias but is not");
+        root.makePage("PageTwo", "hi");
+        ParserTestHelper.assertTranslatesTo(page, "!see [[looks like alias but is not");
+  }
 }


### PR DESCRIPTION
Whilst updating some of the documentation I noticed that the See widget does not handle aliases correctly and due to this the !see [[alias text][AliasLink]] is not rendered properly.

I am not too enamoured with the current solution due to the amount of casting so if someone could suggest a better way of doing this I'd be grateful.