### PR TITLE
Immutable Exceptions

### DIFF
--- a/src/fitnesse/responders/WikiImportingTraverser.java
+++ b/src/fitnesse/responders/WikiImportingTraverser.java
@@ -89,9 +89,9 @@ public class WikiImportingTraverser implements WikiImporterClient, Traverser<Obj
   }
 
   public static class ImportError {
-    private String message;
-    private String type;
-    private Exception exception;
+    private final String message;
+    private final String type;
+    private final Exception exception;
 
     public ImportError(String type, String message) {
       this(type, message, null);

--- a/src/fitnesse/slim/SlimException.java
+++ b/src/fitnesse/slim/SlimException.java
@@ -3,16 +3,16 @@ package fitnesse.slim;
 public class SlimException extends Exception {
   private static final String PRETTY_PRINT_TAG_START = "message:<<";
   private static final String PRETTY_PRINT_TAG_END = ">>";
-  private String tag;
-  private boolean prettyPrint;
+
+  private final String tag;
+  private final boolean prettyPrint;
 
   public SlimException(String message) {
-    this(message, false);
+    this(message, "", false);
   }
 
   public SlimException(String message, boolean prettyPrint) {
-    super(message);
-    this.prettyPrint = prettyPrint;
+    this(message, "", prettyPrint);
   }
 
   public SlimException(String message, String tag) {
@@ -26,12 +26,11 @@ public class SlimException extends Exception {
   }
 
   public SlimException(Throwable cause) {
-    this(cause, false);
+    this(cause, "", false);
   }
 
   public SlimException(Throwable cause, boolean prettyPrint) {
-    super(cause);
-    this.prettyPrint = prettyPrint;
+    this(cause, "", prettyPrint);
   }
 
   public SlimException(Throwable cause, String tag) {
@@ -49,8 +48,7 @@ public class SlimException extends Exception {
   }
 
   public SlimException(String message, Throwable cause, boolean prettyPrint) {
-    super(message, cause);
-    this.prettyPrint = prettyPrint;
+    this(message, cause, "", prettyPrint);
   }
 
   public SlimException(String message, Throwable cause, String tag) {


### PR DESCRIPTION
 Made all fields in exception and errors final so that they cannot be changed after a problem occured.

SlimException checks on line 90 if tag is null or empty, so should be equivalent behaviour to assign an empty string if it is not passed in from the constructor.