### PR TITLE
Improved slim hash handling

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestCustomConverter/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestCustomConverter/content.txt
@@ -1,0 +1,27 @@
+We check whether a custom converter for lists can be used to change how lists are returned to the wiki.
+
+Whether a converter is applied to a method's result depends on its declared return type:
+
+ * List (exactly, no sub-interface or class implementing it): converter is '''not applied''' (this is needed for some Slim tables, such as !-QueryTable-!).
+ * All return types: converter is applied, based on the actual class of the object returned, or on its declared type when !style_code[null] is returned 
+
+
+|import            |
+|fitnesse.slim.test|
+
+|script   |!-TestSlimWithConverter-!|
+|check    |get object     |[a, b, c]|
+|check    |get list       |[a, b, c]|
+|check    |get array list |[a, b, c]|
+|same list|[a, b, c]                |
+|set list converter                 |
+|check    |get object     |{a, b, c}|
+|check    |get list       |[a, b, c]|
+|check    |get array list |{a, b, c}|
+|same list|{a, b, c}                |
+|same list|[a, b, c]                |
+|remove list converter              |
+|check    |get object     |[a, b, c]|
+|check    |get list       |[a, b, c]|
+|check    |get array list |[a, b, c]|
+|same list|[a, b, c]                |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestCustomConverter/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestCustomConverter/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupHashTable/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupHashTable/content.txt
@@ -1,4 +1,4 @@
-Hash Tables are collections of name-value pairs that can be passed as arguments into test fixtures.  They render as tables.  !-DoFixture-! will decode a name-value pair table into a true hashtable.
+Hash Tables are collections of name-value pairs that can be passed as arguments into test fixtures.  They render as tables.  !-DoFixture-! will decode a name-value pair table into a true hashtable. Java_Slim and Ruby_Slim will both convert this HTML string into a Map<String,String> (or a hash in the case of Ruby)
 
 Any text enclosed in '''!-!{-!''' and '''}''' will be treated as a Hash Table.
 
@@ -8,7 +8,7 @@ Any text enclosed in '''!-!{-!''' and '''}''' will be treated as a Hash Table.
 The key name must be plain text, but the value can be any reasonable wiki construct.
 
 |!c '''Markup Text'''|!c '''Displays as'''|
-|!-!{fname:''Bob'', lname:''Martin'', today:!today}-!|!{fname:''Bob'', lname:''Martin'', today:!today}|
+|!-!{fname:''Bob'', lname:''Martin'', today:!today, hash:!{fname:Bob, lname:Martin, dob:5-Dec-1952}}-!|!{fname:''Bob'', lname:''Martin'', today:!today, hash:!{fname:Bob, lname:Martin, dob:5-Dec-1952}}|
 
 
 !3 Syntax issues.

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/CustomTypes/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/CustomTypes/content.txt
@@ -15,4 +15,9 @@ public interface Converter {
 
 Then, in the constructor of first fixture to uses that type simply put the following line of code: {{{fitnesse.slim.converters.ConverterRegistry.addConverter(MyClass.class, new MyClassConverter())}}}
 
+'''Please note''' the application of converters to methods returning !style_code[List]s is special: whether a converter is applied to a method's result depends on its ''declared'' return type:
+ * List (exactly, no sub-interface or class implementing it): converter is '''not applied''' (this is needed for some Slim tables, such as !-QueryTable-!).
+ * All return types: converter is applied, based on the actual class of the object returned, or on its declared type when !style_code[null] is returned 
+
+
 The technique for other language platforms should be similar to this.  Check the documentation of the Slim port for your platform. 

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/CustomTypes/properties.xml
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/CustomTypes/properties.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
-	<saveId>1232745959476</saveId>
-	<ticketId>4415644922513391702</ticketId>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+<saveId>1232745959476</saveId>
+<ticketId>4415644922513391702</ticketId>
 </properties>

--- a/src/fitnesse/slim/MethodExecutionResult.java
+++ b/src/fitnesse/slim/MethodExecutionResult.java
@@ -3,6 +3,7 @@ package fitnesse.slim;
 import java.util.List;
 
 import fitnesse.slim.converters.ConverterRegistry;
+import fitnesse.slim.converters.ElementConverterHelper;
 
 public class MethodExecutionResult {
   private static class NoMethod extends MethodExecutionResult {
@@ -92,7 +93,7 @@ public class MethodExecutionResult {
     if (value == null)
       return "null";
     else
-      return value.toString();
+      return ElementConverterHelper.elementToString(value);
   }
 
   public boolean hasMethod() {

--- a/src/fitnesse/slim/MethodExecutionResult.java
+++ b/src/fitnesse/slim/MethodExecutionResult.java
@@ -77,7 +77,7 @@ public class MethodExecutionResult {
   }
 
   public Object returnValue() {
-    if (List.class.isAssignableFrom(type) && value instanceof List) {
+    if (type == List.class && value instanceof List) {
       return value;
     } else {
       return toString();

--- a/src/fitnesse/slim/MethodExecutionResult.java
+++ b/src/fitnesse/slim/MethodExecutionResult.java
@@ -77,7 +77,7 @@ public class MethodExecutionResult {
   }
 
   public Object returnValue() {
-    if (type == List.class && value instanceof List) {
+    if (List.class.isAssignableFrom(type) && value instanceof List) {
       return value;
     } else {
       return toString();

--- a/src/fitnesse/slim/MethodExecutor.java
+++ b/src/fitnesse/slim/MethodExecutor.java
@@ -37,6 +37,10 @@ public abstract class MethodExecutor {
     Object[] convertedArgs = convertArgs(method, args);
     Object retval = callMethod(instance, method, convertedArgs);
     Class<?> retType = method.getReturnType();
+    if (retval != null && !retType.isPrimitive()) {
+      Class<?> actualClass = retval.getClass();
+      retType = actualClass;
+    }
     return new MethodExecutionResult(retval, retType);
   }
 

--- a/src/fitnesse/slim/MethodExecutor.java
+++ b/src/fitnesse/slim/MethodExecutor.java
@@ -37,10 +37,6 @@ public abstract class MethodExecutor {
     Object[] convertedArgs = convertArgs(method, args);
     Object retval = callMethod(instance, method, convertedArgs);
     Class<?> retType = method.getReturnType();
-    if (retval != null && !retType.isPrimitive()) {
-      Class<?> actualClass = retval.getClass();
-      retType = actualClass;
-    }
     return new MethodExecutionResult(retval, retType);
   }
 

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -56,6 +56,21 @@ public class ConverterRegistry {
     if (converters.containsKey(clazz)) {
       return (Converter<T>) converters.get(clazz);
     }
+    // use converter for superclass set in registry
+    Class<?> superclass = clazz.getSuperclass();
+    while (superclass != null && !Object.class.equals(superclass)) {
+      if (converters.containsKey(superclass)) {
+        return (Converter<T>) converters.get(superclass);
+      }
+      superclass = superclass.getSuperclass();
+    }
+    // use converter for implemented interface set in registry
+    Class<?>[] interfaces = clazz.getInterfaces();
+    for (Class<?> interf : interfaces) {
+      if (converters.containsKey(interf)) {
+        return (Converter<T>) converters.get(interf);
+      }
+    }
 
     //use property editor
     PropertyEditor pe = PropertyEditorManager.findEditor(clazz);

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -117,6 +117,17 @@ public class ConverterRegistry {
         }
       }
     }
+    if (converterForInterface == null) {
+      Class<?> superclass = clazz.getSuperclass();
+      while (superclass != null && !Object.class.equals(superclass)) {
+        converterForInterface = getConverterForInterface(superclass);
+        if (converterForInterface != null) {
+          break;
+        }
+        superclass = superclass.getSuperclass();
+      }
+
+    }
     return converterForInterface;
   }
 

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -10,6 +10,7 @@ import fitnesse.slim.Converter;
 public class ConverterRegistry {
 
   private static final Map<Class<?>, Converter<?>> converters = new HashMap<Class<?>, Converter<?>>();
+  private static Converter<Object> defaultConverter = new DefaultConverter();
 
   static {
     addStandardConverters();
@@ -81,14 +82,14 @@ public class ConverterRegistry {
     //for array, use generic array converter
     if (clazz.isArray()) {
       Class<?> componentType = clazz.getComponentType();
-      Converter<?> converterForClass = getConverterForClassOrStringConverter(componentType);
+      Converter<?> converterForClass = getConverterForClassOrDefaultConverter(componentType);
       return new GenericArrayConverter(componentType, converterForClass);
     }
 
     //for collection, use generic collection converter
     if (Collection.class.isAssignableFrom(clazz)) {
       Class<?> componentType = typedClazz != null ? (Class<?>) typedClazz.getActualTypeArguments()[0] : String.class;
-      Converter<?> converterForClass = getConverterForClassOrStringConverter(componentType);
+      Converter<?> converterForClass = getConverterForClassOrDefaultConverter(componentType);
       return new GenericCollectionConverter(clazz, converterForClass);
     }
 
@@ -130,10 +131,10 @@ public class ConverterRegistry {
   /*
    * PRIVATE
    */
-  public static Converter<?> getConverterForClassOrStringConverter(Class<?> clazz) {
+  public static Converter<?> getConverterForClassOrDefaultConverter(Class<?> clazz) {
     Converter<?> converter = getConverterForClass(clazz);
     if (converter == null) {
-      converter = getConverterForClass(String.class);
+      converter = defaultConverter;
     }
     return converter;
   }

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -136,6 +136,10 @@ public class ConverterRegistry {
     converters.put(clazz, converter);
   }
 
+  public static void removeConverter(Class<?> clazz) {
+    converters.remove(clazz);
+  }
+
   public static Map<Class<?>, Converter<?>> getConverters() {
     return Collections.unmodifiableMap(converters);
   }

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -16,6 +16,11 @@ public class ConverterRegistry {
     addStandardConverters();
   }
 
+  public static void resetToStandardConverters() {
+    converters.clear();
+    addStandardConverters();
+  }
+
   protected static void addStandardConverters() {
     addConverter(void.class, new VoidConverter());
 

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -98,7 +98,8 @@ public class ConverterRegistry {
       return new GenericCollectionConverter(clazz, converterForClass);
     }
 
-    return null;
+    // last resort, see if there is a converter for Object
+    return (Converter<T>) converters.get(Object.class);
   }
 
   public static <T> void addConverter(Class<? extends T> clazz, Converter<T> converter) {

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -116,17 +116,18 @@ public class ConverterRegistry {
           break;
         }
       }
-    }
-    if (converterForInterface == null) {
-      Class<?> superclass = clazz.getSuperclass();
-      while (superclass != null && !Object.class.equals(superclass)) {
-        converterForInterface = getConverterForInterface(superclass);
-        if (converterForInterface != null) {
-          break;
-        }
-        superclass = superclass.getSuperclass();
-      }
 
+      if (converterForInterface == null) {
+        Class<?> superclass = clazz.getSuperclass();
+        while (superclass != null && !Object.class.equals(superclass)) {
+          converterForInterface = getConverterForInterface(superclass);
+          if (converterForInterface != null) {
+            break;
+          }
+          superclass = superclass.getSuperclass();
+        }
+
+      }
     }
     return converterForInterface;
   }

--- a/src/fitnesse/slim/converters/DefaultConverter.java
+++ b/src/fitnesse/slim/converters/DefaultConverter.java
@@ -1,0 +1,15 @@
+package fitnesse.slim.converters;
+
+import fitnesse.slim.Converter;
+
+public class DefaultConverter implements Converter<Object> {
+  @Override
+  public String toString(Object o) {
+    return o == null ? NULL_VALUE : o.toString();
+  }
+
+  @Override
+  public Object fromString(String arg) {
+    return arg;
+  }
+}

--- a/src/fitnesse/slim/converters/ElementConverterHelper.java
+++ b/src/fitnesse/slim/converters/ElementConverterHelper.java
@@ -3,15 +3,15 @@ package fitnesse.slim.converters;
 import fitnesse.slim.Converter;
 
 public class ElementConverterHelper {
-  public static String elementToString(Object cellValue) {
+  public static String elementToString(Object elementValue) {
     String valueToAdd = "null";
-    if (cellValue != null) {
-      Converter converter = ConverterRegistry.getConverterForClass(cellValue.getClass());
+    if (elementValue != null) {
+      Converter converter = ConverterRegistry.getConverterForClass(elementValue.getClass());
       String convertedValue;
       if (converter == null) {
-        convertedValue = cellValue.toString();
+        convertedValue = elementValue.toString();
       } else {
-        convertedValue = converter.toString(cellValue);
+        convertedValue = converter.toString(elementValue);
       }
       if (convertedValue != null) {
         valueToAdd = convertedValue;

--- a/src/fitnesse/slim/converters/ElementConverterHelper.java
+++ b/src/fitnesse/slim/converters/ElementConverterHelper.java
@@ -1,0 +1,22 @@
+package fitnesse.slim.converters;
+
+import fitnesse.slim.Converter;
+
+public class ElementConverterHelper {
+  public static String elementToString(Object cellValue) {
+    String valueToAdd = "null";
+    if (cellValue != null) {
+      Converter converter = ConverterRegistry.getConverterForClass(cellValue.getClass());
+      String convertedValue;
+      if (converter == null) {
+        convertedValue = cellValue.toString();
+      } else {
+        convertedValue = converter.toString(cellValue);
+      }
+      if (convertedValue != null) {
+        valueToAdd = convertedValue;
+      }
+    }
+    return valueToAdd;
+  }
+}

--- a/src/fitnesse/slim/converters/GenericArrayConverter.java
+++ b/src/fitnesse/slim/converters/GenericArrayConverter.java
@@ -4,9 +4,8 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
-import fitnesse.util.StringUtils;
-
 import fitnesse.slim.Converter;
+import fitnesse.util.StringUtils;
 
 public class GenericArrayConverter<T> implements Converter<Object> {
   private final Class<T> componentClass;
@@ -25,10 +24,21 @@ public class GenericArrayConverter<T> implements Converter<Object> {
     int size = Array.getLength(array);
     List<String> ret = new ArrayList<String>(size);
     for (int i = 0; i < size; i++) {
-      ret.add(componentConverter.toString((T) Array.get(array, i)));
+      ret.add(getElementString(array, i));
     }
 
     return ret.toString();
+  }
+
+  private String getElementString(Object array, int i) {
+    T element = (T) Array.get(array, i);
+    String result;
+    if (element == null) {
+      result = componentConverter.toString(element);
+    } else {
+      result = ElementConverterHelper.elementToString(element);
+    }
+    return result;
   }
 
   public Object fromString(String arg) {

--- a/src/fitnesse/slim/converters/GenericCollectionConverter.java
+++ b/src/fitnesse/slim/converters/GenericCollectionConverter.java
@@ -20,6 +20,7 @@ public class GenericCollectionConverter<T, C extends Collection<T>> implements C
     DEFAULT_COLLECTION_IMPL.put(List.class, ArrayList.class);
     DEFAULT_COLLECTION_IMPL.put(Set.class, HashSet.class);
     DEFAULT_COLLECTION_IMPL.put(Queue.class, PriorityQueue.class);
+    DEFAULT_COLLECTION_IMPL.put(Collection.class, ArrayList.class);
   }
 
   private final Class<C> collectionClass;

--- a/src/fitnesse/slim/converters/GenericCollectionConverter.java
+++ b/src/fitnesse/slim/converters/GenericCollectionConverter.java
@@ -10,9 +10,8 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 
-import fitnesse.util.StringUtils;
-
 import fitnesse.slim.Converter;
+import fitnesse.util.StringUtils;
 
 public class GenericCollectionConverter<T, C extends Collection<T>> implements Converter<C> {
 
@@ -42,9 +41,19 @@ public class GenericCollectionConverter<T, C extends Collection<T>> implements C
     int size = collection.size();
     List<String> ret = new ArrayList<String>(size);
     for (T item : collection) {
-      ret.add(componentConverter.toString(item));
+      ret.add(getElementString(item));
     }
     return ListConverterHelper.toString(ret);
+  }
+
+  private String getElementString(T item) {
+    String result;
+    if (item == null) {
+      result = componentConverter.toString(item);
+    } else {
+      result = ElementConverterHelper.elementToString(item);
+    }
+    return result;
   }
 
   public C fromString(String arg) {

--- a/src/fitnesse/slim/converters/ListConverterHelper.java
+++ b/src/fitnesse/slim/converters/ListConverterHelper.java
@@ -2,11 +2,14 @@ package fitnesse.slim.converters;
 
 import java.util.List;
 
+import fitnesse.slim.Converter;
 import fitnesse.util.StringUtils;
 
 final class ListConverterHelper {
 
   static String toString(List<?> list) {
+    if (list == null)
+      return Converter.NULL_VALUE;
     return list.toString();
   }
 

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -41,20 +41,22 @@ public class MapConverter implements Converter<Map> {
       keyCell.addAttribute("class", "hash_key");
       row.add(keyCell);
 
-      Object entryValue = entry.getValue();
       HtmlTag valueCell = new HtmlTag("td");
-      Converter converter;
-      if (entryValue != null) {
-        converter = ConverterRegistry.getConverterForClassOrStringConverter(entryValue.getClass());
-        String convertedValue = converter.toString(entryValue);
-        valueCell.add(convertedValue.trim());
-      } else {
-        valueCell.add("null");
-      }
+      addValueContent(valueCell, entry.getValue());
       valueCell.addAttribute("class", "hash_value");
       row.add(valueCell);
     }
     return table;
+  }
+
+  protected void addValueContent(HtmlTag valueCell, Object entryValue) {
+    if (entryValue != null) {
+      Converter converter = ConverterRegistry.getConverterForClassOrStringConverter(entryValue.getClass());
+      String convertedValue = converter.toString(entryValue);
+      valueCell.add(convertedValue.trim());
+    } else {
+      valueCell.add("null");
+    }
   }
 
   @Override

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -43,10 +43,13 @@ public class MapConverter implements Converter<Map> {
 
       Object entryValue = entry.getValue();
       HtmlTag valueCell = new HtmlTag("td");
-      if (entryValue instanceof Map) {
-        valueCell.add(createTag((Map<?, ?>) entryValue, depth + 1));
+      Converter converter;
+      if (entryValue != null) {
+        converter = ConverterRegistry.getConverterForClassOrStringConverter(entryValue.getClass());
+        String convertedValue = converter.toString(entryValue);
+        valueCell.add(convertedValue.trim());
       } else {
-        valueCell.add(entryValue.toString().trim());
+        valueCell.add("null");
       }
       valueCell.addAttribute("class", "hash_value");
       row.add(valueCell);

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -40,8 +40,8 @@ public class MapConverter implements Converter<Map> {
       HtmlTag row = new HtmlTag("tr");
       row.addAttribute("class", "hash_row");
       table.add(row);
-      String key = entry.getKey().toString();
-      HtmlTag keyCell = new HtmlTag("td", key.trim());
+      HtmlTag keyCell = new HtmlTag("td");
+      addCellContent(keyCell, entry.getKey());
       keyCell.addAttribute("class", "hash_key");
       row.add(keyCell);
 

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -54,20 +54,8 @@ public class MapConverter implements Converter<Map> {
   }
 
   protected void addCellContent(HtmlTag valueCell, Object cellValue) {
-    String valueToAdd = "null";
-    if (cellValue != null) {
-      Converter converter = ConverterRegistry.getConverterForClass(cellValue.getClass());
-      String convertedValue;
-      if (converter == null) {
-        convertedValue = cellValue.toString();
-      } else {
-        convertedValue = converter.toString(cellValue);
-      }
-      if (convertedValue != null) {
-        valueToAdd = convertedValue.trim();
-      }
-    }
-    valueCell.add(valueToAdd);
+    String valueToAdd = ElementConverterHelper.elementToString(cellValue);
+    valueCell.add(valueToAdd.trim());
   }
 
   @Override

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -23,10 +23,16 @@ public class MapConverter implements Converter<Map> {
 
   @Override
   public String toString(Map hash) {
+    HtmlTag table = createTag(hash, 0);
+
+    return table.html().trim();
+  }
+
+  protected HtmlTag createTag(Map<?, ?> hash, int depth) {
     // Use HtmlTag, same as we do for fitnesse.wikitext.parser.HashTable.
     HtmlTag table = new HtmlTag("table");
     table.addAttribute("class", "hash_table");
-    for (Map.Entry<?, ?> entry : ((Map<?, ?>) hash).entrySet()) {
+    for (Map.Entry<?, ?> entry : hash.entrySet()) {
       HtmlTag row = new HtmlTag("tr");
       row.addAttribute("class", "hash_row");
       table.add(row);
@@ -35,12 +41,17 @@ public class MapConverter implements Converter<Map> {
       keyCell.addAttribute("class", "hash_key");
       row.add(keyCell);
 
-      String value = entry.getValue().toString();
-      HtmlTag valueCell = new HtmlTag("td", value.trim());
+      Object entryValue = entry.getValue();
+      HtmlTag valueCell = new HtmlTag("td");
+      if (entryValue instanceof Map) {
+        valueCell.add(createTag((Map<?, ?>) entryValue, depth + 1));
+      } else {
+        valueCell.add(entryValue.toString().trim());
+      }
       valueCell.addAttribute("class", "hash_value");
       row.add(valueCell);
     }
-    return table.html().trim();
+    return table;
   }
 
   @Override

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -46,26 +46,28 @@ public class MapConverter implements Converter<Map> {
       row.add(keyCell);
 
       HtmlTag valueCell = new HtmlTag("td");
-      addValueContent(valueCell, entry.getValue());
+      addCellContent(valueCell, entry.getValue());
       valueCell.addAttribute("class", "hash_value");
       row.add(valueCell);
     }
     return table;
   }
 
-  protected void addValueContent(HtmlTag valueCell, Object entryValue) {
-    if (entryValue != null) {
-      Converter converter = ConverterRegistry.getConverterForClass(entryValue.getClass());
+  protected void addCellContent(HtmlTag valueCell, Object cellValue) {
+    String valueToAdd = "null";
+    if (cellValue != null) {
+      Converter converter = ConverterRegistry.getConverterForClass(cellValue.getClass());
       String convertedValue;
       if (converter == null) {
-        convertedValue = entryValue.toString();
+        convertedValue = cellValue.toString();
       } else {
-        convertedValue = converter.toString(entryValue);
+        convertedValue = converter.toString(cellValue);
       }
-      valueCell.add(convertedValue.trim());
-    } else {
-      valueCell.add("null");
+      if (convertedValue != null) {
+        valueToAdd = convertedValue.trim();
+      }
     }
+    valueCell.add(valueToAdd);
   }
 
   @Override

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -23,6 +23,10 @@ public class MapConverter implements Converter<Map> {
 
   @Override
   public String toString(Map hash) {
+    if (hash == null) {
+      return NULL_VALUE;
+    }
+
     HtmlTag table = createTag(hash, 0);
 
     return table.html().trim();

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -51,8 +51,13 @@ public class MapConverter implements Converter<Map> {
 
   protected void addValueContent(HtmlTag valueCell, Object entryValue) {
     if (entryValue != null) {
-      Converter converter = ConverterRegistry.getConverterForClassOrStringConverter(entryValue.getClass());
-      String convertedValue = converter.toString(entryValue);
+      Converter converter = ConverterRegistry.getConverterForClass(entryValue.getClass());
+      String convertedValue;
+      if (converter == null) {
+        convertedValue = entryValue.toString();
+      } else {
+        convertedValue = converter.toString(entryValue);
+      }
       valueCell.add(convertedValue.trim());
     } else {
       valueCell.add("null");

--- a/src/fitnesse/slim/test/TestSlimWithConverter.java
+++ b/src/fitnesse/slim/test/TestSlimWithConverter.java
@@ -1,0 +1,58 @@
+package fitnesse.slim.test;
+
+import fitnesse.slim.Converter;
+import fitnesse.slim.converters.ConverterRegistry;
+import fitnesse.slim.converters.DefaultConverter;
+import fitnesse.slim.converters.GenericCollectionConverter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestSlimWithConverter {
+    private Converter<List> standardConverter = null;
+
+    public void setListConverter() {
+        standardConverter = ConverterRegistry.getConverterForClass(List.class);
+        ConverterRegistry.addConverter(List.class, new ListConverter());
+    }
+
+    public void removeListConverter() {
+        ConverterRegistry.addConverter(List.class, standardConverter);
+    }
+
+    public Object getObject() {
+        return getArrayList();
+    }
+
+    public List<String> getList() {
+        return getArrayList();
+    }
+
+    public ArrayList<String> getArrayList() {
+        return new ArrayList<String>(Arrays.asList("a", "b", "c"));
+    }
+
+    public boolean sameList(List otherList) {
+        return getList().equals(otherList);
+    }
+
+    private class ListConverter implements Converter<List> {
+        private GenericCollectionConverter<Object, List<Object>> converter;
+        public ListConverter() {
+            converter = new GenericCollectionConverter<Object, List<Object>>(List.class, new DefaultConverter());
+        }
+
+        @Override
+        public String toString(List o) {
+            String s = converter.toString(o);
+            return s.replace("[", "{").replace("]", "}");
+        }
+
+        @Override
+        public List fromString(String arg) {
+            String replace = arg.replace("{", "[").replace("}", "]");
+            return converter.fromString(replace);
+        }
+    }
+}

--- a/test/fitnesse/slim/HashWidgetConversionTest.java
+++ b/test/fitnesse/slim/HashWidgetConversionTest.java
@@ -60,30 +60,32 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
     statementExecutor.create(instance1Id, NestedMapSender.class.getName());
 
     String expected =
-            "<table class=\"hash_table\">\n" +
-                    "\t<tr class=\"hash_row\">\n" +
-                    "\t\t<td class=\"hash_key\">address</td>\n" +
-                    "\t\t<td class=\"hash_value\">1</td>\n" +
-                    "\t</tr>\n" +
-                    "\t<tr class=\"hash_row\">\n" +
-                    "\t\t<td class=\"hash_key\">nestedMap</td>\n" +
-                    "\t\t<td class=\"hash_value\">\n" +
-                    "\t\t\t<table class=\"hash_table\">\n" +
-                    "\t\t\t\t<tr class=\"hash_row\">\n" +
-                    "\t\t\t\t\t<td class=\"hash_key\">name2</td>\n" +
-                    "\t\t\t\t\t<td class=\"hash_value\">Bob2</td>\n" +
-                    "\t\t\t\t</tr>\n" +
-                    "\t\t\t\t<tr class=\"hash_row\">\n" +
-                    "\t\t\t\t\t<td class=\"hash_key\">address2</td>\n" +
-                    "\t\t\t\t\t<td class=\"hash_value\">2</td>\n" +
-                    "\t\t\t\t</tr>\n" +
-                    "\t\t\t</table>\n" +
-                    "\t\t</td>\n" +
-                    "\t</tr>\n" +
-                    "\t<tr class=\"hash_row\">\n" +
-                    "\t\t<td class=\"hash_key\">name</td>\n" +
-                    "\t\t<td class=\"hash_value\">Bob</td>\n" +
-                    "\t</tr>\n" +
+            "<table class=\"hash_table\">" +
+                    "<tr class=\"hash_row\">" +
+                    "<td class=\"hash_key\">address</td>" +
+                    "<td class=\"hash_value\">1</td>" +
+                    "</tr>" +
+                    "<tr class=\"hash_row\">" +
+                    "<td class=\"hash_key\">nestedMap</td>" +
+                    "<td class=\"hash_value\">" +
+                    "<table class=\"hash_table\">" +
+                    "<tr class=\"hash_row\">" +
+                    "<td class=\"hash_key\">name2</td>" +
+                    "<td class=\"hash_value\">Bob2</td>" +
+                    "</tr>" +
+                    "<tr class=\"hash_row\">" +
+                    "<td class=\"hash_key\">address2</td>" +
+                    "<td class=\"hash_value\">2</td>" +
+                    "</tr>" +
+                    "</table>" +
+                    "</td>" +
+                    "</tr>" +
+                    "<tr class=\"hash_row\">" +
+                    "<td class=\"hash_key\">name</td>" +
+                    "<td class=\"hash_value\">Bob</td>" +
+                    "</tr>" +
+                    "<tr class=\"hash_row\"><td class=\"hash_key\">list</td><td class=\"hash_value\">[a, b]</td></tr>" +
+                    "<tr class=\"hash_row\"><td class=\"hash_key\">nullKey</td><td class=\"hash_value\">null</td></tr>" +
                     "</table>";
 
     Object respMap = statementExecutor.call(instance1Id, "getMap");
@@ -103,7 +105,7 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
   private String checkStringResponse(String method, Object resp) {
     assertTrue("Other object than String result from " + method
                 + ": " + resp.getClass().getName(), resp instanceof String);
-    return ((String) resp).replace("\r\n", "\n");
+    return ((String) resp).replace("\r", "").replace("\n", "").replace("\t", "");
   }
 
   public static class NestedMapSender {
@@ -116,6 +118,8 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
       nestedMap.put("address2", 2);
       theMap.put("nestedMap", nestedMap);
       theMap.put("name", "Bob");
+      theMap.put("list", Arrays.asList("a", "b"));
+      theMap.put("nullKey", null);
     }
 
     public Map<String, Object> getMap() {

--- a/test/fitnesse/slim/HashWidgetConversionTest.java
+++ b/test/fitnesse/slim/HashWidgetConversionTest.java
@@ -5,8 +5,7 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
 
@@ -27,15 +26,23 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
       theMap = map;
       return true;
     }
-    
+
     public List<Object> query() {
-      List<Object> list = new ArrayList<Object>();
+      return queryAsArrayList();
+    }
+
+    public ArrayList<Object> queryAsArrayList() {
+      ArrayList<Object> list = new ArrayList<Object>();
       // Make the test stable by ordering the keys
       TreeSet<String> orderedKeySet = new TreeSet<String>(theMap.keySet());
       for (String key : orderedKeySet) {
         list.add(Arrays.asList(key, theMap.get(key)));
       }
       return list;
+    }
+
+    public Object queryAsObject() {
+      return queryAsArrayList();
     }
   }
 
@@ -52,6 +59,32 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
   @Override
   protected String mapConstructorClassName() {
     return MapConstructor.class.getName();
+  }
+
+  @Test
+  public void methodsReturningExactlyListShouldNotBeConverteredToStrings() throws Exception {
+    String instance1Id = "a";
+    statementExecutor.create(instance1Id, MapReceptor.class.getName());
+
+    assertEquals("true", statementExecutor.call(instance1Id, "setMap",
+                    "<table>" +
+                    "<tr>" +
+                    "  <td>name</td>" +
+                    "  <td>Bob</td>" +
+                    "</tr>" +
+                    "</table>"));
+
+    Object respQuery = statementExecutor.call(instance1Id, "query");
+    assertNotNull(respQuery);
+    assertTrue(respQuery instanceof List);
+
+    Object respObject = statementExecutor.call(instance1Id, "queryAsObject");
+    String actualQueryObj = checkStringResponse("queryAsObject()", respObject);
+    assertEquals(respQuery.toString(), actualQueryObj);
+
+    Object respArrayList = statementExecutor.call(instance1Id, "queryAsArrayList");
+    String actualArrayList = checkStringResponse("queryAsArrayList()", respArrayList);
+    assertEquals(respQuery.toString(), actualArrayList);
   }
 
   @Test

--- a/test/fitnesse/slim/HashWidgetConversionTest.java
+++ b/test/fitnesse/slim/HashWidgetConversionTest.java
@@ -1,11 +1,12 @@
 package fitnesse.slim;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
 
@@ -51,5 +52,81 @@ public class HashWidgetConversionTest extends HashWidgetConversionTestBase {
   @Override
   protected String mapConstructorClassName() {
     return MapConstructor.class.getName();
+  }
+
+  @Test
+  public void fromTableWithNestedTables_shouldCreateMapWithThreeEntries() throws Exception {
+    String instance1Id = "a";
+    statementExecutor.create(instance1Id, NestedMapSender.class.getName());
+
+    String expected =
+            "<table class=\"hash_table\">\n" +
+                    "\t<tr class=\"hash_row\">\n" +
+                    "\t\t<td class=\"hash_key\">address</td>\n" +
+                    "\t\t<td class=\"hash_value\">1</td>\n" +
+                    "\t</tr>\n" +
+                    "\t<tr class=\"hash_row\">\n" +
+                    "\t\t<td class=\"hash_key\">nestedMap</td>\n" +
+                    "\t\t<td class=\"hash_value\">\n" +
+                    "\t\t\t<table class=\"hash_table\">\n" +
+                    "\t\t\t\t<tr class=\"hash_row\">\n" +
+                    "\t\t\t\t\t<td class=\"hash_key\">name2</td>\n" +
+                    "\t\t\t\t\t<td class=\"hash_value\">Bob2</td>\n" +
+                    "\t\t\t\t</tr>\n" +
+                    "\t\t\t\t<tr class=\"hash_row\">\n" +
+                    "\t\t\t\t\t<td class=\"hash_key\">address2</td>\n" +
+                    "\t\t\t\t\t<td class=\"hash_value\">2</td>\n" +
+                    "\t\t\t\t</tr>\n" +
+                    "\t\t\t</table>\n" +
+                    "\t\t</td>\n" +
+                    "\t</tr>\n" +
+                    "\t<tr class=\"hash_row\">\n" +
+                    "\t\t<td class=\"hash_key\">name</td>\n" +
+                    "\t\t<td class=\"hash_value\">Bob</td>\n" +
+                    "\t</tr>\n" +
+                    "</table>";
+
+    Object respMap = statementExecutor.call(instance1Id, "getMap");
+    String actualMap = checkStringResponse("getMap()", respMap);
+
+    Object respObject = statementExecutor.call(instance1Id, "getMapAsObject");
+    String actualObj = checkStringResponse("getMapAsObject()", respObject);
+
+    Object respLinked = statementExecutor.call(instance1Id, "getLinkedMap");
+    String actualLinked = checkStringResponse("getLinkedMap()", respLinked);
+
+    assertEquals(actualMap, actualLinked);
+    assertEquals(actualMap, actualObj);
+    assertEquals(expected, actualMap);
+  }
+
+  private String checkStringResponse(String method, Object resp) {
+    assertTrue("Other object than String result from " + method
+                + ": " + resp.getClass().getName(), resp instanceof String);
+    return ((String) resp).replace("\r\n", "\n");
+  }
+
+  public static class NestedMapSender {
+    public LinkedHashMap<String, Object> theMap = new LinkedHashMap<String, Object>();
+
+    public NestedMapSender() {
+      theMap.put("address", 1);
+      Map<String, Object> nestedMap = new LinkedHashMap<String, Object>();
+      nestedMap.put("name2", "Bob2");
+      nestedMap.put("address2", 2);
+      theMap.put("nestedMap", nestedMap);
+      theMap.put("name", "Bob");
+    }
+
+    public Map<String, Object> getMap() {
+      return theMap;
+    }
+    public Object getMapAsObject() {
+      return theMap;
+    }
+
+    public LinkedHashMap<String, Object> getLinkedMap() {
+      return theMap;
+    }
   }
 }

--- a/test/fitnesse/slim/converters/BooleanConverterTest.java
+++ b/test/fitnesse/slim/converters/BooleanConverterTest.java
@@ -1,5 +1,6 @@
 package fitnesse.slim.converters;
 
+import fitnesse.slim.Converter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,6 +18,11 @@ public class BooleanConverterTest extends AbstractConverterTest<Boolean, Boolean
   /*
    * TO STRING
    */
+  @Test
+  public void fromNull_shouldCreateNullString() {
+    assertEquals(Converter.NULL_VALUE, converter.toString(null));
+  }
+
   @Test
   public void toString_should_return_true_string_when_value_is_true() {
     Boolean value = Boolean.TRUE;

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -2,6 +2,7 @@ package fitnesse.slim.converters;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -212,6 +213,13 @@ public class ConverterRegistryTest {
     assertTrue(converter instanceof GenericCollectionConverter);
     assertTrue(current instanceof String);
     assertEquals("1", current);
+
+    List<Object> listToConvert = new ArrayList<Object>();
+    listToConvert.add(this);
+    listToConvert.add(new StringBuilderConverter());
+    String converted = converter.toString(listToConvert);
+    Pattern p = Pattern.compile("\\[(.*?),\\s*(.*?)\\]");
+    assertTrue(p.matcher(converted).matches());
   }
 
   /*

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -121,6 +121,7 @@ public class ConverterRegistryTest {
 
   @Test
   public void getConverterForClass_should_return_Object_Converter_as_last_resort() throws SecurityException, NoSuchMethodException {
+    Converter<Object> oldObjectConverter = ConverterRegistry.getConverterForClass(Object.class);
     try {
       ConverterRegistry.addConverter(Object.class, new MyObjectConverter());
 
@@ -130,8 +131,7 @@ public class ConverterRegistryTest {
       assertEquals(MyObjectConverter.class, converter.getClass());
     } finally {
       // cleanup
-      ConverterRegistry.addConverter(Object.class, null);
-      assertNull(ConverterRegistry.getConverterForClass(Object.class));
+      ConverterRegistry.addConverter(Object.class, oldObjectConverter);
     }
   }
 

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -1,10 +1,7 @@
 package fitnesse.slim.converters;
 
 import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.Test;
 
@@ -79,6 +76,59 @@ public class ConverterRegistryTest {
 
     assertTrue(current instanceof GenericArrayConverter);
     assertEquals(Integer.valueOf(1), value2[0]);
+  }
+
+  @Test
+  public void getConverterForClass_should_return_a_MapConverter_when_type_is_typed_map() throws SecurityException, NoSuchMethodException {
+    Class<?> typedClass = MyFixture.class.getMethod("getMap").getReturnType();
+
+    Converter<?> converter = ConverterRegistry.getConverterForClass(typedClass);
+
+    assertNotNull("no converter retunred", converter);
+    assertEquals(MapConverter.class, converter.getClass());
+  }
+
+  @Test
+  public void getConverterForClass_should_return_a_MapConverter_when_type_implements_map() throws SecurityException, NoSuchMethodException {
+    Class<?> typedClass = MyFixture.class.getMethod("getLinkedMap").getReturnType();
+
+    Converter<?> converter = ConverterRegistry.getConverterForClass(typedClass);
+
+    assertNotNull("no converter retunred", converter);
+    assertEquals(MapConverter.class, converter.getClass());
+  }
+
+  @Test
+  public void getConverterForClass_should_return_Converter_when_type_superclass_registered() throws SecurityException, NoSuchMethodException {
+    ConverterRegistry.addConverter(MyFixture.class, new MyFixtureConverter());
+
+    Converter<?> converter = ConverterRegistry.getConverterForClass(MySubFixture.class);
+
+    assertNotNull("no converter retunred", converter);
+    assertEquals(MyFixtureConverter.class, converter.getClass());
+  }
+
+  private static class MyFixture {
+    public Map<String, Object> getMap() {
+      return null;
+    }
+    public LinkedHashMap<String, Object> getLinkedMap() {
+      return null;
+    }
+  }
+
+  private static class MyFixtureConverter implements Converter<MyFixture> {
+    @Override
+    public String toString(MyFixture o) {
+      return null;
+    }
+    @Override
+    public MyFixture fromString(String arg) {
+      return null;
+    }
+  }
+
+  private static class MySubFixture extends MyFixture {
   }
 
   @Test

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -4,6 +4,8 @@ import java.lang.reflect.ParameterizedType;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import fitnesse.slim.Converter;
@@ -12,6 +14,16 @@ import fitnesse.slim.test.AnotherEnum;
 import static org.junit.Assert.*;
 
 public class ConverterRegistryTest {
+
+  @Before
+  public void setUp() {
+    ConverterRegistry.resetToStandardConverters();
+  }
+
+  @AfterClass
+  public static void finalCleanUp() {
+    ConverterRegistry.resetToStandardConverters();
+  }
 
   @Test
   public void getConverters_should_return_several_default_converter() {

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -99,6 +99,16 @@ public class ConverterRegistryTest {
   }
 
   @Test
+  public void getConverterForClass_should_return_a_MapConverter_when_type_implements_map_indirectly() throws SecurityException, NoSuchMethodException {
+    Class<?> typedClass = MyFixture.class.getMethod("getTreeMap").getReturnType();
+
+    Converter<?> converter = ConverterRegistry.getConverterForClass(typedClass);
+
+    assertNotNull("no converter retunred", converter);
+    assertEquals(MapConverter.class, converter.getClass());
+  }
+
+  @Test
   public void getConverterForClass_should_return_Converter_when_type_superclass_registered() throws SecurityException, NoSuchMethodException {
     ConverterRegistry.addConverter(MyFixture.class, new MyFixtureConverter());
 
@@ -129,6 +139,9 @@ public class ConverterRegistryTest {
       return null;
     }
     public LinkedHashMap<String, Object> getLinkedMap() {
+      return null;
+    }
+    public TreeMap<String, Object> getTreeMap() {
       return null;
     }
   }

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -217,8 +217,9 @@ public class ConverterRegistryTest {
     List<Object> listToConvert = new ArrayList<Object>();
     listToConvert.add(this);
     listToConvert.add(new StringBuilderConverter());
+    listToConvert.add(null);
     String converted = converter.toString(listToConvert);
-    Pattern p = Pattern.compile("\\[(.*?),\\s*(.*?)\\]");
+    Pattern p = Pattern.compile("\\[(.*?),\\s*(.*?),\\s*null\\]");
     assertTrue(p.matcher(converted).matches());
   }
 

--- a/test/fitnesse/slim/converters/ConverterRegistryTest.java
+++ b/test/fitnesse/slim/converters/ConverterRegistryTest.java
@@ -108,6 +108,22 @@ public class ConverterRegistryTest {
     assertEquals(MyFixtureConverter.class, converter.getClass());
   }
 
+  @Test
+  public void getConverterForClass_should_return_Object_Converter_as_last_resort() throws SecurityException, NoSuchMethodException {
+    try {
+      ConverterRegistry.addConverter(Object.class, new MyObjectConverter());
+
+      Converter<?> converter = ConverterRegistry.getConverterForClass(ConverterRegistryTest.class);
+
+      assertNotNull("no converter retunred", converter);
+      assertEquals(MyObjectConverter.class, converter.getClass());
+    } finally {
+      // cleanup
+      ConverterRegistry.addConverter(Object.class, null);
+      assertNull(ConverterRegistry.getConverterForClass(Object.class));
+    }
+  }
+
   private static class MyFixture {
     public Map<String, Object> getMap() {
       return null;
@@ -124,6 +140,17 @@ public class ConverterRegistryTest {
     }
     @Override
     public MyFixture fromString(String arg) {
+      return null;
+    }
+  }
+
+  private static class MyObjectConverter implements Converter<Object> {
+    @Override
+    public String toString(Object o) {
+      return null;
+    }
+    @Override
+    public Object fromString(String arg) {
       return null;
     }
   }

--- a/test/fitnesse/slim/converters/GenericArrayConverterTest.java
+++ b/test/fitnesse/slim/converters/GenericArrayConverterTest.java
@@ -1,5 +1,6 @@
 package fitnesse.slim.converters;
 
+import fitnesse.slim.Converter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -14,6 +15,11 @@ public class GenericArrayConverterTest extends AbstractConverterTest<Object, Gen
    * TO STRING
    */
   @Test
+  public void fromNull_shouldCreateNullString() {
+    assertEquals(Converter.NULL_VALUE, converter.toString(null));
+  }
+
+  @Test
   public void toString_should_return_a_formated_string_when_value_is_a_empty_array() {
     Integer[] value = {};
 
@@ -24,11 +30,11 @@ public class GenericArrayConverterTest extends AbstractConverterTest<Object, Gen
 
   @Test
   public void toString_should_return_a_formated_string_when_value_is_a_valid_array() {
-    Integer[] value = { 1, 2, 3 };
+    Integer[] value = { 1, 2, 3, null };
 
     String current = converter.toString(value);
 
-    assertEquals("[1, 2, 3]", current);
+    assertEquals("[1, 2, 3, null]", current);
   }
 
   /*

--- a/test/fitnesse/slim/converters/GenericArrayConverterTest.java
+++ b/test/fitnesse/slim/converters/GenericArrayConverterTest.java
@@ -1,5 +1,7 @@
 package fitnesse.slim.converters;
 
+import java.util.Collections;
+
 import fitnesse.slim.Converter;
 import org.junit.Test;
 
@@ -35,6 +37,17 @@ public class GenericArrayConverterTest extends AbstractConverterTest<Object, Gen
     String current = converter.toString(value);
 
     assertEquals("[1, 2, 3, null]", current);
+  }
+
+  @Test
+  public void toString_should_use_converters_for_element_values() {
+    Object[] value = { 1, Collections.singletonMap("a", "b"), 3, null };
+
+    Converter c = new GenericArrayConverter<Object>(Object.class, new DefaultConverter());
+    String current = c.toString(value);
+
+    assertEquals("[1, <table class=\"hash_table\"> <tr class=\"hash_row\"> <td class=\"hash_key\">a</td> <td class=\"hash_value\">b</td> </tr> </table>, 3, null]",
+            current.replaceAll("\\s+", " "));
   }
 
   /*

--- a/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
+++ b/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import fitnesse.slim.Converter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -19,6 +20,11 @@ public class GenericCollectionConverterTest extends AbstractConverterTest<List<I
    * TO STRING
    */
   @Test
+  public void fromNull_shouldCreateNullString() {
+    assertEquals(Converter.NULL_VALUE, converter.toString(null));
+  }
+
+  @Test
   public void toString_should_return_a_formated_string_when_value_is_a_empty_list() {
     List<Integer> value = new ArrayList<Integer>();
 
@@ -32,10 +38,11 @@ public class GenericCollectionConverterTest extends AbstractConverterTest<List<I
     value.add(1);
     value.add(2);
     value.add(3);
+    value.add(null);
 
     String current = converter.toString(value);
 
-    assertEquals("[1, 2, 3]", current);
+    assertEquals("[1, 2, 3, null]", current);
   }
 
   /*

--- a/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
+++ b/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
@@ -2,6 +2,7 @@ package fitnesse.slim.converters;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,10 +71,32 @@ public class GenericCollectionConverterTest extends AbstractConverterTest<List<I
   }
 
   @Test
+  public void fromString_should_return_an_empty_list_when_value_represent_an_empty_collection() {
+    String value = "[]";
+    GenericCollectionConverter<Integer, Collection<Integer>> collConverter
+            = new GenericCollectionConverter<Integer, Collection<Integer>>(Collection.class, new IntConverter());
+
+    Collection<Integer> current = collConverter.fromString(value);
+
+    assertEquals(0, current.size());
+  }
+
+  @Test
   public void fromString_should_return_an_typed_list_when_value_is_an_valid_list() {
     String value = "[1,2,3]";
 
     List<Integer> current = converter.fromString(value);
+
+    assertEquals(Arrays.asList(new Integer[] { 1, 2, 3 }), current);
+  }
+
+  @Test
+  public void fromString_should_return_an_typed_list_when_value_is_an_valid_collection() {
+    String value = "[1,2,3]";
+    GenericCollectionConverter<Integer, Collection<Integer>> collConverter
+            = new GenericCollectionConverter<Integer, Collection<Integer>>(Collection.class, new IntConverter());
+
+    Collection<Integer> current = collConverter.fromString(value);
 
     assertEquals(Arrays.asList(new Integer[] { 1, 2, 3 }), current);
   }

--- a/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
+++ b/test/fitnesse/slim/converters/GenericCollectionConverterTest.java
@@ -2,6 +2,7 @@ package fitnesse.slim.converters;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import fitnesse.slim.Converter;
@@ -43,6 +44,17 @@ public class GenericCollectionConverterTest extends AbstractConverterTest<List<I
     String current = converter.toString(value);
 
     assertEquals("[1, 2, 3, null]", current);
+  }
+
+  @Test
+  public void toString_should_use_converters_for_element_values() {
+    List<Object> value = Arrays.asList(1, Collections.singletonMap("a", "b"), 3, null);
+
+    Converter c = new GenericCollectionConverter<Object, List<Object>>(ArrayList.class, new DefaultConverter());
+    String current = c.toString(value);
+
+    assertEquals("[1, <table class=\"hash_table\"> <tr class=\"hash_row\"> <td class=\"hash_key\">a</td> <td class=\"hash_value\">b</td> </tr> </table>, 3, null]",
+            current.replaceAll("\\s+", " "));
   }
 
   /*

--- a/test/fitnesse/slim/converters/ListConverterHelperTest.java
+++ b/test/fitnesse/slim/converters/ListConverterHelperTest.java
@@ -3,6 +3,7 @@ package fitnesse.slim.converters;
 import java.util.ArrayList;
 import java.util.List;
 
+import fitnesse.slim.Converter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -12,6 +13,11 @@ public class ListConverterHelperTest {
   /*
    * TO STRING
    */
+  @Test
+  public void fromNull_shouldCreateNullString() {
+    assertEquals(Converter.NULL_VALUE, ListConverterHelper.toString(null));
+  }
+
   @Test
   public void toString_should_return_string_represents_empy_list_when_list_is_empty() throws Exception {
     List<String> value = new ArrayList<String>();

--- a/test/fitnesse/slim/converters/MapConverterTest.java
+++ b/test/fitnesse/slim/converters/MapConverterTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import fitnesse.html.HtmlTag;
+import fitnesse.slim.Converter;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +20,11 @@ public class MapConverterTest {
   public void setup() {
 
     converter = new MapConverter();
+  }
+
+  @Test
+  public void fromNull_shouldCreateNullString() {
+    assertEquals(Converter.NULL_VALUE, converter.toString(null));
   }
 
   @Test

--- a/test/fitnesse/slim/converters/MapConverterTest.java
+++ b/test/fitnesse/slim/converters/MapConverterTest.java
@@ -1,6 +1,7 @@
 package fitnesse.slim.converters;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -25,6 +26,19 @@ public class MapConverterTest {
   @Test
   public void fromNull_shouldCreateNullString() {
     assertEquals(Converter.NULL_VALUE, converter.toString(null));
+  }
+
+  @Test
+  public void fromNestedMap_shouldCreateString() {
+    Map nestedMap = new LinkedHashMap();
+    nestedMap.put("a", null);
+    nestedMap.put(Arrays.asList("b", "c", "d"), "listValue");
+    nestedMap.put("listKey", Arrays.asList("e", "f"));
+    nestedMap.put(null, true);
+    String actual = converter.toString(nestedMap);
+    // check without considering whitespace
+    assertEquals("<table class=\"hash_table\"> <tr class=\"hash_row\"> <td class=\"hash_key\">a</td> <td class=\"hash_value\">null</td> </tr> <tr class=\"hash_row\"> <td class=\"hash_key\">[b, c, d]</td> <td class=\"hash_value\">listValue</td> </tr> <tr class=\"hash_row\"> <td class=\"hash_key\">listKey</td> <td class=\"hash_value\">[e, f]</td> </tr> <tr class=\"hash_row\"> <td class=\"hash_key\">null</td> <td class=\"hash_value\">true</td> </tr> </table>",
+                  actual.replaceAll("\\s+", " "));
   }
 
   @Test


### PR DESCRIPTION
Fixes #738 

I'm not quite sure of the the change to `MethodExecutionResult.returnValue() `, it was needed to keep the unit tests green, BUT I don't really grasp why Lists were treated this special before and whether my change capture the intent of the previous code.

What I believe happens with the current (and previous) code is that all output objects are sent back to FitNesse using their converter's toString() result, except Lists (which is always sent using its own toString() result). Why prohibit defining a custom toString() for lists using a converter?
As in-fact the conversion of Lists can not be controlled, shouldn't that be made explicit somewhere in the documentation (with reason)?
