### PR TITLE
Make SlimExceptionResult recognize message with a newline

### DIFF
--- a/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
+++ b/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
@@ -9,7 +9,7 @@ import fitnesse.testsystems.ExecutionResult;
 import static fitnesse.slim.SlimServer.*;
 
 public class SlimExceptionResult implements ExceptionResult {
-  public static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("message:<<(.*)>>");
+  public static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("^message:<<(.*)>>$", Pattern.DOTALL);
 
   private final String resultKey;
   private final String exceptionValue;

--- a/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
+++ b/src/fitnesse/testsystems/slim/results/SlimExceptionResult.java
@@ -9,7 +9,7 @@ import fitnesse.testsystems.ExecutionResult;
 import static fitnesse.slim.SlimServer.*;
 
 public class SlimExceptionResult implements ExceptionResult {
-  public static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("^message:<<(.*)>>$", Pattern.DOTALL);
+  public static final Pattern EXCEPTION_MESSAGE_PATTERN = Pattern.compile("message:<<(.*)>>", Pattern.DOTALL);
 
   private final String resultKey;
   private final String exceptionValue;

--- a/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
+++ b/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
@@ -1,0 +1,29 @@
+package fitnesse.testsystems.slim.result;
+
+import fitnesse.testsystems.slim.results.SlimExceptionResult;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SlimExceptionResultTest {
+  @Test
+  public void otherExceptionRecognized() {
+    SlimExceptionResult result = new SlimExceptionResult("key", "my normal exception");
+    assertFalse(result.hasMessage());
+    assertNull(result.getMessage());
+  }
+
+  @Test
+  public void messageFound() {
+    SlimExceptionResult result = new SlimExceptionResult("key", "message:<<Bad things>>");
+    assertTrue(result.hasMessage());
+    assertEquals("Bad things", result.getMessage());
+  }
+
+  @Test
+  public void messageWithNewlineFound() {
+    SlimExceptionResult result = new SlimExceptionResult("key", "message:<<Bad things\nhappened>>");
+    assertTrue(result.hasMessage());
+    assertEquals("Bad things\nhappened", result.getMessage());
+  }
+}

--- a/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
+++ b/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
@@ -26,18 +26,4 @@ public class SlimExceptionResultTest {
     assertTrue(result.hasMessage());
     assertEquals("Bad things\nhappened", result.getMessage());
   }
-
-  @Test
-  public void otherMessageWithExtraText() {
-    SlimExceptionResult result = new SlimExceptionResult("key", "message:<<Bad things>>1");
-    assertFalse(result.hasMessage());
-    assertNull(result.getMessage());
-  }
-
-  @Test
-  public void otherMessageWithPrefix() {
-    SlimExceptionResult result = new SlimExceptionResult("key", "2message:<<Bad things>>");
-    assertFalse(result.hasMessage());
-    assertNull(result.getMessage());
-  }
 }

--- a/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
+++ b/test/fitnesse/testsystems/slim/result/SlimExceptionResultTest.java
@@ -26,4 +26,18 @@ public class SlimExceptionResultTest {
     assertTrue(result.hasMessage());
     assertEquals("Bad things\nhappened", result.getMessage());
   }
+
+  @Test
+  public void otherMessageWithExtraText() {
+    SlimExceptionResult result = new SlimExceptionResult("key", "message:<<Bad things>>1");
+    assertFalse(result.hasMessage());
+    assertNull(result.getMessage());
+  }
+
+  @Test
+  public void otherMessageWithPrefix() {
+    SlimExceptionResult result = new SlimExceptionResult("key", "2message:<<Bad things>>");
+    assertFalse(result.hasMessage());
+    assertNull(result.getMessage());
+  }
 }


### PR DESCRIPTION
Fixes #731

Besides allowing newlines in the message it also ensures that the pattern matches the whole of the exception text (i.e. the exception text should not have more content)