### PR TITLE
fixes #698: tag filtering is case insensitive

### DIFF
--- a/src/fitnesse/testrunner/SuiteFilter.java
+++ b/src/fitnesse/testrunner/SuiteFilter.java
@@ -16,6 +16,9 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import org.apache.commons.lang.StringUtils;
 
+import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang.StringUtils.trim;
+
 public class SuiteFilter {
   private static final Logger LOG = Logger.getLogger(SuiteFilter.class.getName());
 
@@ -158,9 +161,8 @@ public class SuiteFilter {
     }
 
     private boolean checkIfAllQueryTagsExist(String[] testTags) {
-      List<String> testTagList = Arrays.asList(testTags);
       for (String queryTag : tags) {
-        if (!testTagList.contains(queryTag)) {
+        if (!containsTag(testTags, queryTag)) {
           return false;
         }
       }
@@ -168,14 +170,25 @@ public class SuiteFilter {
     }
 
     private boolean checkIfAnyTestTagMatchesAnyQueryTag(String[] testTags) {
-      for (String testTag : testTags) {
-        for (String queryTag : tags) {
-          if (testTag.equalsIgnoreCase(queryTag)) {
-            return true;
-          }
+      for (String queryTag : tags) {
+        if (containsTag(testTags, queryTag)) {
+          return true;
         }
       }
       return false;
+    }
+
+    private boolean containsTag(String[] testTags, String queryTag) {
+      for (String testTag: testTags) {
+        if (tagsMatch(queryTag, testTag)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private boolean tagsMatch(String queryTag, String testTag) {
+      return equalsIgnoreCase(trim(testTag), trim(queryTag));
     }
   }
 }

--- a/test/fitnesse/testrunner/SuiteFilterTest.java
+++ b/test/fitnesse/testrunner/SuiteFilterTest.java
@@ -189,4 +189,34 @@ public class SuiteFilterTest {
     SuiteFilter filter = new SuiteFilter(null, "bad", "good, better", "FirstTest");
     assertEquals("matches all of 'good, better' & doesn't match 'bad' & starts with test 'FirstTest'", filter.toString());
   }
+
+  @Test
+  public void testChecksNotMatchFilterWithInvalidTagSuiteIsCaseInsensitive() throws Exception {
+    SuiteFilter filter = new SuiteFilter(null, "BaD, notsobad", "",  null);
+
+    WikiPage failSuite = addTestPage(root, "FailSuite", "Bad Test");
+    PageData data = failSuite.getData();
+    data.setAttribute(PageData.PropertySUITES, "bad");
+    data.setAttribute("Suite");
+    failSuite.commit(data);
+
+    assertFalse(filter.getFilterForTestsInSuite(failSuite).hasMatchingTests());
+  }
+
+  @Test
+  public void testTestRequiresAllTagsWithIntersectIsCaseInsensitive() throws Exception {
+    SuiteFilter filter = new SuiteFilter(null, null, "Good, beTTer",  "");
+
+    WikiPage goodTest = addTestPage(root, "GoodTest", "Good Test");
+    PageData data = goodTest.getData();
+    data.setAttribute(PageData.PropertySUITES, "good, better, best");
+    goodTest.commit(data);
+    assertTrue(filter.isMatchingTest(goodTest));
+
+    WikiPage notGoodTest = addTestPage(root, "NotGoodTest", "Not Good Test");
+    PageData data2 = notGoodTest.getData();
+    data2.setAttribute(PageData.PropertySUITES, "good, bad");
+    notGoodTest.commit(data2);
+    assertFalse(filter.isMatchingTest(notGoodTest));
+  }
 }


### PR DESCRIPTION
in the original code the tag filter was caseinsentive and with the introduction of the exclude filter this was implemented wrongly

Change-Id: I7ec37f74e5f3015a647651d4f61ae8273d2bf2a7