### PR TITLE
Let !include handle non-wiki-word page names.

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ShouldNotBeAbleToIncludeParentPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ShouldNotBeAbleToIncludeParentPage/content.txt
@@ -1,4 +1,5 @@
 !|script|
 |given page|ParentPage|
-|given page|ParentPage.ChildPage|with content|&bang;include <ParentPage|
+|given page|ParentPage.ChildPage|with content|!-!include <ParentPage
+-!|
 |it should contain|Cannot include parent page|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ShouldNotBeAbleToIncludeParentPage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ShouldNotBeAbleToIncludeParentPage/properties.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Test/>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test/>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
 </properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestIncludeBackwardsSearchPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestIncludeBackwardsSearchPage/content.txt
@@ -14,7 +14,8 @@ Make sure the !-!include <MyAncestorPage.MyPage-! syntax works.
 |script|
 |start|Page Builder|
 |line|before|
-|line|!-&bang;include <MiddlePage.IncludedPage-! |
+|line|!-&bang;include <MiddlePage.IncludedPage
+-! |
 |line|after|
 |page|!-ParentPage.MiddlePage.MiddlePageTwo.IncludingPage-!|
 #

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestIncludeBackwardsSearchPage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestIncludeBackwardsSearchPage/properties.xml
@@ -1,11 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-  <Files/>
-  <LastModified>20081025203818</LastModified>
-  <RecentChanges/>
-  <Suites/>
-  <Test/>
-  <WhereUsed/>
-  <saveId>1224985098949</saveId>
-  <ticketId>1988325188839757829</ticketId>
+<Files/>
+<RecentChanges/>
+<Test/>
+<WhereUsed/>
+<saveId>1224985098949</saveId>
+<ticketId>1988325188839757829</ticketId>
 </properties>

--- a/src/fitnesse/wikitext/parser/Parser.java
+++ b/src/fitnesse/wikitext/parser/Parser.java
@@ -71,7 +71,7 @@ public class Parser {
         int start = scanner.getOffset();
         scanner.markStart();
         parseTo(terminator);
-        if (atEnd() || !getCurrent().isType(terminator)) return Maybe.noString;
+        if (!atEnd() && !getCurrent().isType(terminator)) return Maybe.noString;
         return scanner.stringFromStart(start);
     }
 

--- a/src/fitnesse/wikitext/parser/WikiSourcePage.java
+++ b/src/fitnesse/wikitext/parser/WikiSourcePage.java
@@ -59,7 +59,7 @@ public class WikiSourcePage implements SourcePage {
         PageCrawler crawler = page.getPageCrawler();
         WikiPagePath pagePath = PathParser.parse(pageName);
         if (pagePath == null) {
-          return Maybe.nothingBecause("Page include failed because the page " + pageName + " does not have a valid WikiPage name.");
+          return Maybe.nothingBecause("Page include failed because the page " + pageName + " does not have a valid wiki page name.");
         }
 
         WikiPage includedPage = crawler.getSiblingPage(pagePath);

--- a/src/fitnesse/wikitext/parser/WikiWord.java
+++ b/src/fitnesse/wikitext/parser/WikiWord.java
@@ -28,10 +28,6 @@ public class WikiWord extends SymbolType implements Translation {
                 formatWikiWord(symbol));
     }
 
-    public SourcePage getSourcePage() {
-      return sourcePage;
-    }
-    
     private String buildLink(String pagePath, String linkBody) {
          return new WikiWordBuilder(sourcePage, pagePath, linkBody).buildLink( "", pagePath);
     }

--- a/test/fitnesse/wikitext/parser/DefineTest.java
+++ b/test/fitnesse/wikitext/parser/DefineTest.java
@@ -4,6 +4,7 @@ import fitnesse.html.HtmlElement;
 import fitnesse.wiki.WikiPage;
 import org.junit.Test;
 
+import static fitnesse.wikitext.parser.ParserTestHelper.assertParses;
 import static org.junit.Assert.assertEquals;
 
 public class DefineTest {
@@ -12,6 +13,13 @@ public class DefineTest {
         ParserTestHelper.assertScansTokenType("|!define x {y}|/n", "Define", true);
     }
 
+  @Test
+  public void parsesDefine() {
+    assertParses("!define x {y}", "SymbolList[Define[Text, Text]]");
+    assertParses("!define x {y" /* eof */, "SymbolList[Define[Text, Text]]");
+    assertParses("!define x" /* eof */, "SymbolList[Define[Text, Text]]");
+
+  }
     @Test public void translatesDefines()  {
         assertTranslatesDefine("!define x {y}", "x=y");
         assertTranslatesDefine("!define BoBo {y}", "BoBo=y");
@@ -22,6 +30,7 @@ public class DefineTest {
         assertTranslatesDefine("!define x (y)", "x=y");
         assertTranslatesDefine("!define x [y]", "x=y");
         assertTranslatesDefine("!define x {''y''}", "x=''y''");
+        assertTranslatesDefine("!define x", "x=");
         ParserTestHelper.assertTranslatesTo("|!define x {y}", "|!define x {y}");
     }
 

--- a/test/fitnesse/wikitext/parser/IncludeTest.java
+++ b/test/fitnesse/wikitext/parser/IncludeTest.java
@@ -190,7 +190,7 @@ public class IncludeTest {
     WikiPage currentPage = root.makePage(parent, "PageOne", "!include +not.a.+wiki.page");
     ParserTestHelper.assertTranslatesTo(currentPage, String.format(HTML_ERR,
         "+not.a.+wiki.page",
-        "Page include failed because the page +not.a.+wiki.page does not have a valid WikiPage name."));
+        "Page include failed because the page +not.a.+wiki.page does not have a valid wiki page name."));
   }
 
   @Test

--- a/test/fitnesse/wikitext/parser/TodayExtensionTest.java
+++ b/test/fitnesse/wikitext/parser/TodayExtensionTest.java
@@ -30,7 +30,7 @@ public class TodayExtensionTest {
         ParserTestHelper.assertTranslatesTo("!monthsFromToday -xml", "2003-03-04T15:06:07");
         ParserTestHelper.assertTranslatesTo("!monthsFromToday (MMM)", "Mar");
         ParserTestHelper.assertTranslatesTo("!monthsFromToday (dd MMM)", "04 Mar");
-        ParserTestHelper.assertTranslatesTo("!monthsFromToday (dd MMM", "!monthsFromToday (dd MMM");
+        ParserTestHelper.assertTranslatesTo("!monthsFromToday (dd MMM" /* eof */, "04 Mar");
         ParserTestHelper.assertTranslatesTo("!monthsFromToday -t.", "04 Mar, 2003 15:06.");
         ParserTestHelper.assertTranslatesTo("!monthsFromToday -xml.", "2003-03-04T15:06:07.");
     }

--- a/test/fitnesse/wikitext/parser/TodayTest.java
+++ b/test/fitnesse/wikitext/parser/TodayTest.java
@@ -27,9 +27,10 @@ public class TodayTest {
         ParserTestHelper.assertTranslatesTo("!today -xml", "2002-03-04T15:06:07");
         ParserTestHelper.assertTranslatesTo("!today (MMM)", "Mar");
         ParserTestHelper.assertTranslatesTo("!today (dd MMM)", "04 Mar");
-        ParserTestHelper.assertTranslatesTo("!today (dd MMM", "!today (dd MMM");
+        ParserTestHelper.assertTranslatesTo("!today (dd MMM" /* eof */, "04 Mar");
         ParserTestHelper.assertTranslatesTo("!today -t.", "04 Mar, 2002 15:06.");
         ParserTestHelper.assertTranslatesTo("!today -xml.", "2002-03-04T15:06:07.");
+        ParserTestHelper.assertTranslatesTo("!today (MMM" /* eof */, "Mar");
     }
 
     @Test

--- a/test/fitnesse/wikitext/parser/VariableTest.java
+++ b/test/fitnesse/wikitext/parser/VariableTest.java
@@ -16,7 +16,8 @@ public class VariableTest {
         ParserTestHelper.assertTranslatesTo("${BoBo}", new TestVariableSource("BoBo", "y"), "y");
         assertTranslatesVariable("${x}", "y");
         assertTranslatesVariable("${z}", "<span class=\"meta\">undefined variable: z</span>");
-        assertTranslatesVariable("${}", "${}");
+      assertTranslatesVariable("${}", "${}");
+      assertTranslatesVariable("${x" /* eof */, "y");
     }
 
     private void assertTranslatesVariable(String variable, String expected) throws Exception {


### PR DESCRIPTION
Relax the page name parsing, using relaxed page name parsing.

Fixes #733 and #770.