### PR TITLE
Revert old behaviour for Slim String converter

### DIFF
--- a/src/fitnesse/slim/converters/StringConverter.java
+++ b/src/fitnesse/slim/converters/StringConverter.java
@@ -13,6 +13,6 @@ public class StringConverter implements Converter<String> {
   }
 
   public String fromString(String arg) {
-    return !StringUtils.isBlank(arg) ? arg : null;
+    return arg;
   }
 }

--- a/test/fitnesse/slim/ConverterSupportTest.java
+++ b/test/fitnesse/slim/ConverterSupportTest.java
@@ -59,7 +59,7 @@ public class ConverterSupportTest {
 
     Object current = convertSingleValue(value, clazz);
 
-    assertNull(value, current);
+    assertEquals(value, current);
   }
 
   @Test

--- a/test/fitnesse/slim/ListExecutorTestBase.java
+++ b/test/fitnesse/slim/ListExecutorTestBase.java
@@ -138,7 +138,7 @@ public abstract class ListExecutorTestBase {
   @Test
   public void oneFunctionCallWithBlankArgument() throws Exception {
     statements.add(Arrays.asList("id", "call", "testSlim", "echoString", ""));
-    respondsWith(Arrays.asList(Arrays.asList("id", null)));
+    respondsWith(Arrays.asList(Arrays.asList("id", "")));
   }
 
   @Test
@@ -146,7 +146,7 @@ public abstract class ListExecutorTestBase {
     statements.add(0, Arrays.asList("i2", "import", getTestClassPath() + ".testSlimInThisPackageShouldNotBeTheOneUsed"));
     statements.add(Arrays.asList("id", "call", "testSlim", "returnString"));
     expectedResults.add(0, Arrays.asList("i2", "OK"));
-    respondsWith(Arrays.asList(Arrays.asList("id", (Object) "string")));
+    respondsWith(Arrays.asList(Arrays.asList("id", "string")));
   }
 
   @Test

--- a/test/fitnesse/slim/converters/StringConverterTest.java
+++ b/test/fitnesse/slim/converters/StringConverterTest.java
@@ -1,13 +1,16 @@
 package fitnesse.slim.converters;
 
+import fitnesse.slim.Converter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class StringConverterTest extends AbstractConverterTest<String, StringConverter> {
+public class StringConverterTest {
+
+  private final StringConverter converter;
 
   public StringConverterTest() {
-    super(new StringConverter());
+    converter = new StringConverter();
   }
 
   /*
@@ -26,8 +29,26 @@ public class StringConverterTest extends AbstractConverterTest<String, StringCon
    * FROM STRING
    */
   @Test
+  public void toString_should_return_null_string_when_value_is_not_defined() {
+    String value = null;
+
+    String current = converter.toString(value);
+
+    assertEquals(Converter.NULL_VALUE, current);
+  }
+
+  @Test
   public void fromString_should_return_the_same_string_when_value_is_a_string() {
     String value = "^_^";
+
+    String current = converter.fromString(value);
+
+    assertSame(value, current);
+  }
+
+  @Test
+  public void fromString_should_return_empty_string() {
+    String value = "";
 
     String current = converter.fromString(value);
 


### PR DESCRIPTION
String converter used to pass strings as is. The 20150226 version converts empty Strings to null values.

This PR reverts the old behaviour.