### PR TITLE
SlimTestContext modified to provide current TestPage

### DIFF
--- a/src/fitnesse/testsystems/slim/SlimTestContext.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContext.java
@@ -5,6 +5,7 @@ package fitnesse.testsystems.slim;
 import java.util.Collection;
 
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.tables.ScenarioTable;
 
@@ -30,4 +31,6 @@ public interface SlimTestContext {
   void increment(ExecutionResult testSummary);
 
   void increment(TestSummary testSummary);
+  
+  TestPage getPageToTest();
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.tables.ScenarioTable;
 
@@ -14,6 +15,15 @@ public class SlimTestContextImpl implements SlimTestContext {
   private final Map<String, String> symbols = new HashMap<String, String>();
   private final Map<String, ScenarioTable> scenarios = new HashMap<String, ScenarioTable>();
   private final TestSummary testSummary = new TestSummary();
+  private TestPage pageToTest;
+
+  public SlimTestContextImpl(TestPage pageToTest) {
+    this.pageToTest = pageToTest;
+  }
+  
+  public SlimTestContextImpl() {
+    super();
+  }
 
   public String getSymbol(String symbolName) {
     return symbols.get(symbolName);
@@ -67,5 +77,9 @@ public class SlimTestContextImpl implements SlimTestContext {
 
   public TestSummary getTestSummary() {
     return testSummary;
+  }
+
+  public TestPage getPageToTest() {
+    return pageToTest;
   }
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -15,14 +15,10 @@ public class SlimTestContextImpl implements SlimTestContext {
   private final Map<String, String> symbols = new HashMap<String, String>();
   private final Map<String, ScenarioTable> scenarios = new HashMap<String, ScenarioTable>();
   private final TestSummary testSummary = new TestSummary();
-  private TestPage pageToTest;
+  private final TestPage pageToTest;
 
   public SlimTestContextImpl(TestPage pageToTest) {
     this.pageToTest = pageToTest;
-  }
-  
-  public SlimTestContextImpl() {
-    super();
   }
 
   public String getSymbol(String symbolName) {

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -96,7 +96,7 @@ public abstract class SlimTestSystem implements TestSystem {
 
   @Override
   public void runTests(TestPage pageToTest) throws IOException {
-    initializeTest();
+    initializeTest(pageToTest);
 
     testStarted(pageToTest);
     try {
@@ -113,8 +113,8 @@ public abstract class SlimTestSystem implements TestSystem {
     testSystemListener.addTestSystemListener(listener);
   }
 
-  private void initializeTest() {
-    testContext = new SlimTestContextImpl();
+  private void initializeTest(TestPage pageToTest) {
+    testContext = new SlimTestContextImpl(pageToTest);
     stopTestCalled = false;
   }
 

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -15,11 +15,13 @@ import java.util.regex.Pattern;
 
 import fitnesse.slim.instructions.Instruction;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.results.SlimTestResult;
+
 import org.apache.commons.lang.StringUtils;
 
 
@@ -380,6 +382,11 @@ private void splitInputAndOutputArguments(String argName) {
 
     ExecutionResult getExecutionResult() {
       return ExecutionResult.getExecutionResult(testSummary);
+    }
+
+    @Override
+    public TestPage getPageToTest() {
+      return testContext.getPageToTest();
     }
   }
 }

--- a/test/fitnesse/plugins/PluginsLoaderTest.java
+++ b/test/fitnesse/plugins/PluginsLoaderTest.java
@@ -21,6 +21,8 @@ import fitnesse.responders.editing.ContentFilter;
 import fitnesse.responders.editing.EditResponder;
 import fitnesse.testrunner.MultipleTestSystemFactory;
 import fitnesse.testrunner.TestSystemFactoryRegistry;
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.Descriptor;
 import fitnesse.testsystems.TestSystem;
 import fitnesse.testsystems.TestSystemFactory;
@@ -35,6 +37,7 @@ import fitnesse.testsystems.slim.tables.SlimTable;
 import fitnesse.testsystems.slim.tables.SlimTableFactory;
 import fitnesse.testutil.SimpleAuthenticator;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wiki.WikiPageFactoryRegistry;
 import fitnesse.wiki.fs.FileSystemPageFactory;
@@ -46,6 +49,7 @@ import fitnesse.wikitext.parser.SymbolStream;
 import fitnesse.wikitext.parser.SymbolType;
 import fitnesse.wikitext.parser.Today;
 import fitnesse.wikitext.parser.VariableSource;
+
 import org.htmlparser.nodes.TextNode;
 import org.htmlparser.tags.TableColumn;
 import org.htmlparser.tags.TableRow;
@@ -223,7 +227,7 @@ public class PluginsLoaderTest {
     loader.loadSlimTables(slimTableFactory);
 
     HtmlTable table = makeMockTable("test");
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     assertSame(TestSlimTable.class, slimTable.getClass());
   }
 
@@ -234,7 +238,7 @@ public class PluginsLoaderTest {
     loader.loadSlimTables(slimTableFactory);
 
     HtmlTable table = makeMockTable("test:");
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     assertSame(TestSlimTable.class, slimTable.getClass());
   }
 
@@ -244,7 +248,7 @@ public class PluginsLoaderTest {
     loader.loadSlimTables(slimTableFactory);
 
     HtmlTable table = makeMockTable(DummyPluginFeatureFactory.SLIM_TABLE);
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "foo", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     assertSame(TestSlimTable.class, slimTable.getClass());
   }
 

--- a/test/fitnesse/testsystems/slim/tables/QueryTableTestBase.java
+++ b/test/fitnesse/testsystems/slim/tables/QueryTableTestBase.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import fitnesse.html.HtmlUtil;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
@@ -22,6 +23,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,7 +62,7 @@ public abstract class QueryTableTestBase {
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    testContext = new SlimTestContextImpl();
+    testContext = new SlimTestContextImpl(new WikiTestPage(root));
     return constructQueryTable(t);
   }
 

--- a/test/fitnesse/testsystems/slim/tables/ReturnedValueExpectationTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ReturnedValueExpectationTest.java
@@ -2,11 +2,14 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.testsystems.slim.tables;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.testsystems.slim.results.SlimTestResult;
+import fitnesse.wiki.WikiPageDummy;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,7 +20,7 @@ public class ReturnedValueExpectationTest {
 
   @Before
   public void setup() {
-    testContext = new SlimTestContextImpl();
+    testContext = new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy()));
   }
 
   private void assertExpectationMessage(String expected, String value, String message) throws Exception {

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import fitnesse.slim.instructions.CallInstruction;
 import fitnesse.slim.instructions.Instruction;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.testsystems.slim.SlimTestContext;
@@ -17,6 +18,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,7 +48,7 @@ public class ScenarioAndDecisionTableExtensionTest {
   }
 
   private SlimTestContextImpl makeTables(String scenarioText, String scriptText) throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     String tableText = "!|" + SCEN_EXTENSION_NAME + "|" + scenarioText + "|\n"
             + "\n"
             + "!|DT:" + scriptText + "|\n";

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableScriptOnlyExtensionTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import fitnesse.slim.instructions.CallInstruction;
 import fitnesse.slim.instructions.Instruction;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.testsystems.slim.SlimTestContext;
@@ -17,6 +18,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +46,7 @@ public class ScenarioAndDecisionTableScriptOnlyExtensionTest {
   }
 
   private SlimTestContextImpl makeTables(String scenarioText, String scriptText) throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     String tableText = "!|scenario|" + scenarioText + "|\n"
             + "\n"
             + "!|" + SCRIPT_EXTENSION_NAME + "|\n"
@@ -108,7 +110,7 @@ public class ScenarioAndDecisionTableScriptOnlyExtensionTest {
 
   @Test
   public void twoDecisionTablesDifferentScripts() throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     String tableText = "!|scenario|myScenario|input|\n"
             + "|function|@input|\n"
             + "\n"

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.instructions.CallInstruction;
 import fitnesse.slim.instructions.Instruction;
@@ -16,6 +17,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,7 +41,7 @@ public class ScenarioAndDecisionTableTest {
   }
 
   private SlimTestContextImpl makeTables(String tableText) throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndScriptTableTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.instructions.CallInstruction;
 import fitnesse.slim.instructions.Instruction;
@@ -16,6 +17,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +37,7 @@ public class ScenarioAndScriptTableTest {
   }
 
   private SlimTestContextImpl makeTables(String tableText) throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
@@ -286,7 +288,7 @@ public class ScenarioAndScriptTableTest {
 
   @Test
   public void matchesScenarioWithMostArguments() throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     WikiPageUtil.setPageContents(root, "" +
         "!|scenario|Login user|name|\n" +
         "|should not get here|\n" +
@@ -310,7 +312,7 @@ public class ScenarioAndScriptTableTest {
 
   @Test
   public void doesntMatchScenarioWithNoArgumentsThatSharesFirstWord() throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     WikiPageUtil.setPageContents(root, "" +
         "!|scenario|login |\n" +
         "|should not get here|\n" +
@@ -335,7 +337,7 @@ public class ScenarioAndScriptTableTest {
 
   @Test
   public void dontTryParameterizedForRowWithMultipleCells() throws Exception {
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     WikiPageUtil.setPageContents(root, "" +
         "!|scenario|login with |name|\n" +
         "|should not get here|\n" +

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
@@ -17,6 +18,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,7 +44,7 @@ public class ScenarioTableExtensionTest {
 
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     st = new AutoArgScenarioTable(t, "id", testContext);
     instructions.addAll(st.getAssertions());
 

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
 import fitnesse.testsystems.slim.Table;
@@ -13,6 +14,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,7 +38,7 @@ public class ScenarioTableTest {
 
         TableScanner ts = new HtmlTableScanner(root.getHtml());
         Table t = ts.getTable(0);
-      SlimTestContextImpl testContext = new SlimTestContextImpl();
+      SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
         st = new ScenarioTable(t, "id", testContext);
         instructions.addAll(st.getAssertions());
 

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableExtensionTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import fitnesse.html.HtmlUtil;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.converters.BooleanConverter;
 import fitnesse.slim.converters.VoidConverter;
@@ -25,6 +26,7 @@ import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.apache.commons.collections.ListUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,7 +90,7 @@ public class ScriptTableExtensionTest {
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     return new HtmlScriptTable(t, "id", testContext);
   }
 

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import fitnesse.html.HtmlUtil;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.converters.BooleanConverter;
 import fitnesse.slim.converters.VoidConverter;
@@ -24,6 +25,7 @@ import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.apache.commons.collections.ListUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,7 +90,7 @@ public class ScriptTableTest {
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(root));
     if (localized) return new LocalizedScriptTable(t, "id", testContext);
     else return new ScriptTable(t, "id", testContext);
   }

--- a/test/fitnesse/testsystems/slim/tables/SlimTableFactoryTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableFactoryTest.java
@@ -4,8 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
 import fitnesse.testsystems.slim.Table;
+import fitnesse.wiki.WikiPageDummy;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,14 +48,14 @@ public class SlimTableFactoryTest {
   @Test
   public void commentTableShouldReturnNull() {
     when(table.getCellContents(0, 0)).thenReturn("comment");
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     assertThat(slimTable, nullValue());
   }
 
   @Test
   public void tableTypeStartingWithcommentColonShouldReturnNull() {
     when(table.getCellContents(0, 0)).thenReturn("comment: a comment table");
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     assertThat(slimTable, nullValue());
   }
 
@@ -65,7 +68,7 @@ public class SlimTableFactoryTest {
 
   private void assertThatTableTypeCreateSlimTableType(String tableType, Class<? extends SlimTable> expectedClass) {
     when(table.getCellContents(0, 0)).thenReturn(tableType);
-    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl());
+    SlimTable slimTable = slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     String message = "should have created a " + expectedClass + " for tabletype: " + tableType
         + " but was " + slimTable.getClass();
     assertThat(message, slimTable, instanceOf(expectedClass));
@@ -109,6 +112,6 @@ public class SlimTableFactoryTest {
     when(table.getRowCount()).thenReturn(2);
     when(table.getColumnCountInRow(0)).thenReturn(1);
     when(table.getColumnCountInRow(1)).thenReturn(2);
-    slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl());
+    slimTableFactory.makeSlimTable(table, "0", new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
   }
 }

--- a/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
@@ -5,7 +5,10 @@ package fitnesse.testsystems.slim.tables;
 import java.util.Collections;
 import java.util.List;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.SlimTestContextImpl;
+import fitnesse.wiki.WikiPageDummy;
+
 import org.junit.Test;
 
 import static fitnesse.testsystems.slim.tables.Disgracer.disgraceClassName;
@@ -121,7 +124,7 @@ public class SlimTableTest {
 
   private static class MockTable extends SlimTable {
     public MockTable() {
-      super(null, null, new SlimTestContextImpl());
+      super(null, null, new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy())));
     }
 
     protected String getTableType() {

--- a/test/fitnesse/testsystems/slim/tables/SlimTableTestSupport.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableTestSupport.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import fitnesse.slim.instructions.Instruction;
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.slim.HtmlTable;
 import fitnesse.testsystems.slim.HtmlTableScanner;
 import fitnesse.testsystems.slim.SlimTestContext;
@@ -14,8 +15,10 @@ import fitnesse.testsystems.slim.SlimTestContextImpl;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 
 /**
@@ -49,7 +52,7 @@ public abstract class SlimTableTestSupport<T extends SlimTable> {
       String html = root.getHtml();
       TableScanner<HtmlTable> ts = new HtmlTableScanner(html);
       Table t = ts.getTable(0);
-      SlimTestContextImpl testContext = new SlimTestContextImpl();
+      SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy()));
       return constructor.newInstance(t, "id", testContext);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/test/fitnesse/testsystems/slim/tables/TableTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/TableTableTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.instructions.CallInstruction;
@@ -16,8 +17,10 @@ import fitnesse.testsystems.slim.SlimTestContextImpl;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.TableScanner;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,7 +51,7 @@ public class TableTableTest {
     WikiPageUtil.setPageContents(root, tableText);
     TableScanner ts = new HtmlTableScanner(root.getHtml());
     Table t = ts.getTable(0);
-    SlimTestContextImpl testContext = new SlimTestContextImpl();
+    SlimTestContextImpl testContext = new SlimTestContextImpl(new WikiTestPage(new WikiPageDummy()));
     return new TableTable(t, "id", testContext);
   }
 


### PR DESCRIPTION
Following guidelines for contributing, I just posted a [question on stackoverflow](http://stackoverflow.com/questions/30959027/fitnesseroot-dir-access-from-a-custom-slim-table).

This pull request is my own approach to resolve that need. By adding the current TestPage instance to SlimTestContext, from my custom SlimTable I'm able to fetch variables from SystemVariableSource, such as *FITNESSE_ROOTPATH* and *FITNESSE_ROOT_DIR*.

