### PR TITLE
Handing utf-8 symbols in replacements, not only assignments

### DIFF
--- a/src/fitnesse/slim/VariableStore.java
+++ b/src/fitnesse/slim/VariableStore.java
@@ -8,7 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class VariableStore {
-  public static final Pattern SYMBOL_PATTERN = Pattern.compile("\\$([A-Za-z]\\w*)");
+  public static final Pattern SYMBOL_PATTERN = Pattern.compile("\\$([A-Za-z\\p{L}][\\w\\p{L}]*)");
   private Map<String, MethodExecutionResult> variables = new HashMap<String, MethodExecutionResult>();
   private Matcher symbolMatcher;
 

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
@@ -436,6 +436,16 @@ public class ScriptTableTest {
   }
 
   @Test
+  public void useSymbolUTF8() throws Exception {
+    buildInstructionsFor("|function|$ÆØÅ|\n", false);
+    List<CallInstruction> expectedInstructions =
+      asList(
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"$ÆØÅ"})
+      );
+    assertEquals(expectedInstructions, instructions());
+  }
+
+  @Test
   public void noteDoesNothing() throws Exception {
     buildInstructionsFor("|note|blah|blah|\n", false);
     List<Instruction> expectedInstructions = Collections.emptyList();

--- a/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
@@ -82,6 +82,24 @@ public class SlimTableTest {
   }
 
   @Test
+  public void replaceSymbolsShouldMatchSingalUTF8SymbolName() throws Exception {
+    SlimTable table = new MockTable();
+    table.setSymbol("Æ", "ae");
+    table.setSymbol("Ø", "oe");
+    String actual = table.replaceSymbols("$Æ $Ø");
+    assertEquals("ae oe", actual);
+  }
+
+  @Test
+  public void replaceSymbolsShouldMatchUTF8SymbolName() throws Exception {
+    SlimTable table = new MockTable();
+    table.setSymbol("Ære", "honer");
+    table.setSymbol("Høre", "hear");
+    String actual = table.replaceSymbols("$Ære $Høre");
+    assertEquals("honer hear", actual);
+  }
+
+  @Test
   public void replaceSymbolsFullExpansion_ShouldReplaceSimpleSymbol() throws Exception {
     SlimTable table = new MockTable();
     table.setSymbol("x", "a");
@@ -118,6 +136,14 @@ public class SlimTableTest {
     table.setSymbol("x", "1");
     table.setSymbol("y", "1");
     assertEquals("this is $x->[1]1 and $y->[1]1", table.replaceSymbolsWithFullExpansion("this is $x1 and $y1"));
+  }
+
+  @Test
+  public void replaceSymbolsFullExpansion_ShouldReplaceUTF8Symbols() throws Exception {
+    SlimTable table = new MockTable();
+    table.setSymbol("æ", "1");
+    table.setSymbol("ø", "1");
+    assertEquals("this is $æ->[1]1 and $ø->[1]1", table.replaceSymbolsWithFullExpansion("this is $æ1 and $ø1"));
   }
 
 


### PR DESCRIPTION
Finishing off #791 as mentioned by @six42 in #779 