### PR TITLE
Remove extra character which broke half of the paragraph

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/FixtureGallery/FitLibraryFixtures/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/FixtureGallery/FitLibraryFixtures/content.txt
@@ -1,6 +1,6 @@
 ''Previous page: [[!-Basic FIT fixtures-!][<UserGuide.FixtureGallery.BasicFitFixtures]] Next page: [[!-Important concepts-!][<UserGuide.FixtureGallery.ImportantConcepts]] Parent page: [[!-Table of contents-!][<UserGuide.FixtureGallery.TableOfContents]]''
 !2 !-FitLibrary Fixtures-!
-!- FitLibrary started as a third-party set of fixtures, but it was so useful that it is now considered part of the standard test types. For the Java version, it is still maintained as a separate library but it is packaged within the<UserGuide bundle. The .NET versions of FIT and FitLibrary are distributed together in the same package ( FitLibrary is just a separate DLL). -!
+!- FitLibrary started as a third-party set of fixtures, but it was so useful that it is now considered part of the standard test types. For the Java version, it is still maintained as a separate library but it is packaged within the UserGuide bundle. The .NET versions of FIT and FitLibrary are distributed together in the same package ( FitLibrary is just a separate DLL). -!
 
 # section SetUpFixture
 [[!-SetUpFixture-!][>SetUpFixture]]


### PR DESCRIPTION
With the extra character in place, the remainder of the paragraph was not shown. 

I stumbled across this after a colleague asked if I knew why both FitNesse and FitLibrary contains the fit package with various fixtures. I looked a bit into it, but didn't find any definitive answer, though I registered FitLibrary had a similar question on their mailing list recently[1]. Is there a historical reason why both projects contain this package?

[1] http://sourceforge.net/p/fitlibrary/mailman/fitlibrary-user/?viewmonth=201501