### PR TITLE
Notify jUnit of test system exceptions

### DIFF
--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -362,8 +362,8 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
 
   protected void runPages(List<WikiPage>pages, final RunNotifier notifier) {
     MultipleTestsRunner testRunner = createTestRunner(pages);
-    addTestSystemListeners(notifier, testRunner);
-    addExecutionLogListener(notifier, testRunner);
+    addTestSystemListeners(notifier, testRunner, suiteClass);
+    addExecutionLogListener(notifier, testRunner, suiteClass);
     try {
       executeTests(testRunner);
     } catch (AssertionError e) {
@@ -373,11 +373,11 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
     }
   }
 
-  protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner) {
+  protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
     testRunner.addTestSystemListener(new JUnitRunNotifierResultsListener(notifier, suiteClass));
   }
 
-  protected void addExecutionLogListener(RunNotifier notifier, MultipleTestsRunner testRunner) {
+  protected void addExecutionLogListener(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
     testRunner.addExecutionLogListener(new ConsoleExecutionLogListener());
   }
 

--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -362,8 +362,8 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
 
   protected void runPages(List<WikiPage>pages, final RunNotifier notifier) {
     MultipleTestsRunner testRunner = createTestRunner(pages);
-    testRunner.addTestSystemListener(new JUnitRunNotifierResultsListener(notifier, suiteClass));
-    testRunner.addExecutionLogListener(new ConsoleExecutionLogListener());
+    addTestSystemListeners(notifier, testRunner);
+    addExecutionLogListener(notifier, testRunner);
     try {
       executeTests(testRunner);
     } catch (AssertionError e) {
@@ -371,6 +371,14 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
     } catch (Exception e) {
       notifier.fireTestFailure(new Failure(Description.createSuiteDescription(suiteClass), e));
     }
+  }
+
+  protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner) {
+    testRunner.addTestSystemListener(new JUnitRunNotifierResultsListener(notifier, suiteClass));
+  }
+
+  protected void addExecutionLogListener(RunNotifier notifier, MultipleTestsRunner testRunner) {
+    testRunner.addExecutionLogListener(new ConsoleExecutionLogListener());
   }
 
   protected List<WikiPage> initChildren() {

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -65,6 +65,9 @@ public class JUnitRunNotifierResultsListener implements TestSystemListener<WikiT
 
   @Override
   public void testSystemStopped(TestSystem testSystem, Throwable cause) {
+    if (cause != null) {
+      notifier.fireTestFailure(new Failure(Description.createSuiteDescription(mainClass), cause));
+    }
   }
 
   private Description descriptionFor(WikiTestPage test) {

--- a/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
+++ b/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
@@ -2,8 +2,16 @@ package fitnesse.junit;
 
 import fitnesse.FitNesseContext;
 import fitnesse.components.PluginsClassLoader;
+import fitnesse.testrunner.MultipleTestsRunner;
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.*;
 import org.junit.runner.RunWith;
+import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNull;
 
 @RunWith(FitNesseRunnerExtensionTest.SuiteExtension.class)
 @FitNesseRunner.FitnesseDir(".")
@@ -16,6 +24,11 @@ public class FitNesseRunnerExtensionTest {
     }
 
     @Override
+    protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner) {
+      testRunner.addTestSystemListener(new ListenerExtension(notifier, getTestClass().getJavaClass()));
+    }
+
+    @Override
     protected String getSuiteName(Class<?> klass) throws InitializationError {
       return "FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TestScriptTable";
     }
@@ -25,6 +38,37 @@ public class FitNesseRunnerExtensionTest {
       new PluginsClassLoader(getFitNesseRoot(suiteClass)).addPluginsToClassLoader();
 
       return super.createContext(suiteClass);
+    }
+  }
+
+  public static class ListenerExtension extends JUnitRunNotifierResultsListener {
+    public ListenerExtension(RunNotifier notifier, Class<?> mainClass) {
+      super(notifier, mainClass);
+    }
+
+    @Override
+    public void announceNumberTestsToRun(int testsToRun) {
+      super.announceNumberTestsToRun(testsToRun);
+    }
+
+    @Override
+    public void unableToStartTestSystem(String testSystemName, Throwable cause) throws IOException {
+      super.unableToStartTestSystem(testSystemName, cause);
+    }
+
+    @Override
+    public void testStarted(WikiTestPage test) {
+      super.testStarted(test);
+    }
+
+    @Override
+    public void testComplete(WikiTestPage test, TestSummary testSummary) {
+      super.testComplete(test, testSummary);
+    }
+
+    @Override
+    public void testSystemStopped(TestSystem testSystem, Throwable cause) {
+      super.testSystemStopped(testSystem, cause);
     }
   }
 }

--- a/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
+++ b/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
@@ -24,8 +24,8 @@ public class FitNesseRunnerExtensionTest {
     }
 
     @Override
-    protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner) {
-      testRunner.addTestSystemListener(new ListenerExtension(notifier, getTestClass().getJavaClass()));
+    protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
+      testRunner.addTestSystemListener(new ListenerExtension(notifier, suiteClass));
     }
 
     @Override


### PR DESCRIPTION
Pass information on test system exceptions to jUnit's RunNotifier, also reporting if tests were skipped because of this, #714.
Furthermore allow subclasses of FitNesseRunner to control which listeners are used in a test run.
