### PR TITLE
Change of test result layout and fix of test order 

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioLibraryTestSuite/ScenarioLibraryShouldIncludeIncludedPages/ScenarioLibrary/IncludedPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioLibraryTestSuite/ScenarioLibraryShouldIncludeIncludedPages/ScenarioLibrary/IncludedPage/content.txt
@@ -1,2 +1,2 @@
-
 | scenario | scenario in included page |
+|pass|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioLibraryTestSuite/ScenarioLibraryShouldIncludeIncludedPages/ScenarioLibrary/IncludedPage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioLibraryTestSuite/ScenarioLibraryShouldIncludeIncludedPages/ScenarioLibrary/IncludedPage/properties.xml
@@ -1,13 +1,12 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<Help></Help>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Suites></Suites>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
+<Edit>true</Edit>
+<Files>true</Files>
+<LastModifyingUser>six42</LastModifyingUser>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
 </properties>

--- a/src/fitnesse/reporting/TestTextFormatter.java
+++ b/src/fitnesse/reporting/TestTextFormatter.java
@@ -24,7 +24,8 @@ public class TestTextFormatter extends BaseFormatter implements Closeable {
 
   @Override
   public void testSystemStarted(TestSystem testSystem) {
-    response.add(String.format("\nStarting Test System: %s.\n", testSystem.getName()));
+	String timeString = new SimpleDateFormat("yyyy-mm-dd HH:mm:ss").format(totalTimeMeasurement.startedAtDate());
+    response.add(String.format("\nStarting Test System at %s: %s.\n", timeString, testSystem.getName()));
   }
 
   @Override
@@ -40,9 +41,8 @@ public class TestTextFormatter extends BaseFormatter implements Closeable {
   public void testComplete(WikiTestPage page, TestSummary summary) throws IOException {
     timeMeasurement.stop();
     updateCounters(summary);
-    String timeString = new SimpleDateFormat("HH:mm:ss").format(timeMeasurement.startedAtDate());
-    response.add(String.format("%s %s R:%-4d W:%-4d I:%-4d E:%-4d %s\t(%s)\t%.03f seconds\n",
-      passFail(summary), timeString, summary.getRight(), summary.getWrong(), summary.getIgnores(), summary.getExceptions(), page.getName(), page.getFullPath(), timeMeasurement.elapsedSeconds()));
+    response.add(String.format("%s %.03f sec R:%-4d W:%-4d I:%-4d E:%-4d %s\t(%s)\n",
+      passFail(summary),  timeMeasurement.elapsedSeconds(), summary.getRight(), summary.getWrong(), summary.getIgnores(), summary.getExceptions(), page.getName(), page.getFullPath() ));
   }
 
   private void updateCounters(TestSummary summary) {

--- a/src/fitnesse/reporting/history/SuiteExecutionReport.java
+++ b/src/fitnesse/reporting/history/SuiteExecutionReport.java
@@ -160,6 +160,14 @@ public class SuiteExecutionReport extends ExecutionReport {
       return PathParser.parse(pageName).last();
     }
 
+    public String getPath() {
+        return PathParser.parse(pageName).parentPath().toString();
+      }
+    
+    public String subtractFromFront(String operand){
+    	return  PathParser.parse(pageName).parentPath().subtractFromFront(PathParser.parse(operand)).toString();
+    }
+    
     public long getTime() {
       return time;
     }

--- a/src/fitnesse/resources/templates/suiteExecutionReport.vm
+++ b/src/fitnesse/resources/templates/suiteExecutionReport.vm
@@ -28,11 +28,13 @@
     <th class="numeric">Wrong</th>
     <th class="numeric">Ignored</th>
     <th class="numeric">Exceptions</th>
-    <th>Page</th>
     #if($suiteExecutionReport.hasRunTimes())
     <th class="numeric">Run&nbsp;time&nbsp;(ms)</th>
     #end
+    <th>Page</th>
+    <th>Path</th>
   </tr>
+  #set ($previousPage = $suiteExecutionReport.getRootPath())
   #foreach($pageHistoryReference in $suiteExecutionReport.getPageHistoryReferences())
   #set($counts = $pageHistoryReference.getTestSummary())
   <tr class="$ExecutionResult.getExecutionResult($pageHistoryReference.pageName, $counts)">
@@ -48,14 +50,17 @@
     <td class="numeric">
       $counts.Exceptions
     </td>
-    <td>
-      <a href="$pageHistoryReference.pageName?pageHistory&resultDate=$pageHistoryReference.getResultDate()">$pageHistoryReference.getPageName()</a>
-    </td>
     #if($suiteExecutionReport.hasRunTimes())
     <td class="numeric">
       $pageHistoryReference.RunTimeInMillis
     </td>
     #end
+    <td>
+      <a href="$pageHistoryReference.pageName?pageHistory&resultDate=$pageHistoryReference.getResultDate()">$pageHistoryReference.getRelativePageName()</a>
+    </td>
+    <td>
+      $pageHistoryReference.subtractFromFront($previousPage)
+    </td>
   </tr>
   #end
 </table>

--- a/src/fitnesse/wiki/WikiPagePath.java
+++ b/src/fitnesse/wiki/WikiPagePath.java
@@ -136,8 +136,8 @@ public class WikiPagePath implements Comparable<Object> {
   public int compareTo(Object o) {
     if (o instanceof WikiPagePath) {
       WikiPagePath p = (WikiPagePath) o;
-      String compressedName = StringUtils.join(names, "");
-      String compressedArgumentName = StringUtils.join(p.names, "");
+      String compressedName = StringUtils.join(names, ".");
+      String compressedArgumentName = StringUtils.join(p.names, ".");
       return compressedName.compareTo(compressedArgumentName);
     }
     return 1; // we are greater because we are the right type.

--- a/test/fitnesse/reporting/TestTextFormatterTest.java
+++ b/test/fitnesse/reporting/TestTextFormatterTest.java
@@ -46,7 +46,7 @@ public class TestTextFormatterTest {
     clock.elapse(9800);
     formatter.testComplete(page, summary);
     formatter.close();
-    verify(response).add("F " + START_TIME + " R:1    W:2    I:3    E:4    page\t()\t9" + getDecimalSeparator() + "800 seconds\n");
+    verify(response).add("F 9" + getDecimalSeparator() + "800 sec R:1    W:2    I:3    E:4    page\t()\n");
   }
   
   @Test

--- a/test/fitnesse/wiki/WikiPagePathTest.java
+++ b/test/fitnesse/wiki/WikiPagePathTest.java
@@ -157,6 +157,30 @@ public class WikiPagePathTest {
   }
 
   @Test
+  public void testCompareToWithRealWorldNames() throws Exception {
+	  //if a suite name is a substring of another suite name the order must still be correct
+	    WikiPagePath a = PathParser.parse("SuiteExecution.ExecutionLogOfSuitePage");
+	    WikiPagePath b = PathParser.parse("SuiteExecution.SuiteExecutionCleansUpHistory");
+	    WikiPagePath c = PathParser.parse("SuiteExecutionLog.ExecutionLogOfSuitePage");
+
+	    assertTrue(a.compareTo(b) < 0);    // a < b
+	    assertTrue(a.compareTo(c) < 0);    // a < b
+	    assertTrue(b.compareTo(c) < 0);    // a < b
+	    /*
+	     * The join must add a separator (dot) between the path parts to sort names as the below correctly
+	    SuiteExecution.ExecutionLogOfSuitePage
+	    SuiteExecution.SuiteExecutionCleansUpHistory 
+	    SuiteExecutionLog.ExecutionLogOfSuitePage
+	    SuiteExecutionLog.ExecutionLogOfTestPage
+	     * The order below would result without the separator.
+	    SuiteExecution.ExecutionLogOfSuitePage
+	    SuiteExecutionLog.ExecutionLogOfSuitePage
+	    SuiteExecutionLog.ExecutionLogOfTestPage
+	    SuiteExecution.SuiteExecutionCleansUpHistory 
+	    */
+	  }
+  
+  @Test
   public void testMakeAbsolute() throws Exception {
     WikiPagePath p = PathParser.parse("PathOne");
     p.makeAbsolute();


### PR DESCRIPTION
This PR combines 4 independent items:

1. Bug fix: Order of test execution 

 * The pages should be executed in the below order

 SuiteExecution.ExecutionLogOfSuitePage

 SuiteExecution.SuiteExecutionCleansUpHistory

 SuiteExecutionLog.ExecutionLogOfSuitePage

 SuiteExecutionLog.ExecutionLogOfTestPage
 * The order below would result without this commit

 SuiteExecution.ExecutionLogOfSuitePage

 SuiteExecutionLog.ExecutionLogOfSuitePage

 SuiteExecutionLog.ExecutionLogOfTestPage

 SuiteExecution.SuiteExecutionCleansUpHistory

2. Change of TestTextFormatter layout

 This closes item #680 
 Sample of New Format:
     [java] Starting Test System at 2015-50-01 01:50:22: slim:fitnesse.slim.SlimService.
     [java] . 0,844 sec R:14   W:0    I:1    E:0    AlwaysSecureOperation	(FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation)
     [java] . 0,216 sec R:30   W:0    I:1    E:0    SecureReadOperations	(FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations)
     [java] . 0,100 sec R:4    W:0    I:1    E:0    SecureTestOperations	(FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations)
     [java] . 0,103 sec R:8    W:0    I:1    E:0    SecureWriteOperations	(FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureWriteOperations)


3. Align layout of SuiteExecutionReport to TestTextFormatter
 The new format requires less space and helps to identify slow test cases.

 Old Format:
 ![suiteexecutionreport_old](https://cloud.githubusercontent.com/assets/5906592/6931965/c6147722-d813-11e4-9d35-a11b83f93f5f.jpg)

 New Format:
 ![suiteexecutionreport_new](https://cloud.githubusercontent.com/assets/5906592/6931976/e454edd4-d813-11e4-8e75-401c26be053d.jpg)

4. Make ScenarioLibraryShouldIncludeIncludedPages pass 

 This has now 1 right result instead of zero.