### PR TITLE
Replace use of StringBuffer with StringBuilder and String

### DIFF
--- a/src/fit/Fixture.java
+++ b/src/fit/Fixture.java
@@ -257,7 +257,7 @@ public class Fixture {
   }
 
   public static String camel(String name) {
-    StringBuffer b = new StringBuffer(name.length());
+    StringBuilder b = new StringBuilder(name.length());
     StringTokenizer t = new StringTokenizer(name);
     b.append(t.nextToken());
     while (t.hasMoreTokens()) {

--- a/src/fit/TypeAdapter.java
+++ b/src/fit/TypeAdapter.java
@@ -327,7 +327,7 @@ public class TypeAdapter {
       if (o == null)
         return "";
       int length = Array.getLength(o);
-      StringBuffer b = new StringBuffer(5 * length);
+      StringBuilder b = new StringBuilder(5 * length);
       for (int i = 0; i < length; i++) {
         b.append(componentAdapter.toString(Array.get(o, i)));
         if (i < (length - 1)) {

--- a/src/fitnesse/components/Logger.java
+++ b/src/fitnesse/components/Logger.java
@@ -51,9 +51,7 @@ public class Logger {
   }
 
   static String makeLogFileName(Calendar calendar) {
-    StringBuilder name = new StringBuilder();
-    name.append("fitnesse").append(format(makeFileNameFormat(), calendar)).append(".log");
-    return name.toString();
+    return "fitnesse" + format(makeFileNameFormat(), calendar) + ".log";
   }
 
   public void log(LogData data) {

--- a/src/fitnesse/components/Logger.java
+++ b/src/fitnesse/components/Logger.java
@@ -40,7 +40,7 @@ public class Logger {
   }
 
   String formatLogLine(LogData data) {
-    StringBuffer line = new StringBuffer();
+    StringBuilder line = new StringBuilder();
     line.append(data.host).append(" - ");
     line.append(data.username == null ? "-" : data.username);
     line.append(" [").append(format(makeLogFormat(), data.time)).append("] ");
@@ -51,7 +51,7 @@ public class Logger {
   }
 
   static String makeLogFileName(Calendar calendar) {
-    StringBuffer name = new StringBuffer();
+    StringBuilder name = new StringBuilder();
     name.append("fitnesse").append(format(makeFileNameFormat(), calendar)).append(".log");
     return name.toString();
   }

--- a/src/fitnesse/html/HtmlUtil.java
+++ b/src/fitnesse/html/HtmlUtil.java
@@ -69,7 +69,7 @@ public class HtmlUtil {
     String getElement = "document.getElementById(\"" + idElementToAppend + "\")";
     String escapedHtml = escapeHtmlForJavaScript(htmlToAppend);
     
-    StringBuffer script = new StringBuffer();
+    StringBuilder script = new StringBuilder();
     script.append("var existingContent = ").append(getElement).append(".innerHTML;");
     script.append(HtmlTag.endl);
     script.append(getElement).append(".innerHTML = existingContent + \"").append(escapedHtml).append("\";");

--- a/src/fitnesse/html/TagGroup.java
+++ b/src/fitnesse/html/TagGroup.java
@@ -8,7 +8,7 @@ public class TagGroup extends HtmlTag {
   }
 
   public String html(int depth) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (HtmlElement element : this) {
       if (element instanceof HtmlTag)
         buffer.append(((HtmlTag) element).html(depth));

--- a/src/fitnesse/http/Request.java
+++ b/src/fitnesse/http/Request.java
@@ -193,7 +193,7 @@ public class Request {
   }
 
   private String concatenateItems(String existingItem, String value) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append(existingItem);
     buffer.append(',');
     buffer.append(value);

--- a/src/fitnesse/http/Request.java
+++ b/src/fitnesse/http/Request.java
@@ -193,11 +193,7 @@ public class Request {
   }
 
   private String concatenateItems(String existingItem, String value) {
-    StringBuilder buffer = new StringBuilder();
-    buffer.append(existingItem);
-    buffer.append(',');
-    buffer.append(value);
-    return buffer.toString();
+    return existingItem + ',' + value;
   }
 
   private boolean itemExistAndMismatches(Object existingItem, String value) {

--- a/src/fitnesse/http/RequestBuilder.java
+++ b/src/fitnesse/http/RequestBuilder.java
@@ -11,7 +11,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.SecureRandom;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -81,8 +80,7 @@ public class RequestBuilder {
 
   private void sendHeaders(OutputStream output) throws IOException {
     addHostHeader();
-    for (Iterator<String> iterator = headers.keySet().iterator(); iterator.hasNext();) {
-      String key = iterator.next();
+    for (String key : headers.keySet()) {
       output.write((key + ": " + headers.get(key)).getBytes(CHARENCODING));
       output.write(ENDL);
     }
@@ -94,8 +92,7 @@ public class RequestBuilder {
       bodyParts.add(new ByteArrayInputStream(bytes));
       bodyLength += bytes.length;
     } else {
-      for (Iterator<String> iterator = inputs.keySet().iterator(); iterator.hasNext();) {
-        String name = iterator.next();
+      for (String name : inputs.keySet()) {
         Object value = inputs.get(name);
         StringBuilder partBuffer = new StringBuilder();
         partBuffer.append("--").append(getBoundary()).append("\r\n");
@@ -116,9 +113,8 @@ public class RequestBuilder {
           addBodyPart(partBuffer.toString());
         }
       }
-      StringBuilder tail = new StringBuilder();
-      tail.append("--").append(getBoundary()).append("--").append("\r\n");
-      addBodyPart(tail.toString());
+      String tail = "--" + getBoundary() + "--" + "\r\n";
+      addBodyPart(tail);
     }
     addHeader("Content-Length", bodyLength + "");
   }
@@ -130,9 +126,7 @@ public class RequestBuilder {
   }
 
   private void sendBody(OutputStream output) throws IOException {
-    for (Iterator<InputStream> iterator = bodyParts.iterator(); iterator.hasNext();) {
-      InputStream input = iterator.next();
-
+    for (InputStream input : bodyParts) {
       StreamReader reader = new StreamReader(input);
       while (!reader.isEof()) {
         byte[] bytes = reader.readBytes(1000);
@@ -155,8 +149,7 @@ public class RequestBuilder {
   public String inputString() throws UnsupportedEncodingException {
     StringBuilder buffer = new StringBuilder();
     boolean first = true;
-    for (Iterator<String> iterator = inputs.keySet().iterator(); iterator.hasNext();) {
-      String key = iterator.next();
+    for (String key : inputs.keySet()) {
       String value = (String) inputs.get(key);
       if (!first)
         buffer.append("&");

--- a/src/fitnesse/http/ResponseParser.java
+++ b/src/fitnesse/http/ResponseParser.java
@@ -70,7 +70,7 @@ public class ResponseParser {
   }
 
   private void parseChunks() throws IOException {
-    StringBuffer bodyBuffer = new StringBuffer();
+    StringBuilder bodyBuffer = new StringBuilder();
     int chunkSize = readChunkSize();
     while (chunkSize != 0) {
       bodyBuffer.append(input.read(chunkSize));
@@ -107,7 +107,7 @@ public class ResponseParser {
   }
 
   public String toString() {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append("Status: ").append(status).append("\n");
     buffer.append("Headers: ").append("\n");
     for (String key : headers.keySet()) {

--- a/src/fitnesse/junit/JavaFormatter.java
+++ b/src/fitnesse/junit/JavaFormatter.java
@@ -208,7 +208,7 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append("<tr class=\"").append(getCssClass(testSummary)).append("\"><td>").append(
               "<a href=\"").append(testName).append(".html\">").append(testName).append("</a>").append(
               "</td><td>").append(testSummary.getRight()).append("</td><td>").append(testSummary.getWrong())
@@ -244,7 +244,7 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer();
+      StringBuilder sb = new StringBuilder();
       sb.append(SUMMARY_HEADER);
       for (String s : visitedTestPages) {
         sb.append(summaryRow(s, testSummaries.get(s)));

--- a/src/fitnesse/responders/ErrorResponder.java
+++ b/src/fitnesse/responders/ErrorResponder.java
@@ -44,7 +44,7 @@ public class ErrorResponder implements Responder {
   }
 
   public static String makeExceptionString(Throwable e) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append(e.toString()).append("\n");
     StackTraceElement[] stackTreace = e.getStackTrace();
     for (int i = 0; i < stackTreace.length; i++)

--- a/src/fitnesse/slim/SlimException.java
+++ b/src/fitnesse/slim/SlimException.java
@@ -76,7 +76,7 @@ public class SlimException extends Exception {
    */
   @Override
   public String toString() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
 
     if (isStopTestException(getCause())) {
       sb.append(SlimServer.EXCEPTION_STOP_TEST_TAG);

--- a/src/fitnesse/slim/StackTraceEnricher.java
+++ b/src/fitnesse/slim/StackTraceEnricher.java
@@ -35,7 +35,7 @@ public class StackTraceEnricher {
   }
 
   public String getStackTraceAsString(Throwable throwable) {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     Throwable t = throwable;
     if (throwable.getStackTrace() == null || throwable.getStackTrace().length == 0) {
       t = throwable.fillInStackTrace();

--- a/src/fitnesse/slim/instructions/Instruction.java
+++ b/src/fitnesse/slim/instructions/Instruction.java
@@ -41,11 +41,7 @@ public abstract class Instruction {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("Instruction");
-    sb.append("{id='").append(id).append('\'');
-    sb.append('}');
-    return sb.toString();
+    return "Instruction{id='" + id + "'}";
   }
 
   @Override

--- a/src/fitnesse/testrunner/WikiTestPageUtil.java
+++ b/src/fitnesse/testrunner/WikiTestPageUtil.java
@@ -8,10 +8,7 @@ import fitnesse.wiki.WikiPageUtil;
 public class WikiTestPageUtil {
 
   public static String makePageHtml(WikiTestPage page){
-    StringBuilder buffer = new StringBuilder();
-    buffer.append(WikiPageUtil.getHeaderPageHtml(page.getSourcePage()));
-    buffer.append(page.getHtml());
-    return buffer.toString();
+    return WikiPageUtil.getHeaderPageHtml(page.getSourcePage()) + page.getHtml();
   }
 
   public static WikiPage getSourcePage(TestPage testPage) {

--- a/src/fitnesse/testrunner/WikiTestPageUtil.java
+++ b/src/fitnesse/testrunner/WikiTestPageUtil.java
@@ -8,7 +8,7 @@ import fitnesse.wiki.WikiPageUtil;
 public class WikiTestPageUtil {
 
   public static String makePageHtml(WikiTestPage page){
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append(WikiPageUtil.getHeaderPageHtml(page.getSourcePage()));
     buffer.append(page.getHtml());
     return buffer.toString();

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -44,7 +44,7 @@ public class DecisionTable extends SlimTable {
   }
 
   private String getScenarioName() {
-    StringBuffer nameBuffer = new StringBuffer();
+    StringBuilder nameBuffer = new StringBuilder();
     for (int nameCol = 0; nameCol < table.getColumnCountInRow(0); nameCol += 2) {
       if (nameCol == 0)
         nameBuffer.append(getFixtureName(table.getCellContents(nameCol, 0)));

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -135,7 +135,7 @@ private void splitInputAndOutputArguments(String argName) {
   }
 
   private String getNameFromAlternatingCells() {
-    StringBuffer nameBuffer = new StringBuffer();
+    StringBuilder nameBuffer = new StringBuilder();
 
     for (int nameCol = 1; nameCol < colsInHeader; nameCol += 2)
       nameBuffer.append(table.getCellContents(nameCol, 0)).append(" ");

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -258,7 +258,7 @@ public class ScriptTable extends SlimTable {
   }
 
   protected String getActionNameStartingAt(int startingCol, int endingCol, int row) {
-    StringBuffer actionName = new StringBuffer();
+    StringBuilder actionName = new StringBuilder();
     actionName.append(table.getCellContents(startingCol, row));
     int actionNameCol = startingCol + 2;
     while (actionNameCol <= endingCol &&

--- a/src/fitnesse/wiki/PageCrawlerImpl.java
+++ b/src/fitnesse/wiki/PageCrawlerImpl.java
@@ -79,7 +79,7 @@ public class PageCrawlerImpl implements PageCrawler {
   }
 
   public String getRelativeName(WikiPage page) {
-    StringBuffer name = new StringBuffer();
+    StringBuilder name = new StringBuilder();
     for (WikiPage p = page; !p.isRoot() && !p.equals(context); p = p.getParent()) {
       if (p != page)
         name.insert(0, ".");

--- a/src/fitnesse/wiki/PathParser.java
+++ b/src/fitnesse/wiki/PathParser.java
@@ -60,7 +60,7 @@ public class PathParser {
   }
 
   public static String render(WikiPagePath path) {
-    StringBuffer renderedPath = new StringBuffer();
+    StringBuilder renderedPath = new StringBuilder();
     if (path.isSubPagePath())
       renderedPath.append(">");
     else if (path.isBackwardSearchPath())

--- a/src/fitnesse/wiki/RecentChangesWikiPage.java
+++ b/src/fitnesse/wiki/RecentChangesWikiPage.java
@@ -102,7 +102,7 @@ public class RecentChangesWikiPage implements RecentChanges {
   }
 
   private String convertLinesToWikiText(List<String> lines) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
       String s = iterator.next();
       buffer.append(s).append("\n");

--- a/src/fitnesse/wiki/WikiPageProperties.java
+++ b/src/fitnesse/wiki/WikiPageProperties.java
@@ -140,7 +140,7 @@ public class WikiPageProperties extends WikiPageProperty implements Serializable
   }
 
   public String toString() {
-    StringBuffer s = new StringBuffer();
+    StringBuilder s = new StringBuilder();
     s.append(super.toString("WikiPageProperties", 0));
     return s.toString();
   }

--- a/src/fitnesse/wiki/WikiPageProperties.java
+++ b/src/fitnesse/wiki/WikiPageProperties.java
@@ -140,9 +140,7 @@ public class WikiPageProperties extends WikiPageProperty implements Serializable
   }
 
   public String toString() {
-    StringBuilder s = new StringBuilder();
-    s.append(super.toString("WikiPageProperties", 0));
-    return s.toString();
+    return super.toString("WikiPageProperties", 0);
   }
 
   public Date getLastModificationTime() {

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -87,8 +87,7 @@ public class WikiPageProperty implements Serializable {
       buffer.append(" = ").append(getValue());
     buffer.append("\n");
 
-    for (Iterator<?> iterator = keySet().iterator(); iterator.hasNext();) {
-      String childKey = (String) iterator.next();
+    for (String childKey : keySet()) {
       WikiPageProperty value = getProperty(childKey);
       if (value != null)
         buffer.append(value.toString(childKey, depth + 1));

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -78,7 +78,7 @@ public class WikiPageProperty implements Serializable {
   }
 
   protected String toString(String key, int depth) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
 
     for (int i = 0; i < depth; i++)
       buffer.append("\t");

--- a/src/fitnesse/wikitext/parser/Expression.java
+++ b/src/fitnesse/wikitext/parser/Expression.java
@@ -14,7 +14,7 @@ public class Expression {
    */
   private double term() {
     double ans = 0;
-    StringBuffer temp = new StringBuffer();
+    StringBuilder temp = new StringBuilder();
     while (!s.isEmpty() && Character.isDigit(s.charAt(0))) {
       temp.append(Integer.parseInt("" + s.charAt(0)));
       advance();


### PR DESCRIPTION
Replaced use of StringBuffer since it has synchronized methods which has a negative impact on performance. Additionally, a couple of places could use a simple String instead.

(As a bonus, also a few places where foreach could be utilized.)


I left some cases alone, like Logger.formatLogLine(LogData) and various toString-methods where it wasn't clear if a single String would increas or hinder readability.