### PR TITLE
Issue 703: making prevention of System.exit() calls configurable.

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SystemExitIsPrevented/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SystemExitIsPrevented/content.txt
@@ -1,5 +1,13 @@
+!|script|SystemExitTableConfiguration                 |
+|set system property|prevent.system.exit|to|true|
+
+
 !|SystemExitTable                                        |
 |System exit code|exception message?                     |
 |0               |prevented system exit with exit code 0 |
 |1               |prevented system exit with exit code 1 |
 |42              |prevented system exit with exit code 42|
+
+
+!|script|SystemExitTableConfiguration                |
+|restore original system property|prevent.system.exit  |

--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/CommandLineArguments/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/CommandLineArguments/content.txt
@@ -1,3 +1,5 @@
+!1 Command line arguments
+
 A subset of configuration options can be provided through the command line. Command line properties take precedence over properties set in the configuration file and system properties (''-Dproperty=value''). 
 
 | ''Command!-&nbsp;-!line!-&nbsp;-!parameter'' | ''Configuration!-&nbsp;-!property'' | ''Default'' | ''Description'' |
@@ -14,7 +16,14 @@ A subset of configuration options can be provided through the command line. Comm
 | {{{-b <filename>}}} | !-RedirectOutput-! | ''stdout'' | redirect command output. This is most useful in conjunction with the ''-c'' option |
 | {{{-f <config file>}}} | n.a. | plugins.properties | Load an alternative configuration file. The file format adhere's to the java standard of property files. If this option is not provided, the default file ''plugins.properties'' will be loaded if it exists. |
 
-If you are using [[Slim][<UserGuide.WritingAcceptanceTests.SliM]], you can also pass in -Dslim.port to hard code the port that the Slim server uses, or configure slim.port in the configuration file.  This can be used in conjunction with Jenkins Port Allocator Plugin or the reserver-network-port mojo of the Maven build-helper plugin.
+
+!1 Java system properties
+
+Some system properties can be used to control and/or to configure FitNesse (-Dproperty=value):
+
+|''System property'' 		|''Description''|
+|{{{slim.port}}}			|If you are using [[Slim][<UserGuide.WritingAcceptanceTests.SliM]], you can also pass in -Dslim.port to hard code the port that the Slim server uses, or configure slim.port in the configuration file.  This can be used in conjunction with Jenkins Port Allocator Plugin or the reserver-network-port mojo of the Maven build-helper plugin.|
+|{{{prevent.system.exit}}}	|If this property is set to true, then the ''!-SystemExitSecurityManager-!'' is activated to catch System.exit() calls and prevent them from terminating the VM. Default is set to ''true''.|
 
 See also: ConfigurationFile.
 

--- a/src/fitnesse/fixtures/SystemExitTableConfiguration.java
+++ b/src/fitnesse/fixtures/SystemExitTableConfiguration.java
@@ -1,0 +1,26 @@
+package fitnesse.fixtures;
+
+
+public class SystemExitTableConfiguration {
+
+  public boolean setSystemPropertyTo(String systemProperty, String value) {
+    String originalSystemProperty = System.getProperty(systemProperty);
+    if (originalSystemProperty != null){
+      System.setProperty(systemProperty + ".orig", originalSystemProperty);
+    }
+    System.setProperty(systemProperty, value);
+    return true;
+  }
+
+  public boolean restoreOriginalSystemProperty(String systemProperty) {
+    String originalSystemProperty = System.getProperty(systemProperty + ".orig");
+    if (originalSystemProperty == null) {
+      System.clearProperty(systemProperty);
+    } else {
+      System.setProperty(systemProperty, originalSystemProperty);
+    }
+    System.clearProperty(systemProperty + ".orig");
+    return true;
+  }
+
+}

--- a/src/fitnesse/slim/instructions/Instruction.java
+++ b/src/fitnesse/slim/instructions/Instruction.java
@@ -22,18 +22,17 @@ public abstract class Instruction {
   }
 
   public final InstructionResult execute(InstructionExecutor executor) {
-    SecurityManager oldSecurityManager = System.getSecurityManager();
-    System.setSecurityManager(new SystemExitSecurityManager(oldSecurityManager));
     
     InstructionResult result;
     try {
+      SystemExitSecurityManager.activateIfWanted();
       result = executeInternal(executor);
     } catch (SlimException e) {
       result = new InstructionResult.Error(getId(), e);
     } catch (SystemExitException e) {
       result = new InstructionResult.Error(getId(), e);
     } finally {
-      System.setSecurityManager(oldSecurityManager);
+      SystemExitSecurityManager.restoreOriginalSecurityManager();
     }
     return result;
   }

--- a/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
+++ b/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
@@ -4,10 +4,50 @@ import java.security.Permission;
 
 public class SystemExitSecurityManager extends SecurityManager {
 
+  public static final String PREVENT_SYSTEM_EXIT = "prevent.system.exit";
   private SecurityManager delegate;
 
-  public SystemExitSecurityManager(SecurityManager delegate) {
+  /**
+   * The {@link SystemExitSecurityManager} overrides the behavior of the wrapped
+   * original {@link SecurityManager} to prevent {@link System#exit(int)} calls
+   * from being executed.
+   * 
+   * @author Anis Ben Hamidene
+   *
+   */
+  private SystemExitSecurityManager(SecurityManager delegate) {
     this.delegate = delegate;
+  }
+
+  /**
+   * Replaces the current {@link SecurityManager} with a
+   * {@link SystemExitSecurityManager}.
+   */
+  public static void activateIfWanted() {
+    if (isPreventSystemExit()) {
+      SecurityManager currentSecMgr = System.getSecurityManager();
+      SystemExitSecurityManager systemExitSecurityManager = new SystemExitSecurityManager(
+          currentSecMgr);
+      System.setSecurityManager(systemExitSecurityManager);
+    }
+  }
+
+  public static void restoreOriginalSecurityManager() {
+    SecurityManager currentSecMgr = System.getSecurityManager();
+    if (currentSecMgr != null
+        && currentSecMgr instanceof SystemExitSecurityManager) {
+      SecurityManager originalSecurityManager = ((SystemExitSecurityManager) currentSecMgr).delegate;
+      System.setSecurityManager(originalSecurityManager);
+    }
+  }
+
+  private static boolean isPreventSystemExit() {
+    String preventSystemExitString = System.getProperty(PREVENT_SYSTEM_EXIT);
+    if (preventSystemExitString != null) {
+      return Boolean.parseBoolean(preventSystemExitString);      
+    } else {
+      return true;
+    }
   }
 
   @Override
@@ -27,6 +67,198 @@ public class SystemExitSecurityManager extends SecurityManager {
   public void checkPermission(Permission perm) {
     if (delegate != null) {
       delegate.checkPermission(perm);
+    }
+  }
+
+  @Override
+  public void checkCreateClassLoader() {
+
+    if (delegate != null) {
+      delegate.checkCreateClassLoader();
+    }
+  }
+
+  @Override
+  public void checkAccess(Thread t) {
+
+    if (delegate != null) {
+      delegate.checkAccess(t);
+    }
+  }
+
+  @Override
+  public void checkAccess(ThreadGroup g) {
+
+    if (delegate != null) {
+      delegate.checkAccess(g);
+    }
+  }
+
+  @Override
+  public void checkExec(String cmd) {
+
+    if (delegate != null) {
+      delegate.checkExec(cmd);
+    }
+  }
+
+  @Override
+  public void checkLink(String lib) {
+
+    if (delegate != null) {
+      delegate.checkLink(lib);
+    }
+  }
+
+  @Override
+  public void checkRead(String file) {
+
+    if (delegate != null) {
+      delegate.checkRead(file);
+    }
+  }
+
+  @Override
+  public void checkRead(String file, Object context) {
+
+    if (delegate != null) {
+      delegate.checkRead(file, context);
+    }
+  }
+
+  @Override
+  public void checkWrite(String file) {
+
+    if (delegate != null) {
+      delegate.checkWrite(file);
+    }
+  }
+
+  @Override
+  public void checkDelete(String file) {
+
+    if (delegate != null) {
+      delegate.checkDelete(file);
+    }
+  }
+
+  @Override
+  public void checkConnect(String host, int port) {
+
+    if (delegate != null) {
+      delegate.checkConnect(host, port);
+    }
+  }
+
+  @Override
+  public void checkConnect(String host, int port, Object context) {
+
+    if (delegate != null) {
+      delegate.checkConnect(host, port, context);
+    }
+  }
+
+  @Override
+  public void checkListen(int port) {
+
+    if (delegate != null) {
+      delegate.checkListen(port);
+    }
+  }
+
+  @Override
+  public void checkAccept(String host, int port) {
+
+    if (delegate != null) {
+      delegate.checkAccept(host, port);
+    }
+  }
+
+  @Override
+  public void checkPropertiesAccess() {
+
+    if (delegate != null) {
+      delegate.checkPropertiesAccess();
+    }
+  }
+
+  @Override
+  public void checkPropertyAccess(String key) {
+
+    if (delegate != null) {
+      delegate.checkPropertyAccess(key);
+    }
+  }
+
+  @Override
+  public boolean checkTopLevelWindow(Object window) {
+    if (delegate != null) {
+      return delegate.checkTopLevelWindow(window);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void checkPrintJobAccess() {
+
+    if (delegate != null) {
+      delegate.checkPrintJobAccess();
+    }
+  }
+
+  @Override
+  public void checkSystemClipboardAccess() {
+
+    if (delegate != null) {
+      delegate.checkSystemClipboardAccess();
+    }
+  }
+
+  @Override
+  public void checkAwtEventQueueAccess() {
+
+    if (delegate != null) {
+      delegate.checkAwtEventQueueAccess();
+    }
+  }
+
+  @Override
+  public void checkPackageAccess(String pkg) {
+
+    if (delegate != null) {
+      delegate.checkPackageAccess(pkg);
+    }
+  }
+
+  @Override
+  public void checkPackageDefinition(String pkg) {
+
+    if (delegate != null) {
+      delegate.checkPackageDefinition(pkg);
+    }
+  }
+
+  @Override
+  public void checkSetFactory() {
+    if (delegate != null) {
+      delegate.checkSetFactory();
+    }
+  }
+
+  @Override
+  public void checkMemberAccess(Class<?> clazz, int which) {
+
+    if (delegate != null) {
+      delegate.checkMemberAccess(clazz, which);
+    }
+  }
+
+  @Override
+  public void checkSecurityAccess(String target) {
+
+    if (delegate != null) {
+      delegate.checkSecurityAccess(target);
     }
   }
 

--- a/test/fitnesse/slim/instructions/SystemExitSecurityManagerTest.java
+++ b/test/fitnesse/slim/instructions/SystemExitSecurityManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.fail;
 import static util.RegexTestCase.assertMatches;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import fitnesse.slim.instructions.SystemExitSecurityManager.SystemExitException;
@@ -15,34 +14,33 @@ public class SystemExitSecurityManagerTest {
 
   SecurityManager securityManager;
 
-  @Before
-  public void setup() {
-    oldSecurityManager = System.getSecurityManager();
-    securityManager = new SystemExitSecurityManager(oldSecurityManager);
-    System.setSecurityManager(securityManager);
-  }
-
   @After
   public void teardown() {
-    System.setSecurityManager(oldSecurityManager);
+    SystemExitSecurityManager.restoreOriginalSecurityManager();
   }
 
-  @Test
+  @Test(expected = SystemExitException.class)
   public void shouldThrowExceptionWhenSystemExitIsCalled() {
-    try {
-      System.exit(0);
-      fail("should have thrown exception");
-    } catch (SystemExitException e) {
-    }
+    acticateSystemExitSecurityManager();
+    System.exit(0);
+    fail("should have thrown exception");
+
   }
 
   @Test
   public void shouldIncludeExitCode() {
     try {
+      acticateSystemExitSecurityManager();
       System.exit(42);
       fail("should have thrown exception");
     } catch (SystemExitException e) {
       assertMatches("system exit with exit code 42", e.getMessage());
     }
+  }
+  
+  private void acticateSystemExitSecurityManager() {
+    System.setSecurityManager(null);
+    System.setProperty(SystemExitSecurityManager.PREVENT_SYSTEM_EXIT, "true");
+    SystemExitSecurityManager.activateIfWanted();
   }
 }


### PR DESCRIPTION
Introduced new system property prevent.system.exit to control the activation of the SystemExitSecurityManager. Default behaviour is that the SystemExitSecurityManager is activated if the property is not found