### PR TITLE
content -H option -- shows subWiki page's help text as title in TOC and ...

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ContentsUsage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ContentsUsage/content.txt
@@ -6,6 +6,8 @@ Use !contents to list all or some of the child pages of the current page along w
     -f   ...show suite filters--define FILTER_TOC {true} for global;
     -g   ...show graceful names in the list--define REGRACE_TOC {true} for global;
     -h   ...show help property text--define HELP_TOC {true} for global;
+    -H   ...show help property text as TOC title, and show page name using small
+              letters--define HELP_INSTEAD_OF_TITLE_TOC {true} for global
     -p   ...show property suffixes--define PROPERTY_TOC {true} for global;
               defaults:  Suite(*), Test(+), Imported(@), Symbolic(>), Skip(-)
               define PROPERTY_CHARACTERS {*+@>-} to change.}}}

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/content.txt
@@ -42,9 +42,7 @@
 !|Response Examiner.|
 |type|pattern|matches?|
 |contents|a href="ParentPage.FirstChild"[\s\w="]+>First Child's help</a|true|
-|contents|span class="pageHelp">: FirstChild</span|true|
 |contents|a href="ParentPage.SecondChild"[\s\w="]+>Second Child's help</a|true|
-|contents|span class="pageHelp">: SecondChild</span|true|
 #-------------------------------------------------
 !3 Implicitly Request Help Text Suffix via Variable
 '''First create the parent page.'''
@@ -67,6 +65,4 @@
 !|Response Examiner.|
 |type|pattern|matches?|
 |contents|a href="ParentPage.FirstChild"[\s\w="]+>First Child's help</a|true|
-|contents|span class="pageHelp">: FirstChild</span|true|
 |contents|a href="ParentPage.SecondChild"[\s\w="]+>Second Child's help</a|true|
-|contents|span class="pageHelp">: SecondChild</span|true|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/content.txt
@@ -1,0 +1,72 @@
+!3 !-!contents-! with Help Text Option Instead of Title
+
+!include -seamless ContentsUsage
+#-------------------------------------------------
+!3 Test Rollover Help
+'''First create the parent page.'''
+-|script|
+|start|Page Builder|
+|line|I'm the parent|
+|line|!-!contents-!|
+|page|!-ParentPage-!|
+
+!include ContentsTestsIncludeWithHelp
+
+'''Then request the parent page.'''
+|Response Requester.|
+|uri|valid?|contents?|
+|!-ParentPage-!|true||
+
+'''...and examine the requested page to insure rollover help text exists'''
+!|Response Examiner.|
+|type|pattern|matches?|
+|contents|a href="ParentPage.FirstChild"[\s\w="]+ title="First Child's help">FirstChild</a|true|
+|contents|a href="ParentPage.SecondChild"[\s\w="]+ title="Second Child's help">SecondChild</a|true|
+#-------------------------------------------------
+!3 Explicitly Request Help Text Suffix
+'''First create the parent page.'''
+-|script|
+|start|Page Builder|
+|line|I'm also the parent|
+|line|!-!contents -H-!|
+|page|!-ParentPage-!|
+
+!include ContentsTestsIncludeWithHelp
+
+'''Then request the parent page.'''
+|Response Requester.|
+|uri|valid?|contents?|
+|!-ParentPage-!|true||
+
+'''...and examine the requested page to insure help text is visible'''
+!|Response Examiner.|
+|type|pattern|matches?|
+|contents|a href="ParentPage.FirstChild"[\s\w="]+>First Child's help</a|true|
+|contents|span class="pageHelp">: FirstChild</span|true|
+|contents|a href="ParentPage.SecondChild"[\s\w="]+>Second Child's help</a|true|
+|contents|span class="pageHelp">: SecondChild</span|true|
+#-------------------------------------------------
+!3 Implicitly Request Help Text Suffix via Variable
+'''First create the parent page.'''
+-|script|
+|start|Page Builder|
+|line|I'm also the parent|
+|line|!-!define HELP_INSTEAD_OF_TITLE_TOC {true}-!|
+|line|!-!contents-!|
+|line|!-!define HELP_INSTEAD_OF_TITLE_TOC {false}-!|
+|page|!-ParentPage-!|
+
+!include ContentsTestsIncludeWithHelp
+
+'''Then request the parent page.'''
+|Response Requester.|
+|uri|valid?|contents?|
+|!-ParentPage-!|true||
+
+'''...and examine the requested page to insure help text is visible'''
+!|Response Examiner.|
+|type|pattern|matches?|
+|contents|a href="ParentPage.FirstChild"[\s\w="]+>First Child's help</a|true|
+|contents|span class="pageHelp">: FirstChild</span|true|
+|contents|a href="ParentPage.SecondChild"[\s\w="]+>Second Child's help</a|true|
+|contents|span class="pageHelp">: SecondChild</span|true|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestContentsHelpInsteadOfTitle/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+<saveId>1224982407810</saveId>
+<ticketId>-6939253104715124315</ticketId>
+</properties>

--- a/src/fitnesse/wikitext/parser/Contents.java
+++ b/src/fitnesse/wikitext/parser/Contents.java
@@ -6,6 +6,7 @@ import fitnesse.html.HtmlUtil;
 public class Contents extends SymbolType implements Rule, Translation {
     public static final String FILTER_TOC = "FILTER_TOC";
     public static final String HELP_TOC = "HELP_TOC";
+    public static final String HELP_INSTEAD_OF_TITLE_TOC = "HELP_INSTEAD_OF_TITLE_TOC";
     public static final String MORE_SUFFIX_DEFAULT = " ...";
     public static final String MORE_SUFFIX_TOC = "MORE_SUFFIX_TOC";
     public static final String PROPERTY_TOC = "PROPERTY_TOC";
@@ -29,7 +30,7 @@ public class Contents extends SymbolType implements Rule, Translation {
         }
 
         current.evaluateVariables(
-                new String[] {HELP_TOC, REGRACE_TOC, PROPERTY_TOC, FILTER_TOC, MORE_SUFFIX_TOC, PROPERTY_CHARACTERS},
+                new String[] {HELP_TOC, HELP_INSTEAD_OF_TITLE_TOC, REGRACE_TOC, PROPERTY_TOC, FILTER_TOC, MORE_SUFFIX_TOC, PROPERTY_CHARACTERS},
                 parser.getVariableSource());
 
         return new Maybe<Symbol>(current);

--- a/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
@@ -65,6 +65,10 @@ public class ContentsItemBuilder {
             if (hasOption("-h", Contents.HELP_TOC)) {
                 listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + help));
             }
+            else if (hasOption("-H", Contents.HELP_INSTEAD_OF_TITLE_TOC)) {
+                link.use(help);
+                listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + buildBody(page)));
+            }
             else {
                 link.addAttribute("title", help);
             }

--- a/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/parser/ContentsItemBuilder.java
@@ -67,7 +67,6 @@ public class ContentsItemBuilder {
             }
             else if (hasOption("-H", Contents.HELP_INSTEAD_OF_TITLE_TOC)) {
                 link.use(help);
-                listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + buildBody(page)));
             }
             else {
                 link.addAttribute("title", help);


### PR DESCRIPTION
...shows subWiki page's name with small letters (i.e. swaps subWiki page's name and help text in TOC)

Main reason - to let make titles in TOC contain pieces of text, that are not allowed in page name (i.e. non-ASCII chars).