### PR TITLE
fixes issue #691

### DIFF
--- a/src/fitnesse/FitNesseContext.java
+++ b/src/fitnesse/FitNesseContext.java
@@ -98,17 +98,17 @@ public class FitNesseContext {
   public File getTestHistoryDirectory() {
     String testHistoryPath = getProperty("test.history.path");
     if (testHistoryPath == null) {
-      testHistoryPath = String.format("%s/files/%s", getRootPagePath(), testResultsDirectoryName);
+      testHistoryPath = String.format(unifiedPathPattern("%s/files/%s"), getRootPagePath(), testResultsDirectoryName);
     }
     return new File(testHistoryPath);
   }
 
   public String getTestProgressPath() {
-    return String.format("%s/files/testProgress/", getRootPagePath());
+    return String.format(unifiedPathPattern("%s/files/testProgress"), getRootPagePath());
   }
 
   public String getRootPagePath() {
-    return String.format("%s/%s", rootPath, rootDirectoryName);
+    return String.format(unifiedPathPattern("%s/%s"), rootPath, rootDirectoryName);
   }
 
   public Properties getProperties() {
@@ -117,5 +117,10 @@ public class FitNesseContext {
 
   public String getProperty(String name) {
     return variableSource.getProperty(name);
+  }
+  
+  private String unifiedPathPattern(String s)
+  {
+    return s.replace("/",File.separator);
   }
 }

--- a/src/fitnesse/reporting/PageInProgressFormatter.java
+++ b/src/fitnesse/reporting/PageInProgressFormatter.java
@@ -10,6 +10,7 @@ import fitnesse.testsystems.TestSystemListener;
 import fitnesse.testsystems.TestSummary;
 import util.FileUtil;
 
+import java.io.File;
 import java.io.IOException;
 
 public class PageInProgressFormatter implements TestSystemListener<WikiTestPage> {
@@ -21,7 +22,7 @@ public class PageInProgressFormatter implements TestSystemListener<WikiTestPage>
   }
 
   public String getLockFileName(WikiTestPage test) {
-    return context.getTestProgressPath() + "/" + test.getVariable("PAGE_PATH") + "." + test.getVariable("PAGE_NAME");
+    return context.getTestProgressPath() + File.separator + test.getVariable("PAGE_PATH") + "." + test.getVariable("PAGE_NAME");
   }
 
   @Override

--- a/src/util/FileUtil.java
+++ b/src/util/FileUtil.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 public class FileUtil {
 
@@ -31,7 +32,7 @@ public class FileUtil {
   }
 
   public static File createFile(String path, InputStream content) {
-    String[] names = path.split("/");
+    String[] names = path.replace("/", File.separator).split(Pattern.quote(File.separator));
     if (names.length == 1)
       return createFile(new File(path), content);
     else {


### PR DESCRIPTION
Used File.separator instead of hard-coded "\". Fixes unit test failures on Windows(issue #691). Have no idea about Mac or Linux. Please verify.