### PR TITLE
Issue #771 - Default includeHtml suite xml results flag to false.

### DIFF
--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -81,7 +81,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
 
   private boolean debug = false;
   private boolean remoteDebug = false;
-  protected boolean includeHtml = true;
+  protected boolean includeHtml = false;
   int exitCode;
 
   public SuiteResponder() {

--- a/test/fitnesse/responders/run/SuiteResponderTest.java
+++ b/test/fitnesse/responders/run/SuiteResponderTest.java
@@ -435,6 +435,15 @@ public class SuiteResponderTest {
     assertSubString("<content>", results);
   }
 
+  @Test
+  public void Default_producesNoHTMLResultsInXMLSuite() throws Exception {
+    request.addInput("format", "xml");
+    addTestToSuite("SlimTestOne", simpleSlimDecisionTable);
+    addTestToSuite("SlimTestTwo", simpleSlimDecisionTable);
+    String results = runSuite();
+    assertNotSubString("<content>", results);
+  }
+
   private File expectedXmlResultsFile() {
     TestSummary counts = new TestSummary(3, 0, 0, 0);
     String resultsFileName = String.format("%s/SuitePage/20081205011900_%d_%d_%d_%d.xml",


### PR DESCRIPTION
Commit dd4595 (5/14/2014) moved the boolean variable includeHtml from using default initialization in SuiteResponder (with false) to explicit initialization to true in TestResponder.  Corrected behavior and added unit test.