### PR TITLE
Fix various warnings and minor issues

### DIFF
--- a/src/fitnesse/fixtures/HashFixture.java
+++ b/src/fitnesse/fixtures/HashFixture.java
@@ -5,15 +5,15 @@ import java.util.TreeMap;
 
 public class HashFixture {
 
-  private Map hash;
+  private Map<String, Object> hash;
 
-  public void sendAsHash(Map hash) {
+  public void sendAsHash(Map<String, Object> hash) {
     this.hash = hash;
   }
 
-  public Map hash() {
+  public Map<String, Object> hash() {
     // Make result predictable (ordered)
-    return new TreeMap(hash);
+    return new TreeMap<String, Object>(hash);
   }
 
   public Object hashIs(String key) {

--- a/src/fitnesse/responders/testHistory/PageHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PageHistoryResponder.java
@@ -174,6 +174,9 @@ public class PageHistoryResponder implements SecureResponder {
     PageTitle pageTitle = new PageTitle("Test History", PathParser.parse(request.getResource()), "");
     page.setPageTitle(pageTitle);
 
+    // FIXME: This variable might be assigned, but either way it is promptly dropped
+    // shortly after. Is there some non-obvious side-effects or initialization going
+    // on here or could this block potentially be removed? 
     String tags = "";    
     if (context.getRootPage() != null){
       WikiPagePath path = PathParser.parse(pageName);

--- a/src/fitnesse/responders/testHistory/PageHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PageHistoryResponder.java
@@ -27,11 +27,7 @@ import fitnesse.reporting.history.TestExecutionReport;
 import fitnesse.html.template.HtmlPage;
 import fitnesse.html.template.PageTitle;
 import fitnesse.testsystems.ExecutionResult;
-import fitnesse.wiki.PageCrawler;
-import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPagePath;
 
 public class PageHistoryResponder implements SecureResponder {
   private SimpleDateFormat dateFormat = new SimpleDateFormat(PageHistory.TEST_RESULT_FILE_DATE_PATTERN);
@@ -173,20 +169,6 @@ public class PageHistoryResponder implements SecureResponder {
     page = context.pageFactory.newPage();
     PageTitle pageTitle = new PageTitle("Test History", PathParser.parse(request.getResource()), "");
     page.setPageTitle(pageTitle);
-
-    // FIXME: This variable might be assigned, but either way it is promptly dropped
-    // shortly after. Is there some non-obvious side-effects or initialization going
-    // on here or could this block potentially be removed? 
-    String tags = "";    
-    if (context.getRootPage() != null){
-      WikiPagePath path = PathParser.parse(pageName);
-      PageCrawler crawler = context.getRootPage().getPageCrawler();
-      WikiPage wikiPage = crawler.getPage(path);
-      if(wikiPage != null) {
-        PageData pageData = wikiPage.getData();
-        tags = pageData.getAttribute(PageData.PropertySUITES);
-      }
-    }
   }
 
   public SecureOperation getSecureOperation() {

--- a/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
+++ b/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
@@ -25,16 +25,6 @@ public class SystemUnderTestMethodExecutor extends MethodExecutor {
     return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
   }
 
-  private Field findSystemUnderTest(Class<?> k) {
-    Field[] fields = k.getDeclaredFields();
-    for (Field field : fields) {
-      if (isSystemUnderTest(field)) {
-          return field;
-        }
-      }
-    return null;
-  }
-
   private Field findSystemUnderTest(String methodName, Class<?> k, Object[] args) {
     Field[] fields = k.getDeclaredFields();
     for (Field field : fields) {

--- a/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
+++ b/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
@@ -3,15 +3,12 @@ package fitnesse.junit;
 import fitnesse.FitNesseContext;
 import fitnesse.components.PluginsClassLoader;
 import fitnesse.testrunner.MultipleTestsRunner;
-import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.*;
 import org.junit.runner.RunWith;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 
 import java.io.IOException;
-
-import static org.junit.Assert.assertNull;
 
 @RunWith(FitNesseRunnerExtensionTest.SuiteExtension.class)
 @FitNesseRunner.FitnesseDir(".")

--- a/test/fitnesse/plugins/PluginsLoaderTest.java
+++ b/test/fitnesse/plugins/PluginsLoaderTest.java
@@ -24,7 +24,6 @@ import fitnesse.responders.editing.EditResponder;
 import fitnesse.testrunner.MultipleTestSystemFactory;
 import fitnesse.testrunner.TestSystemFactoryRegistry;
 import fitnesse.testrunner.WikiTestPage;
-import fitnesse.testrunner.WikiTestPageUtil;
 import fitnesse.testsystems.Descriptor;
 import fitnesse.testsystems.TestSystem;
 import fitnesse.testsystems.TestSystemFactory;

--- a/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import fitnesse.util.Clock;
 import fitnesse.util.DateAlteringClock;
-import fitnesse.util.TimeMeasurement;
 
 public class SuiteHtmlFormatterTest {
   private SuiteHtmlFormatter formatter;
@@ -198,12 +197,4 @@ public class SuiteHtmlFormatterTest {
     assertHasRegexp("<li.*\\(page2\\).*<span.*>\\(0(" + getDecimalSeparatorForRegExp() + "){1}890 seconds\\)</span>.*</li>", pageBuffer.toString());
   }
 
-  private TimeMeasurement newConstantElapsedTimeMeasurement(final long theElapsedTime) {
-    return new TimeMeasurement() {
-      @Override
-      public long elapsed() {
-        return theElapsedTime;
-      }
-    };
-  }
 }

--- a/test/fitnesse/responders/testHistory/HistoryComparerTest.java
+++ b/test/fitnesse/responders/testHistory/HistoryComparerTest.java
@@ -8,7 +8,6 @@ import static util.RegexTestCase.assertSubString;
 
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.ArrayList;
 
 import fitnesse.wiki.*;
 import org.apache.velocity.app.VelocityEngine;

--- a/test/fitnesse/testsystems/fit/FitClientTest.java
+++ b/test/fitnesse/testsystems/fit/FitClientTest.java
@@ -23,7 +23,6 @@ public class FitClientTest implements FitClientListener {
   private List<TestSummary> counts = new ArrayList<TestSummary>();
   private CommandRunningFitClient client;
   private boolean exceptionOccurred = false;
-  private int port = 9080;
 
   @Before
   public void setUp() throws Exception {

--- a/test/fitnesse/wikitext/parser/CustomLexerTest.java
+++ b/test/fitnesse/wikitext/parser/CustomLexerTest.java
@@ -83,9 +83,6 @@ public class CustomLexerTest {
 
   public static class Lexer {
 
-    private final CharSequence buffer;
-    private final int startOffset;
-    private final int endOffset;
     private final ParseSpecification specification;
     private final Scanner scanner;
     private final Parser parser;
@@ -99,9 +96,6 @@ public class CustomLexerTest {
     }
 
     public Lexer(CharSequence buffer, int startOffset, int endOffset, int initialState) {
-      this.buffer = buffer;
-      this.startOffset = startOffset;
-      this.endOffset = endOffset;
       this.state = initialState;
 
       Parser.make(new LexerParsingPage(), buffer.subSequence(startOffset, endOffset)).parse();

--- a/test/fitnesse/wikitext/parser/CustomLexerTest.java
+++ b/test/fitnesse/wikitext/parser/CustomLexerTest.java
@@ -81,7 +81,7 @@ public class CustomLexerTest {
     return lexedTokens;
   }
 
-  public static class Lexer {
+  private static class Lexer {
 
     private final ParseSpecification specification;
     private final Scanner scanner;
@@ -89,15 +89,12 @@ public class CustomLexerTest {
 
     private Iterator<Symbol> symbolIterator = emptyIterator();
     private Symbol currentSymbol;
-    private int state;
 
     public Lexer(CharSequence buffer) {
-      this(buffer, 0, buffer.length(), 0);
+      this(buffer, 0, buffer.length());
     }
 
-    public Lexer(CharSequence buffer, int startOffset, int endOffset, int initialState) {
-      this.state = initialState;
-
+    public Lexer(CharSequence buffer, int startOffset, int endOffset) {
       Parser.make(new LexerParsingPage(), buffer.subSequence(startOffset, endOffset)).parse();
 
       ParsingPage currentPage = new LexerParsingPage();
@@ -108,19 +105,6 @@ public class CustomLexerTest {
       parser = new Parser(null, currentPage, scanner, specification);
 
       advance();
-    }
-
-    String getTokenText() {
-      return currentSymbol.getContent();
-    }
-
-    /**
-     * Returns the current state of the lexer.
-     *
-     * @return the lexer state.
-     */
-    public int getState() {
-      return state;
     }
 
     /**


### PR DESCRIPTION
* Fixed some more unused imports.
* Add parameters to a raw Map based on its usage.
* Removed some unused methods.
* Removed some unused fields. (Note that there's an optional commit which reduces visibility for an inner class in a test suite which made it possible to remove more unused methods and fields from it.)

I've left an open question regarding the unused local variable in PageHistoryResponder. There's a section of the code which spends time and effort assign a value to this variable, but it is never used for anything. I don't know what the intended behaviour here is, because it could be that the value should be used for something, or that the traversing cause some side-effects which are needed here, or potentially that the section is unnecessary and could be removed.