### PR TITLE
Wrap classpath entries which contains spaces in quotation marks

### DIFF
--- a/src/fitnesse/testsystems/ClassPath.java
+++ b/src/fitnesse/testsystems/ClassPath.java
@@ -46,10 +46,16 @@ public class ClassPath {
     if (elements.isEmpty()) {
       return "defaultPath";
     } else {
-      String result = StringUtils.join(elements, separator);
-      if (result.contains(" ") && !(result.startsWith("\"") && result.endsWith("\""))) {
-    	 result = "\""+result +"\"";
+      List<String> newElements = new ArrayList<String>();
+      for (String element : elements) {
+        if (element.contains(" ") && !(element.startsWith("\"") && element.endsWith("\""))) {
+          newElements.add("\""+element +"\"");
+        } else {
+          newElements.add(element);
+        }
       }
+
+      String result = StringUtils.join(newElements, separator);
       return result;
     }
   }

--- a/src/fitnesse/testsystems/ClassPath.java
+++ b/src/fitnesse/testsystems/ClassPath.java
@@ -22,23 +22,15 @@ public class ClassPath {
 
   public ClassPath(List<ClassPath> paths) {
     this.elements = new ArrayList<String>();
-    this.separator = paths.get(0).getSeparator();
+    this.separator = paths.get(0).separator;
 
     for (ClassPath path : paths) {
-      for (String element : path.getElements()) {
+      for (String element : path.elements) {
         if (!elements.contains(element)) {
           elements.add(element);
         }
       }
     }
-  }
-
-  public List<String> getElements() {
-    return elements;
-  }
-
-  public String getSeparator() {
-    return separator;
   }
 
   @Override

--- a/test/fitnesse/testsystems/ClassPathTest.java
+++ b/test/fitnesse/testsystems/ClassPathTest.java
@@ -17,4 +17,10 @@ public class ClassPathTest {
 
     assertThat(cp.toString(), is("foo.jar,baz.jar,bar.jar"));
   }
+
+  @Test
+  public void shouldHandleSpaceInPath() {
+    ClassPath cp = new ClassPath(asList("dir/foo.jar", "other dir/bar.jar"), ";");
+    assertThat(cp.toString(), is("dir/foo.jar;\"other dir/bar.jar\""));
+  }
 }


### PR DESCRIPTION
I work on a project where we've run into problems with the classpath in FitNesse when some of the classpath entries contain spaces.

FitNesse will wrap the classpath in quotation marks when it contains a space, but in our case it fails to read the classpath correctly which cause the test run to fail. The information page after a test execution will display the complete classpath, but indicates that the problem occured at a space and that the rest of the classpath was cut off when it tried to run something. We experimented and found that if we didn't have any entries with spaces, it would run fine, however as soon as we added a jar located in a directory with spaces, it would fail.

We looked into how FitNesse constructs the classpath and found that the current behaviour in ClassPath seems to be that if any of the entries contains a space, the entire classpath is wrapped in quotes. (Additionally the path to the FitNesse-jar is prepended this quoted string in ClientBuilder.buildCommand given that it uses ClientBuilder.DEFAULT_COMMAND_PATTERN, but I don't know whether this affects things or not.) The resulting classpath is then used when running tests.

We did some experimenting by tweaking the classpath and hardcoding it into the test page instead of relying on java.class.path. We found that if we individually wrapped the entries containing spaces, we could run the tests again, so this seems to work better. The attached patch changes the wrapping a bit, from wrapping the whole classpath, to individually wrap those entries containing spaces.

Two comments regarding the patch:
* It could potentially add quotation marks around each element regardless, but I don't know if that makes sense or would just make it look confusing.
* The optional commit additionally removes public access getters which wasn't in use (in FitNesse at least). I guess someone out there might be using it, and I'm not clear on the rules changes in the public API. It's not critical, but I think it is at least a bit odd to have a method returning a list with the underlying elements, when the toString-method will potentially represent them in a different way.

Let me know if you have any questions or comments. :)

PS. This is seems to be the underlying cause of the issue I mentioned in #726, though it appears to have been unrelated.