### PR TITLE
System under test annotation to support multiple annotated fields

### DIFF
--- a/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
+++ b/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
@@ -17,7 +17,7 @@ public class SystemUnderTestMethodExecutor extends MethodExecutor {
     } catch (SlimError e) {
       return MethodExecutionResult.noInstance(instanceName + "." + methodName);
     }
-    Field field = findSystemUnderTest(instance.getClass());
+    Field field = findSystemUnderTest(methodName, instance.getClass(), args);
     if (field != null) {
       Object systemUnderTest = field.get(instance);
       return findAndInvoke(methodName, args, systemUnderTest);
@@ -29,7 +29,19 @@ public class SystemUnderTestMethodExecutor extends MethodExecutor {
     Field[] fields = k.getDeclaredFields();
     for (Field field : fields) {
       if (isSystemUnderTest(field)) {
-        return field;
+          return field;
+        }
+      }
+    return null;
+  }
+
+  private Field findSystemUnderTest(String methodName, Class<?> k, Object[] args) {
+    Field[] fields = k.getDeclaredFields();
+    for (Field field : fields) {
+      if (isSystemUnderTest(field)) {
+        if (null != findMatchingMethod(methodName, field.getType(), args.length)) {
+          return field;
+        }
       }
     }
     return null;


### PR DESCRIPTION
This small change allows a Slim fixture to contain more than one annotated field and search across all of them.

Previously it would just return the first field with the correct annotation, now it checks to see if it contains a compliant method otherwise it moves to the next field.

It allows you to create orchestration style tests that verify several components are behaving correctly together.

Another nice feature now is that it allows you to create fixtures via aggregation rather than inheritance, where test functionality is supplied as components and aggregated by a top level fixture class. Although the annotation name 'SystemUnderTest' does not make so much sense then.

It might make sense therefore to change the name of the annotation to make it more apparent of this extra behaviour?
