### PR TITLE
Improve wiki - test system decoupling

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -18,7 +18,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 public class JUnitRunNotifierResultsListener
-        implements TestSystemListener<TestPage>, TestsRunnerListener, Closeable {
+        implements TestSystemListener, TestsRunnerListener, Closeable {
 
   private final Class<?> mainClass;
   private final RunNotifier notifier;

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -8,6 +8,7 @@ import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
@@ -17,7 +18,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 public class JUnitRunNotifierResultsListener
-        implements TestSystemListener<WikiTestPage>, TestsRunnerListener, Closeable {
+        implements TestSystemListener<TestPage>, TestsRunnerListener, Closeable {
 
   private final Class<?> mainClass;
   private final RunNotifier notifier;
@@ -41,26 +42,22 @@ public class JUnitRunNotifierResultsListener
   }
 
   @Override
-  public void testStarted(WikiTestPage test) {
+  public void testStarted(TestPage test) {
     firstFailure = null;
-    if (test.isTestPage()) {
-      notifier.fireTestStarted(descriptionFor(test));
-    }
+    notifier.fireTestStarted(descriptionFor(test));
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary testSummary) {
+  public void testComplete(TestPage test, TestSummary testSummary) {
     increaseCompletedTests();
     if (firstFailure != null) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), firstFailure));
-    } else if (test.isTestPage()) {
-      if (testSummary.getExceptions() > 0) {
-        notifier.fireTestFailure(new Failure(descriptionFor(test), new Exception("Exception occurred on page " + test.getFullPath())));
-      } else if (testSummary.getWrong() > 0) {
-        notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("Test failures occurred on page " + test.getFullPath())));
-      } else {
-        notifier.fireTestFinished(descriptionFor(test));
-      }
+    } else if (testSummary.getExceptions() > 0) {
+      notifier.fireTestFailure(new Failure(descriptionFor(test), new Exception("Exception occurred on page " + test.getFullPath())));
+    } else if (testSummary.getWrong() > 0) {
+      notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("Test failures occurred on page " + test.getFullPath())));
+    } else {
+      notifier.fireTestFinished(descriptionFor(test));
     }
   }
 
@@ -110,7 +107,7 @@ public class JUnitRunNotifierResultsListener
     }
   }
 
-  private Description descriptionFor(WikiTestPage test) {
+  private Description descriptionFor(TestPage test) {
     return Description.createTestDescription(mainClass, test.getFullPath());
   }
 

--- a/src/fitnesse/junit/JavaFormatter.java
+++ b/src/fitnesse/junit/JavaFormatter.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 import fitnesse.reporting.BaseFormatter;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
-import fitnesse.testrunner.WikiTestPage;
 import util.FileUtil;
 
 /**
@@ -141,12 +141,12 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
   private Map<String, TestSummary> testSummaries = new HashMap<String, TestSummary>();
 
   @Override
-  public void testStarted(WikiTestPage test) throws IOException {
+  public void testStarted(TestPage test) throws IOException {
     resultsRepository.open(test.getFullPath());
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary testSummary) throws IOException {
+  public void testComplete(TestPage test, TestSummary testSummary) throws IOException {
     String fullPath = test.getFullPath();
     visitedTestPages.add(fullPath);
     totalSummary.add(testSummary);

--- a/src/fitnesse/junit/PrintTestListener.java
+++ b/src/fitnesse/junit/PrintTestListener.java
@@ -4,8 +4,10 @@ import java.io.Closeable;
 import java.util.logging.Logger;
 
 import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
@@ -13,7 +15,7 @@ import fitnesse.testsystems.TestSystemListener;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.util.TimeMeasurement;
 
-public class PrintTestListener implements TestSystemListener<WikiTestPage>, Closeable {
+public class PrintTestListener implements TestSystemListener, Closeable {
   private static final Logger LOG = Logger.getLogger(PrintTestListener.class.getName());
 
   private TimeMeasurement timeMeasurement;
@@ -25,13 +27,13 @@ public class PrintTestListener implements TestSystemListener<WikiTestPage>, Clos
   }
 
   @Override
-  public void testStarted(WikiTestPage test) {
+  public void testStarted(TestPage test) {
     timeMeasurement = new TimeMeasurement().start();
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary testSummary) {
-    LOG.info(new WikiPagePath(test.getSourcePage()).toString() + " r " + testSummary.getRight() + " w "
+  public void testComplete(TestPage test, TestSummary testSummary) {
+    LOG.info(new WikiPagePath(WikiTestPageUtil.getSourcePage(test)).toString() + " r " + testSummary.getRight() + " w "
         + testSummary.getWrong() + " " + testSummary.getExceptions()
         + " " + timeMeasurement.elapsedSeconds() + " seconds");
   }

--- a/src/fitnesse/reporting/BaseFormatter.java
+++ b/src/fitnesse/reporting/BaseFormatter.java
@@ -2,6 +2,7 @@ package fitnesse.reporting;
 
 import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testrunner.WikiTestPage;
@@ -33,7 +34,7 @@ public abstract class BaseFormatter implements Formatter {
   }
 
   @Override
-  public void testStarted(WikiTestPage testPage) throws IOException {
+  public void testStarted(TestPage testPage) throws IOException {
   }
 
   @Override
@@ -41,7 +42,7 @@ public abstract class BaseFormatter implements Formatter {
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary summary) throws IOException {
+  public void testComplete(TestPage test, TestSummary summary) throws IOException {
   }
 
   public int getErrorCount() {

--- a/src/fitnesse/reporting/Formatter.java
+++ b/src/fitnesse/reporting/Formatter.java
@@ -1,7 +1,5 @@
 package fitnesse.reporting;
 
-import fitnesse.testrunner.WikiTestPage;
-import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSystemListener;
 
 /**
@@ -9,6 +7,6 @@ import fitnesse.testsystems.TestSystemListener;
  *
  * Optionally implement java.io.Closeable and/or fitnesse.testrunner.TestsRunnerListener.
  */
-public interface Formatter extends TestSystemListener<TestPage> {
+public interface Formatter extends TestSystemListener {
 
 }

--- a/src/fitnesse/reporting/Formatter.java
+++ b/src/fitnesse/reporting/Formatter.java
@@ -1,6 +1,7 @@
 package fitnesse.reporting;
 
 import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSystemListener;
 
 /**
@@ -8,6 +9,6 @@ import fitnesse.testsystems.TestSystemListener;
  *
  * Optionally implement java.io.Closeable and/or fitnesse.testrunner.TestsRunnerListener.
  */
-public interface Formatter extends TestSystemListener<WikiTestPage> {
+public interface Formatter extends TestSystemListener<TestPage> {
 
 }

--- a/src/fitnesse/reporting/InteractiveFormatter.java
+++ b/src/fitnesse/reporting/InteractiveFormatter.java
@@ -43,7 +43,7 @@ public abstract class InteractiveFormatter extends BaseFormatter implements Test
 
   protected String getRelativeName(WikiTestPage testPage) {
     PageCrawler pageCrawler = getPage().getPageCrawler();
-    String relativeName = pageCrawler.getRelativeName(testPage.getSourcePage());
+    String relativeName = pageCrawler.getRelativeName(WikiTestPageUtil.getSourcePage(testPage));
     if ("".equals(relativeName)) {
       relativeName = String.format("(%s)", testPage.getName());
     }

--- a/src/fitnesse/reporting/InteractiveFormatter.java
+++ b/src/fitnesse/reporting/InteractiveFormatter.java
@@ -8,7 +8,9 @@ import fitnesse.testrunner.WikiTestPage;
 import fitnesse.html.HtmlTag;
 import fitnesse.html.HtmlUtil;
 import fitnesse.html.RawHtml;
+import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
 import fitnesse.wiki.PageCrawler;
@@ -41,7 +43,7 @@ public abstract class InteractiveFormatter extends BaseFormatter implements Test
 	  return relativeName;
   }
 
-  protected String getRelativeName(WikiTestPage testPage) {
+  protected String getRelativeName(TestPage testPage) {
     PageCrawler pageCrawler = getPage().getPageCrawler();
     String relativeName = pageCrawler.getRelativeName(WikiTestPageUtil.getSourcePage(testPage));
     if ("".equals(relativeName)) {
@@ -94,7 +96,7 @@ public abstract class InteractiveFormatter extends BaseFormatter implements Test
   }
 
   @Override
-  public void testStarted(WikiTestPage testPage) throws IOException {
+  public void testStarted(TestPage testPage) throws IOException {
     relativeName = getRelativeName(testPage);
   }
 

--- a/src/fitnesse/reporting/SuiteHtmlFormatter.java
+++ b/src/fitnesse/reporting/SuiteHtmlFormatter.java
@@ -8,7 +8,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.Writer;
 
-import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.*;
 import fitnesse.util.TimeMeasurement;
 import fitnesse.html.HtmlTag;
@@ -78,7 +77,7 @@ public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeabl
   }
 
   @Override
-  public void testStarted(WikiTestPage testPage) throws IOException {
+  public void testStarted(TestPage testPage) throws IOException {
     latestTestTime = new TimeMeasurement().start();
     super.testStarted(testPage);
 
@@ -146,7 +145,7 @@ public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeabl
 
 
   @Override
-  public void testComplete(WikiTestPage testPage, TestSummary testSummary) throws IOException {
+  public void testComplete(TestPage testPage, TestSummary testSummary) throws IOException {
     latestTestTime.stop();
     super.testComplete(testPage, testSummary);
 

--- a/src/fitnesse/reporting/TestTextFormatter.java
+++ b/src/fitnesse/reporting/TestTextFormatter.java
@@ -4,7 +4,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 
-import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
 import fitnesse.util.TimeMeasurement;
 import fitnesse.http.ChunkedResponse;
 import fitnesse.testsystems.TestSummary;
@@ -28,7 +28,7 @@ public class TestTextFormatter extends BaseFormatter implements Closeable {
   }
 
   @Override
-  public void testStarted(WikiTestPage page) {
+  public void testStarted(TestPage page) {
     timeMeasurement = new TimeMeasurement().start();
   }
 
@@ -37,7 +37,7 @@ public class TestTextFormatter extends BaseFormatter implements Closeable {
   }
 
   @Override
-  public void testComplete(WikiTestPage page, TestSummary summary) throws IOException {
+  public void testComplete(TestPage page, TestSummary summary) throws IOException {
     timeMeasurement.stop();
     updateCounters(summary);
     String timeString = new SimpleDateFormat("HH:mm:ss").format(timeMeasurement.startedAtDate());

--- a/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
+++ b/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
@@ -69,7 +69,7 @@ public class SuiteHistoryFormatter extends BaseFormatter implements ExecutionLog
   @Override
   public void testStarted(WikiTestPage test) {
     String pageName = test.getFullPath();
-    testHistoryFormatter = new TestXmlFormatter(context, test.getSourcePage(), writerFactory);
+    testHistoryFormatter = new TestXmlFormatter(context, WikiTestPageUtil.getSourcePage(test), writerFactory);
     testHistoryFormatter.testStarted(test);
     referenceToCurrentTest = new SuiteExecutionReport.PageHistoryReference(pageName, testHistoryFormatter.startedAt());
   }

--- a/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
+++ b/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
@@ -8,11 +8,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import fitnesse.reporting.BaseFormatter;
-import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
 import fitnesse.testsystems.ExecutionLogListener;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
@@ -67,7 +68,7 @@ public class SuiteHistoryFormatter extends BaseFormatter implements ExecutionLog
   }
 
   @Override
-  public void testStarted(WikiTestPage test) {
+  public void testStarted(TestPage test) {
     String pageName = test.getFullPath();
     testHistoryFormatter = new TestXmlFormatter(context, WikiTestPageUtil.getSourcePage(test), writerFactory);
     testHistoryFormatter.testStarted(test);
@@ -82,7 +83,7 @@ public class SuiteHistoryFormatter extends BaseFormatter implements ExecutionLog
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary testSummary) throws IOException {
+  public void testComplete(TestPage test, TestSummary testSummary) throws IOException {
     testHistoryFormatter.testComplete(test, testSummary);
     testHistoryFormatter.close();
     referenceToCurrentTest.setTestSummary(testSummary);

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -59,7 +59,7 @@ public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListe
     appendHtmlToBuffer(WikiPageUtil.getHeaderPageHtml(getPage()));
     currentResult = newTestResult();
     currentResult.relativePageName = testPage.getName();
-    currentResult.tags = testPage.getData().getAttribute(PageData.PropertySUITES);
+    currentResult.tags = WikiTestPageUtil.getSourcePage(testPage).getData().getAttribute(PageData.PropertySUITES);
     testResponse.addResult(currentResult);
   }
 

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -4,6 +4,7 @@ package fitnesse.reporting.history;
 
 import fitnesse.FitNesseContext;
 import fitnesse.reporting.BaseFormatter;
+import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.ExecutionLogListener;
 import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.Instruction;
@@ -11,9 +12,9 @@ import fitnesse.testsystems.Assertion;
 import fitnesse.testsystems.ExceptionResult;
 import fitnesse.testsystems.Expectation;
 import fitnesse.testsystems.TableCell;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
-import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.TestSystem;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
@@ -54,7 +55,7 @@ public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListe
   }
 
   @Override
-  public void testStarted(WikiTestPage testPage) {
+  public void testStarted(TestPage testPage) {
     resetTimer();
     appendHtmlToBuffer(WikiPageUtil.getHeaderPageHtml(getPage()));
     currentResult = newTestResult();
@@ -126,7 +127,7 @@ public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListe
   }
 
   @Override
-  public void testComplete(WikiTestPage test, TestSummary testSummary) throws IOException {
+  public void testComplete(TestPage test, TestSummary testSummary) throws IOException {
     currentTestStartTime.stop();
     super.testComplete(test, testSummary);
     currentResult.startTime = currentTestStartTime.startedAt();

--- a/src/fitnesse/responders/WikiPageResponder.java
+++ b/src/fitnesse/responders/WikiPageResponder.java
@@ -79,7 +79,7 @@ public class WikiPageResponder implements SecureResponder {
     html.put("actions", new WikiPageActions(page));
     html.put("helpText", pageData.getProperties().get(PageData.PropertyHELP));
 
-    if (WikiTestPage.isTestPage(page)) {
+    if (WikiPageUtil.isTestPage(page)) {
       // Add test url inputs to context's variableSource.
       WikiTestPage testPage = new TestPageWithSuiteSetUpAndTearDown(page);
       html.put("content", new WikiTestPageRenderer(testPage));

--- a/src/fitnesse/responders/run/TestResponder.java
+++ b/src/fitnesse/responders/run/TestResponder.java
@@ -11,16 +11,16 @@ import fitnesse.testrunner.MultipleTestsRunner;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.wiki.WikiPage;
 
-import static fitnesse.testrunner.WikiTestPage.isTestPage;
-import static java.util.Arrays.asList;
+import static fitnesse.wiki.WikiPageUtil.isTestPage;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 public class TestResponder extends SuiteResponder {
 
   @Override
   protected List<WikiPage> getPagesToRun() {
     if (isTestPage(page)) {
-      return asList(page);
+      return singletonList(page);
     } else {
       return emptyList();
     }

--- a/src/fitnesse/responders/versions/VersionResponder.java
+++ b/src/fitnesse/responders/versions/VersionResponder.java
@@ -108,7 +108,7 @@ public class VersionResponder implements SecureResponder {
     }
 
     public String render() {
-      if (WikiTestPage.isTestPage(page)) {
+      if (WikiPageUtil.isTestPage(page)) {
         WikiTestPage testPage = new WikiTestPage(page);
         return WikiTestPageUtil.makePageHtml(testPage);
       } else {

--- a/src/fitnesse/testrunner/MultipleTestsRunner.java
+++ b/src/fitnesse/testrunner/MultipleTestsRunner.java
@@ -184,7 +184,7 @@ public class MultipleTestsRunner implements Stoppable {
     executionLogListener.addExecutionLogListener(listener);
   }
 
-  private class InternalTestSystemListener implements TestSystemListener<WikiTestPage> {
+  private class InternalTestSystemListener implements TestSystemListener {
     @Override
     public void testSystemStarted(TestSystem testSystem) throws IOException {
       formatters.testSystemStarted(testSystem);
@@ -196,12 +196,12 @@ public class MultipleTestsRunner implements Stoppable {
     }
 
     @Override
-    public void testStarted(WikiTestPage testPage) throws IOException {
+    public void testStarted(TestPage testPage) throws IOException {
       formatters.testStarted(testPage);
     }
 
     @Override
-    public void testComplete(WikiTestPage testPage, TestSummary testSummary) throws IOException {
+    public void testComplete(TestPage testPage, TestSummary testSummary) throws IOException {
       formatters.testComplete(testPage, testSummary);
       testsInProgressCount--;
     }

--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -7,12 +7,14 @@ import java.util.List;
 import fitnesse.components.TraversalListener;
 import fitnesse.testsystems.ClassPath;
 import fitnesse.testsystems.TestPage;
-import fitnesse.wiki.BaseWikiPage;
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.ReadOnlyPageData;
+import fitnesse.wiki.SymbolicPage;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.WikitextPage;
 import fitnesse.wikitext.parser.HtmlTranslator;
 import fitnesse.wikitext.parser.Parser;
 import fitnesse.wikitext.parser.ParsingPage;
@@ -47,9 +49,9 @@ public class WikiTestPage implements TestPage {
   public String getHtml() {
 
     // -AJM- Okay, this is not as clean as I'd like it to be, but for now it does the trick
-    if (sourcePage instanceof BaseWikiPage) {
+    if (containsWikitext()) {
       String content = getDecoratedContent();
-      ParsingPage parsingPage = BaseWikiPage.makeParsingPage((BaseWikiPage) sourcePage);
+      ParsingPage parsingPage = BaseWikitextPage.makeParsingPage((BaseWikitextPage) sourcePage);
 
       Symbol syntaxTree = Parser.make(parsingPage, content).parse();
 
@@ -57,6 +59,11 @@ public class WikiTestPage implements TestPage {
     } else {
       return sourcePage.getHtml();
     }
+  }
+
+  private boolean containsWikitext() {
+    return (sourcePage instanceof SymbolicPage && ((SymbolicPage) sourcePage).containsWikitext())
+            || (sourcePage instanceof WikitextPage);
   }
 
   @Override

--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -21,6 +21,7 @@ import fitnesse.wikitext.parser.ParsingPage;
 import fitnesse.wikitext.parser.Symbol;
 import fitnesse.wikitext.parser.WikiSourcePage;
 
+// TODO: need 2 implementations, one for wiki text pages (Fit, Slim) and one for non-wiki text pages. See PagesByTestSystem
 public class WikiTestPage implements TestPage {
   public static final String TEAR_DOWN = "TearDown";
   public static final String SET_UP = "SetUp";
@@ -72,6 +73,15 @@ public class WikiTestPage implements TestPage {
   @Override
   public ClassPath getClassPath() {
     return new ClassPath(new ClassPathBuilder().getClassPath(sourcePage), getPathSeparator());
+  }
+
+  @Override
+  public String getContent() {
+    if (containsWikitext()) {
+      return getDecoratedContent();
+    } else {
+      return sourcePage.getData().getContent();
+    }
   }
 
 

--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -34,13 +34,6 @@ public class WikiTestPage implements TestPage {
     this.sourcePage = sourcePage;
   }
 
-  public static boolean isTestPage(WikiPage page) {
-    return isTestPage(page.getData());
-  }
-  public static boolean isTestPage(ReadOnlyPageData pageData) {
-    return pageData.hasAttribute("Test");
-  }
-
   public PageData getData() {
     return sourcePage.getData();
   }
@@ -170,10 +163,6 @@ public class WikiTestPage implements TestPage {
     boolean notIncludeScenarios = "false".equalsIgnoreCase(includeScenarioLibraries);
 
     return includeScenarios || (!notIncludeScenarios && isSlim);
-  }
-
-  public boolean isTestPage() {
-    return isTestPage(getData());
   }
 
   public List<WikiPage> getScenarioLibraries() {

--- a/src/fitnesse/testrunner/WikiTestPageUtil.java
+++ b/src/fitnesse/testrunner/WikiTestPageUtil.java
@@ -1,12 +1,23 @@
 package fitnesse.testrunner;
 
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.WikiPageUtil;
 
 public class WikiTestPageUtil {
+
   public static String makePageHtml(WikiTestPage page){
     StringBuffer buffer = new StringBuffer();
     buffer.append(WikiPageUtil.getHeaderPageHtml(page.getSourcePage()));
     buffer.append(page.getHtml());
     return buffer.toString();
+  }
+
+  public static WikiPage getSourcePage(TestPage testPage) {
+    if (testPage instanceof WikiTestPage) {
+      return ((WikiTestPage) testPage).getSourcePage();
+    }
+    return new WikiPageDummy();
   }
 }

--- a/src/fitnesse/testsystems/TestPage.java
+++ b/src/fitnesse/testsystems/TestPage.java
@@ -6,6 +6,8 @@ public interface TestPage {
 
   String getVariable(String name);
 
+  String getName();
+
   String getFullPath();
 
   ClassPath getClassPath();

--- a/src/fitnesse/testsystems/TestPage.java
+++ b/src/fitnesse/testsystems/TestPage.java
@@ -2,13 +2,22 @@ package fitnesse.testsystems;
 
 public interface TestPage {
 
-  String getHtml();
-
-  String getVariable(String name);
-
   String getName();
 
   String getFullPath();
 
+  String getVariable(String name);
+
   ClassPath getClassPath();
+
+  /**
+   * Return the plain (wiki-) text. This function can be used by test systems (such as Cucumber and JBehave)
+   * that do deal with the raw page content.
+   */
+  String getContent();
+
+  /**
+   * Returns the complete, decorated HTML page, as shown in the web interface and as it is used by Fit and Slim.
+   */
+  String getHtml();
 }

--- a/src/fitnesse/testsystems/TestSystemListener.java
+++ b/src/fitnesse/testsystems/TestSystemListener.java
@@ -4,14 +4,14 @@ package fitnesse.testsystems;
 
 import java.io.IOException;
 
-public interface TestSystemListener<PageType extends TestPage> {
+public interface TestSystemListener {
   void testSystemStarted(TestSystem testSystem) throws IOException;
 
   void testOutputChunk(String output) throws IOException;
 
-  void testStarted(PageType testPage) throws IOException;
+  void testStarted(TestPage testPage) throws IOException;
 
-  void testComplete(PageType testPage, TestSummary testSummary) throws IOException;
+  void testComplete(TestPage testPage, TestSummary testSummary) throws IOException;
 
   void testSystemStopped(TestSystem testSystem, Throwable cause /* may be null */);
 

--- a/src/fitnesse/wiki/BaseWikiPage.java
+++ b/src/fitnesse/wiki/BaseWikiPage.java
@@ -1,37 +1,15 @@
-// Copyright (C) 2003-2009 by Object Mentor, Inc. All rights reserved.
-// Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.wiki;
 
-import fitnesse.wikitext.parser.CompositeVariableSource;
-import fitnesse.wikitext.parser.HtmlTranslator;
-import fitnesse.wikitext.parser.Maybe;
-import fitnesse.wikitext.parser.Parser;
-import fitnesse.wikitext.parser.ParsingPage;
-import fitnesse.wikitext.parser.Symbol;
-import fitnesse.wikitext.parser.SymbolProvider;
-import fitnesse.wikitext.parser.VariableSource;
-import fitnesse.wikitext.parser.WikiSourcePage;
+/**
+ * Base implementation for most types of wiki pages.
+ */
+public abstract class BaseWikiPage implements WikiPage {
+  protected final String name;
+  protected final WikiPage parent;
 
-public abstract class BaseWikiPage implements WikiPage, WikitextPage {
-
-  private final String name;
-  private final WikiPage parent;
-  private final VariableSource variableSource;
-  private ParsingPage parsingPage;
-  private Symbol syntaxTree;
-
-  protected BaseWikiPage(String name, VariableSource variableSource) {
-    this(name, null, variableSource);
-  }
-
-  protected BaseWikiPage(String name, WikiPage parent) {
-    this(name, parent, parent instanceof BaseWikiPage ? ((BaseWikiPage) parent).variableSource : null);
-  }
-
-  protected BaseWikiPage(String name, WikiPage parent, VariableSource variableSource) {
+  public BaseWikiPage(String name, WikiPage parent) {
     this.name = name;
     this.parent = parent;
-    this.variableSource = variableSource;
   }
 
   @Override
@@ -54,59 +32,17 @@ public abstract class BaseWikiPage implements WikiPage, WikitextPage {
     return parent == null || parent == this;
   }
 
-  protected VariableSource getVariableSource() {
-    return variableSource;
-  }
-
-  @Override
-  public String getVariable(String name) {
-    ParsingPage parsingPage = getParsingPage();
-    Maybe<String> variable = parsingPage.findVariable(name);
-    if (variable.isNothing()) return null;
-
-    Parser parser = Parser.make(parsingPage, "", SymbolProvider.variableDefinitionSymbolProvider);
-    return new HtmlTranslator(null, parsingPage).translate(parser.parseWithParent(variable.getValue(), null));
-  }
-
-  @Override
-  public String getHtml() {
-    return new HtmlTranslator(new WikiSourcePage(this), getParsingPage()).translateTree(getSyntaxTree());
-  }
-
-  @Override
-  public ParsingPage getParsingPage() {
-    parse();
-    return parsingPage;
-  }
-
-  @Override
-  public Symbol getSyntaxTree() {
-    parse();
-    return syntaxTree;
-  }
-
-  private void parse() {
-    if (syntaxTree == null) {
-      // This is the only page where we need a VariableSource
-      parsingPage = makeParsingPage(this);
-      syntaxTree = Parser.make(parsingPage, getData().getContent()).parse();
-    }
-  }
-
-  protected void resetCache() {
-    parsingPage = null;
-    syntaxTree = null;
-  }
-
   @Override
   public String toString() {
     return this.getClass().getName() + ": " + name;
   }
 
   @Override
-  public int compareTo(Object o) {
+  public int compareTo(WikiPage other) {
     try {
-      return getPageCrawler().getFullPath().compareTo(((WikiPage) o).getPageCrawler().getFullPath());
+      WikiPagePath path1 = getPageCrawler().getFullPath();
+      WikiPagePath path2 = other.getPageCrawler().getFullPath();
+      return path1.compareTo(path2);
     }
     catch (Exception e) {
       return 0;
@@ -114,15 +50,16 @@ public abstract class BaseWikiPage implements WikiPage, WikitextPage {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o)
+  public boolean equals(Object other) {
+    if (this == other)
       return true;
-    if (!(o instanceof WikiPage))
+    if (!(other instanceof WikiPage))
       return false;
     try {
-      return getPageCrawler().getFullPath().equals(((WikiPage) o).getPageCrawler().getFullPath());
-    }
-    catch (Exception e) {
+      WikiPagePath path1 = getPageCrawler().getFullPath();
+      WikiPagePath path2 = ((WikiPage) other).getPageCrawler().getFullPath();
+      return path1.equals(path2);
+    } catch (Exception e) {
       return false;
     }
   }
@@ -131,64 +68,8 @@ public abstract class BaseWikiPage implements WikiPage, WikitextPage {
   public int hashCode() {
     try {
       return getPageCrawler().getFullPath().hashCode();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       return 0;
-    }
-  }
-
-  public static ParsingPage makeParsingPage(BaseWikiPage page) {
-    ParsingPage.Cache cache = new ParsingPage.Cache();
-
-    VariableSource compositeVariableSource = new CompositeVariableSource(
-            new ApplicationVariableSource(page.variableSource),
-            new PageVariableSource(page),
-            new UserVariableSource(page.variableSource),
-            cache,
-            new ParentPageVariableSource(page),
-            page.variableSource);
-    return new ParsingPage(new WikiSourcePage(page), compositeVariableSource, cache);
-  }
-
-  public static class UserVariableSource implements VariableSource {
-
-    private final VariableSource variableSource;
-
-    public UserVariableSource(VariableSource variableSource) {
-      this.variableSource = variableSource;
-    }
-
-    @Override
-    public Maybe<String> findVariable(String name) {
-      if(variableSource instanceof UrlPathVariableSource){
-        Maybe<String> result = ((UrlPathVariableSource) variableSource).findUrlVariable(name);
-        if (!result.isNothing()) return result;
-      }
-      return Maybe.noString;
-    }
-  }
-
-  public static class ParentPageVariableSource implements VariableSource {
-    private final WikiPage page;
-
-    public ParentPageVariableSource(WikiPage page) {
-
-      this.page = page;
-    }
-
-    @Override
-    public Maybe<String> findVariable(String name) {
-      if (page.isRoot()) {
-        // Get variable from
-        return Maybe.noString;
-      }
-      WikiPage parentPage = page.getParent();
-      if (parentPage instanceof WikitextPage) {
-        return ((WikitextPage) parentPage).getParsingPage().findVariable(name);
-      } else {
-        String value = parentPage.getVariable(name);
-        return value != null ? new Maybe<String>(value) : Maybe.noString;
-      }
     }
   }
 }

--- a/src/fitnesse/wiki/BaseWikitextPage.java
+++ b/src/fitnesse/wiki/BaseWikitextPage.java
@@ -1,0 +1,135 @@
+// Copyright (C) 2003-2009 by Object Mentor, Inc. All rights reserved.
+// Released under the terms of the CPL Common Public License version 1.0.
+package fitnesse.wiki;
+
+import fitnesse.wikitext.parser.CompositeVariableSource;
+import fitnesse.wikitext.parser.HtmlTranslator;
+import fitnesse.wikitext.parser.Maybe;
+import fitnesse.wikitext.parser.Parser;
+import fitnesse.wikitext.parser.ParsingPage;
+import fitnesse.wikitext.parser.Symbol;
+import fitnesse.wikitext.parser.SymbolProvider;
+import fitnesse.wikitext.parser.VariableSource;
+import fitnesse.wikitext.parser.WikiSourcePage;
+
+/**
+ * This class adds support for FitNesse wiki text ({@link fitnesse.wikitext.parser.Parser}).
+ */
+public abstract class BaseWikitextPage extends BaseWikiPage implements WikitextPage {
+
+  private final VariableSource variableSource;
+  private ParsingPage parsingPage;
+  private Symbol syntaxTree;
+
+  protected BaseWikitextPage(String name, VariableSource variableSource) {
+    this(name, null, variableSource);
+  }
+
+  protected BaseWikitextPage(String name, WikiPage parent) {
+    this(name, parent, parent instanceof BaseWikitextPage ? ((BaseWikitextPage) parent).variableSource : null);
+  }
+
+  protected BaseWikitextPage(String name, WikiPage parent, VariableSource variableSource) {
+    super(name, parent);
+    this.variableSource = variableSource;
+  }
+
+  protected VariableSource getVariableSource() {
+    return variableSource;
+  }
+
+  @Override
+  public String getVariable(String name) {
+    ParsingPage parsingPage = getParsingPage();
+    Maybe<String> variable = parsingPage.findVariable(name);
+    if (variable.isNothing()) return null;
+
+    Parser parser = Parser.make(parsingPage, "", SymbolProvider.variableDefinitionSymbolProvider);
+    return new HtmlTranslator(null, parsingPage).translate(parser.parseWithParent(variable.getValue(), null));
+  }
+
+  @Override
+  public String getHtml() {
+    return new HtmlTranslator(new WikiSourcePage(this), getParsingPage()).translateTree(getSyntaxTree());
+  }
+
+  @Override
+  public ParsingPage getParsingPage() {
+    parse();
+    return parsingPage;
+  }
+
+  @Override
+  public Symbol getSyntaxTree() {
+    parse();
+    return syntaxTree;
+  }
+
+  private void parse() {
+    if (syntaxTree == null) {
+      // This is the only page where we need a VariableSource
+      parsingPage = makeParsingPage(this);
+      syntaxTree = Parser.make(parsingPage, getData().getContent()).parse();
+    }
+  }
+
+  protected void resetCache() {
+    parsingPage = null;
+    syntaxTree = null;
+  }
+
+  public static ParsingPage makeParsingPage(BaseWikitextPage page) {
+    ParsingPage.Cache cache = new ParsingPage.Cache();
+
+    VariableSource compositeVariableSource = new CompositeVariableSource(
+            new ApplicationVariableSource(page.variableSource),
+            new PageVariableSource(page),
+            new UserVariableSource(page.variableSource),
+            cache,
+            new ParentPageVariableSource(page),
+            page.variableSource);
+    return new ParsingPage(new WikiSourcePage(page), compositeVariableSource, cache);
+  }
+
+  public static class UserVariableSource implements VariableSource {
+
+    private final VariableSource variableSource;
+
+    public UserVariableSource(VariableSource variableSource) {
+      this.variableSource = variableSource;
+    }
+
+    @Override
+    public Maybe<String> findVariable(String name) {
+      if(variableSource instanceof UrlPathVariableSource){
+        Maybe<String> result = ((UrlPathVariableSource) variableSource).findUrlVariable(name);
+        if (!result.isNothing()) return result;
+      }
+      return Maybe.noString;
+    }
+  }
+
+  public static class ParentPageVariableSource implements VariableSource {
+    private final WikiPage page;
+
+    public ParentPageVariableSource(WikiPage page) {
+
+      this.page = page;
+    }
+
+    @Override
+    public Maybe<String> findVariable(String name) {
+      if (page.isRoot()) {
+        // Get variable from
+        return Maybe.noString;
+      }
+      WikiPage parentPage = page.getParent();
+      if (parentPage instanceof WikitextPage) {
+        return ((WikitextPage) parentPage).getParsingPage().findVariable(name);
+      } else {
+        String value = parentPage.getVariable(name);
+        return value != null ? new Maybe<String>(value) : Maybe.noString;
+      }
+    }
+  }
+}

--- a/src/fitnesse/wiki/SymbolicPage.java
+++ b/src/fitnesse/wiki/SymbolicPage.java
@@ -10,8 +10,7 @@ import java.util.List;
 import fitnesse.wikitext.parser.ParsingPage;
 import fitnesse.wikitext.parser.Symbol;
 
-public class SymbolicPage extends BaseWikiPage {
-  private static final long serialVersionUID = 1L;
+public class SymbolicPage extends BaseWikitextPage {
 
   public static final String PROPERTY_NAME = "SymbolicLinks";
 
@@ -25,6 +24,10 @@ public class SymbolicPage extends BaseWikiPage {
 
   public WikiPage getRealPage() {
     return realPage;
+  }
+
+  public boolean containsWikitext() {
+    return realPage instanceof WikitextPage;
   }
 
   @Override
@@ -86,7 +89,7 @@ public class SymbolicPage extends BaseWikiPage {
 
   @Override
   public String getVariable(String name) {
-    if (realPage instanceof WikitextPage) {
+    if (containsWikitext()) {
       return super.getVariable(name);
     }
     return realPage.getVariable(name);
@@ -94,7 +97,7 @@ public class SymbolicPage extends BaseWikiPage {
 
   @Override
   public String getHtml() {
-    if (realPage instanceof WikitextPage) {
+    if (containsWikitext()) {
       return super.getHtml();
     }
     return realPage.getHtml();
@@ -102,7 +105,7 @@ public class SymbolicPage extends BaseWikiPage {
 
   @Override
   public ParsingPage getParsingPage() {
-    if (realPage instanceof WikitextPage) {
+    if (containsWikitext()) {
       return super.getParsingPage();
     }
     return null;
@@ -110,7 +113,7 @@ public class SymbolicPage extends BaseWikiPage {
 
   @Override
   public Symbol getSyntaxTree() {
-    if (realPage instanceof WikitextPage) {
+    if (containsWikitext()) {
       return super.getSyntaxTree();
     }
     return Symbol.emptySymbol;

--- a/src/fitnesse/wiki/WikiPage.java
+++ b/src/fitnesse/wiki/WikiPage.java
@@ -6,7 +6,7 @@ package fitnesse.wiki;
 import java.util.Collection;
 import java.util.List;
 
-public interface WikiPage extends Comparable<Object> {
+public interface WikiPage extends Comparable<WikiPage> {
 
   WikiPage getParent();
 

--- a/src/fitnesse/wiki/WikiPageDummy.java
+++ b/src/fitnesse/wiki/WikiPageDummy.java
@@ -10,38 +10,18 @@ import java.util.List;
 
 import fitnesse.util.Clock;
 
-public class WikiPageDummy implements WikiPage {
-  private static final long serialVersionUID = 1L;
+public class WikiPageDummy extends BaseWikiPage {
 
-  public String name;
   private PageData pageData;
-  private final WikiPage parent;
 
   public WikiPageDummy(String name, String content, WikiPage parent) {
-    this.name = name;
+    super(name, parent);
     pageData = new PageData(content, new WikiPageProperties());
-    this.parent = parent;
   }
 
   public WikiPageDummy() {
-    name = "Default";
+    super("Default", null);
     pageData = new PageData("", new WikiPageProperties());
-    this.parent = null;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public WikiPage getParent() {
-    return parent;
-  }
-
-  @Override
-  public boolean isRoot() {
-    return parent == null;
   }
 
   @Override
@@ -63,11 +43,6 @@ public class WikiPageDummy implements WikiPage {
   @Override
   public List<WikiPage> getChildren() {
     return new ArrayList<WikiPage>();
-  }
-
-  @Override
-  public int compareTo(Object o) {
-    return 0;
   }
 
   @Override

--- a/src/fitnesse/wiki/WikiPageUtil.java
+++ b/src/fitnesse/wiki/WikiPageUtil.java
@@ -114,4 +114,8 @@ public class WikiPageUtil {
     }
     return Collections.emptyList();
   }
+
+  public static boolean isTestPage(WikiPage page) {
+    return page.getData().hasAttribute("Test");
+  }
 }

--- a/src/fitnesse/wiki/WikiPageUtil.java
+++ b/src/fitnesse/wiki/WikiPageUtil.java
@@ -67,10 +67,7 @@ public class WikiPageUtil {
   }
 
   public static String makePageHtml(WikiPage page) {
-    StringBuffer buffer = new StringBuffer();
-    buffer.append(getHeaderPageHtml(page));
-    buffer.append(page.getHtml());
-    return buffer.toString();
+    return getHeaderPageHtml(page) + page.getHtml();
   }
 
   public static File resolveFileUri(String fullPageURI, File rootPath) {

--- a/src/fitnesse/wiki/WikitextPage.java
+++ b/src/fitnesse/wiki/WikitextPage.java
@@ -4,7 +4,7 @@ import fitnesse.wikitext.parser.ParsingPage;
 import fitnesse.wikitext.parser.Symbol;
 
 /**
- * This interface denotes a class that can expose parsed wiki page content,
+ * This interface denotes a class that can expose parsed wiki page content.
  */
 public interface WikitextPage {
   Symbol getSyntaxTree();

--- a/src/fitnesse/wiki/fs/ExternalSuitePage.java
+++ b/src/fitnesse/wiki/fs/ExternalSuitePage.java
@@ -1,5 +1,6 @@
 package fitnesse.wiki.fs;
 
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wikitext.parser.VariableSource;
 
@@ -9,20 +10,19 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import fitnesse.wiki.BaseWikiPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PageType;
 import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.util.Clock;
 
-public class ExternalSuitePage extends BaseWikiPage {
+public class ExternalSuitePage extends BaseWikitextPage {
   public static final String HTML = ".html";
 
   private File path;
   private FileSystem fileSystem;
 
-  public ExternalSuitePage(File path, String name, BaseWikiPage parent, FileSystem fileSystem, VariableSource variableSource) {
+  public ExternalSuitePage(File path, String name, WikiPage parent, FileSystem fileSystem, VariableSource variableSource) {
     super(name, parent, variableSource);
     this.path = path;
     this.fileSystem = fileSystem;

--- a/src/fitnesse/wiki/fs/ExternalSuitePageFactory.java
+++ b/src/fitnesse/wiki/fs/ExternalSuitePageFactory.java
@@ -2,12 +2,12 @@ package fitnesse.wiki.fs;
 
 import java.io.File;
 
-import fitnesse.wiki.BaseWikiPage;
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wikitext.parser.VariableSource;
 
-public class ExternalSuitePageFactory implements WikiPageFactory<BaseWikiPage> {
+public class ExternalSuitePageFactory implements WikiPageFactory<WikiPage> {
 
   private final FileSystem fileSystem;
 
@@ -16,7 +16,7 @@ public class ExternalSuitePageFactory implements WikiPageFactory<BaseWikiPage> {
   }
 
   @Override
-  public WikiPage makePage(File path, String pageName, BaseWikiPage parent, VariableSource variableSource) {
+  public WikiPage makePage(File path, String pageName, WikiPage parent, VariableSource variableSource) {
     return new ExternalSuitePage(path, pageName, parent, fileSystem, variableSource);
   }
 

--- a/src/fitnesse/wiki/fs/ExternalTestPage.java
+++ b/src/fitnesse/wiki/fs/ExternalTestPage.java
@@ -6,20 +6,20 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import fitnesse.wiki.BaseWikiPage;
+import fitnesse.util.Clock;
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PageType;
 import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wikitext.parser.VariableSource;
-import fitnesse.util.Clock;
 
-public class ExternalTestPage extends BaseWikiPage {
+public class ExternalTestPage extends BaseWikitextPage {
   private FileSystem fileSystem;
   private File path;
 
-  public ExternalTestPage(File path, String name, BaseWikiPage parent, FileSystem fileSystem, VariableSource variableSource) {
+  public ExternalTestPage(File path, String name, WikiPage parent, FileSystem fileSystem, VariableSource variableSource) {
     super(name, parent, variableSource);
     this.path = path;
     this.fileSystem = fileSystem;

--- a/src/fitnesse/wiki/fs/FileSystemPage.java
+++ b/src/fitnesse/wiki/fs/FileSystemPage.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import fitnesse.wiki.BaseWikiPage;
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PageType;
 import fitnesse.wiki.VersionInfo;
@@ -23,7 +23,7 @@ import util.FileUtil;
 
 import static fitnesse.wiki.PageType.STATIC;
 
-public class FileSystemPage extends BaseWikiPage {
+public class FileSystemPage extends BaseWikitextPage {
 
   static final String contentFilename = "content.txt";
   static final String propertiesFilename = "properties.xml";
@@ -244,11 +244,11 @@ public class FileSystemPage extends BaseWikiPage {
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof FileSystemPage)) return false;
+  public boolean equals(Object other) {
+    if (this == other) return true;
+    if (!(other instanceof FileSystemPage)) return false;
 
-    FileSystemPage that = (FileSystemPage) o;
+    FileSystemPage that = (FileSystemPage) other;
 
     if (versionName != null ? !versionName.equals(that.versionName) : that.versionName != null) return false;
     return super.equals(that);

--- a/src/fitnesse/wiki/fs/FileSystemPageFactory.java
+++ b/src/fitnesse/wiki/fs/FileSystemPageFactory.java
@@ -1,10 +1,16 @@
 package fitnesse.wiki.fs;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
 import fitnesse.ConfigurationParameter;
 import fitnesse.components.ComponentFactory;
-import fitnesse.wiki.BaseWikiPage;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.SymbolicPage;
+import fitnesse.wiki.VariableTool;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wiki.WikiPageFactoryRegistry;
@@ -12,15 +18,8 @@ import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wikitext.parser.VariableSource;
-import fitnesse.wiki.VariableTool;
 import fitnesse.wikitext.parser.Maybe;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
+import fitnesse.wikitext.parser.VariableSource;
 
 public class FileSystemPageFactory implements WikiPageFactory<FileSystemPage>, WikiPageFactoryRegistry {
   private final FileSystem fileSystem;
@@ -112,7 +111,7 @@ public class FileSystemPageFactory implements WikiPageFactory<FileSystemPage>, W
       return children;
     }
 
-    protected List<WikiPage> getSymlinkChildren(BaseWikiPage page) {
+    protected List<WikiPage> getSymlinkChildren(WikiPage page) {
       List<WikiPage> children = new LinkedList<WikiPage>();
       WikiPageProperties props = page.getData().getProperties();
       WikiPageProperty symLinksProperty = props.getProperty(SymbolicPage.PROPERTY_NAME);
@@ -152,7 +151,7 @@ public class FileSystemPageFactory implements WikiPageFactory<FileSystemPage>, W
     }
 
 
-    private WikiPage createSymbolicPage(BaseWikiPage page, String linkName) {
+    private WikiPage createSymbolicPage(WikiPage page, String linkName) {
       WikiPageProperty symLinkProperty = page.getData().getProperties().getProperty(SymbolicPage.PROPERTY_NAME);
       if (symLinkProperty == null)
         return null;
@@ -166,7 +165,7 @@ public class FileSystemPageFactory implements WikiPageFactory<FileSystemPage>, W
         return createInternalSymbolicPage(linkPath, linkName, page);
     }
 
-    private WikiPage createExternalSymbolicLink(String linkPath, String linkName, BaseWikiPage parent) {
+    private WikiPage createExternalSymbolicLink(String linkPath, String linkName, WikiPage parent) {
       String fullPagePath = new VariableTool(variableSource).replace(linkPath);
       File file = WikiPageUtil.resolveFileUri(fullPagePath, rootPath);
       File parentDirectory = file.getParentFile();
@@ -179,7 +178,7 @@ public class FileSystemPageFactory implements WikiPageFactory<FileSystemPage>, W
       return null;
     }
 
-    protected WikiPage createInternalSymbolicPage(String linkPath, String linkName, BaseWikiPage parent) {
+    protected WikiPage createInternalSymbolicPage(String linkPath, String linkName, WikiPage parent) {
       WikiPagePath path = PathParser.parse(linkPath);
       if (path == null) {
         return null;

--- a/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
+++ b/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
@@ -57,12 +57,12 @@ public class FitNesseRunnerExtensionTest {
     }
 
     @Override
-    public void testStarted(WikiTestPage test) {
+    public void testStarted(TestPage test) {
       super.testStarted(test);
     }
 
     @Override
-    public void testComplete(WikiTestPage test, TestSummary testSummary) {
+    public void testComplete(TestPage test, TestSummary testSummary) {
       super.testComplete(test, testSummary);
     }
 

--- a/test/fitnesse/testrunner/WikiTestPageTest.java
+++ b/test/fitnesse/testrunner/WikiTestPageTest.java
@@ -108,6 +108,14 @@ public class WikiTestPageTest {
     assertNotSubString("Scenario Libraries", html);
   }
 
+  @Test
+  public void shouldReturnDecoratedContentForWikitextPages() throws Exception {
+    WikiPage slimTestPage = addPage("SlimTest", "!define TEST_SYSTEM {slim}\n");
+    TestPage testPage = new WikiTestPage(slimTestPage);
+    String content = testPage.getContent();
+    assertSubString("!define TEST_SYSTEM {slim}\n", content);
+  }
+
 
   @Test
   public void shouldNotIncludeScenarioLibrariesIfNotSlimTest() throws Exception {

--- a/test/fitnesse/wiki/BaseWikiPageTest.java
+++ b/test/fitnesse/wiki/BaseWikiPageTest.java
@@ -20,13 +20,13 @@ import util.FileUtil;
 
 public class BaseWikiPageTest {
   private WikiPage linkingPage;
-  private BaseWikiPage root;
+  private WikiPage root;
   private MemoryFileSystem fileSystem;
 
   @Before
   public void setUp() throws Exception {
     fileSystem = new MemoryFileSystem();
-    root = (BaseWikiPage) InMemoryPage.makeRoot("RooT", fileSystem);
+    root = InMemoryPage.makeRoot("RooT", fileSystem);
     WikiPageUtil.addPage(root, PathParser.parse("LinkedPage"), "");
     linkingPage = WikiPageUtil.addPage(root, PathParser.parse("LinkingPage"), "");
     WikiPageUtil.addPage(linkingPage, PathParser.parse("ChildPage"), "");

--- a/test/fitnesse/wiki/SymbolicPageTest.java
+++ b/test/fitnesse/wiki/SymbolicPageTest.java
@@ -18,7 +18,7 @@ import util.FileUtil;
 
 public class SymbolicPageTest {
   private WikiPage root;
-  private BaseWikiPage pageOne;
+  private WikiPage pageOne;
   private WikiPage pageTwo;
   private SymbolicPage symPage;
   private String pageOnePath = "PageOne";
@@ -30,7 +30,7 @@ public class SymbolicPageTest {
   public void setUp() throws Exception {
     root = InMemoryPage.makeRoot("RooT");
     String pageOneContent = "page one";
-    pageOne = (BaseWikiPage) WikiPageUtil.addPage(root, PathParser.parse(pageOnePath), pageOneContent);
+    pageOne = WikiPageUtil.addPage(root, PathParser.parse(pageOnePath), pageOneContent);
     pageTwo = WikiPageUtil.addPage(root, PathParser.parse(pageTwoPath), pageTwoContent);
     symPage = new SymbolicPage("SymPage", pageTwo, pageOne);
   }

--- a/test/fitnesse/wikitext/parser/ParserTestHelper.java
+++ b/test/fitnesse/wikitext/parser/ParserTestHelper.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import fitnesse.html.HtmlElement;
-import fitnesse.wiki.BaseWikiPage;
+import fitnesse.wiki.BaseWikitextPage;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageDummy;
 
@@ -75,7 +75,7 @@ public class ParserTestHelper {
 
   public static String translateTo(WikiPage page, String input) {
     ParsingPage.Cache cache = new ParsingPage.Cache();
-    VariableSource variableSource = new CompositeVariableSource(cache, new BaseWikiPage.ParentPageVariableSource(page));
+    VariableSource variableSource = new CompositeVariableSource(cache, new BaseWikitextPage.ParentPageVariableSource(page));
     Symbol list = Parser.make(new ParsingPage(new WikiSourcePage(page), variableSource, cache), input).parse();
     return new HtmlTranslator(new WikiSourcePage(page), new ParsingPage(new WikiSourcePage(page))).translateTree(list);
   }


### PR DESCRIPTION
Fixed few things while working on the [JBehave test system](https://github.com/amolenaar/fitnesse-jbehave-test-system).

 * Split `BaseWikiPage` in `BaseWikiPage` and `BaseWikitextPage`. `BaseWikiPage` is now a real base implementation, concerned only about it's name and it's parent page. `BaseWikitextPage` adds text parsing, based on FitNesse's wiki text parser.
 * Change many occurrences of `WikiTestPage` to use only `TestPage`.
 * Removed generic type from `TestSystemListener`. Now all interfaces take a `TestPage`.