### PR TITLE
Issues with modifiers and related

### DIFF
--- a/src/fit/FixtureListener.java
+++ b/src/fit/FixtureListener.java
@@ -4,7 +4,7 @@
 package fit;
 
 public interface FixtureListener {
-  public void tableFinished(Parse table);
+  void tableFinished(Parse table);
 
-  public void tablesFinished(Counts count);
+  void tablesFinished(Counts count);
 }

--- a/src/fitnesse/Responder.java
+++ b/src/fitnesse/Responder.java
@@ -6,5 +6,5 @@ import fitnesse.http.Request;
 import fitnesse.http.Response;
 
 public interface Responder {
-  public Response makeResponse(FitNesseContext context, Request request) throws Exception;
+  Response makeResponse(FitNesseContext context, Request request) throws Exception;
 }

--- a/src/fitnesse/authentication/PasswordCipher.java
+++ b/src/fitnesse/authentication/PasswordCipher.java
@@ -3,5 +3,5 @@
 package fitnesse.authentication;
 
 public interface PasswordCipher {
-  public String encrypt(String password);
+  String encrypt(String password);
 }

--- a/src/fitnesse/authentication/SecureOperation.java
+++ b/src/fitnesse/authentication/SecureOperation.java
@@ -6,5 +6,5 @@ import fitnesse.FitNesseContext;
 import fitnesse.http.Request;
 
 public interface SecureOperation {
-  public abstract boolean shouldAuthenticate(FitNesseContext context, Request request);
+  abstract boolean shouldAuthenticate(FitNesseContext context, Request request);
 }

--- a/src/fitnesse/authentication/SecureOperation.java
+++ b/src/fitnesse/authentication/SecureOperation.java
@@ -6,5 +6,5 @@ import fitnesse.FitNesseContext;
 import fitnesse.http.Request;
 
 public interface SecureOperation {
-  abstract boolean shouldAuthenticate(FitNesseContext context, Request request);
+  boolean shouldAuthenticate(FitNesseContext context, Request request);
 }

--- a/src/fitnesse/http/ResponseSender.java
+++ b/src/fitnesse/http/ResponseSender.java
@@ -5,9 +5,9 @@ package fitnesse.http;
 import java.net.Socket;
 
 public interface ResponseSender {
-  public void send(byte[] bytes);
+  void send(byte[] bytes);
 
-  public void close();
+  void close();
 
-  public Socket getSocket(); //TODO-MdM maybe get rid of this method.
+  Socket getSocket(); //TODO-MdM maybe get rid of this method.
 }

--- a/src/fitnesse/slim/Jsr223StatementExecutor.java
+++ b/src/fitnesse/slim/Jsr223StatementExecutor.java
@@ -29,7 +29,7 @@ public abstract class Jsr223StatementExecutor implements StatementExecutorInterf
   }
 
   @Override
-  public void create(String instanceName, String className, Object[] args) {
+  public void create(String instanceName, String className, Object... args) {
     callMethod("create", new Object[] {instanceName, className, args});
   }
 

--- a/src/fitnesse/slim/NameTranslator.java
+++ b/src/fitnesse/slim/NameTranslator.java
@@ -1,5 +1,5 @@
 package fitnesse.slim;
 
 public interface NameTranslator {
-  public String translate(String name);
+  String translate(String name);
 }

--- a/src/fitnesse/slim/StatementExecutorInterface.java
+++ b/src/fitnesse/slim/StatementExecutorInterface.java
@@ -12,13 +12,13 @@ public interface StatementExecutorInterface extends InstructionExecutor {
    * Have a look to this FitNesse page for some examples:
    * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
    */
-  public abstract Object getSymbol(String symbolName);
+  Object getSymbol(String symbolName);
 	
-  public abstract Object getInstance(String instanceName);
+  Object getInstance(String instanceName);
 
-  public abstract boolean stopHasBeenRequested();
+  boolean stopHasBeenRequested();
 
-  public abstract void reset();
+  void reset();
 
-  public abstract void setInstance(String actorInstanceName, Object actor);
+  void setInstance(String actorInstanceName, Object actor);
 }

--- a/src/fitnesse/slim/test/TestSlimInterface.java
+++ b/src/fitnesse/slim/test/TestSlimInterface.java
@@ -5,24 +5,24 @@ import java.util.List;
 
 public interface TestSlimInterface {
 
-  public abstract boolean niladWasCalled();
+  boolean niladWasCalled();
 
-  public abstract String getStringArg();
+  String getStringArg();
 
-  public abstract int getIntArg();
+  int getIntArg();
 
-  public abstract double getDoubleArg();
+  double getDoubleArg();
 
-  public abstract List<Object> getListArg();
+  List<Object> getListArg();
 
-  public abstract Date getDateArg();
+  Date getDateArg();
 
-  public abstract Zork getZork();
+  Zork getZork();
 
-  public abstract Integer getIntegerObjectArg();
+  Integer getIntegerObjectArg();
 
-  public abstract double getDoubleObjectArg();
+  double getDoubleObjectArg();
 
-  public abstract char getCharArg();
+  char getCharArg();
 
 }

--- a/src/fitnesse/socketservice/SocketServer.java
+++ b/src/fitnesse/socketservice/SocketServer.java
@@ -14,6 +14,7 @@ public interface SocketServer {
 
   public void serve(Socket s) throws IOException;
 
+  //TODO: Hm, how does static inner classes in interfaces work...
   static class StreamUtility {
     public static PrintStream GetPrintStream(Socket s) throws IOException {
       OutputStream os = s.getOutputStream();

--- a/src/fitnesse/testrunner/Stoppable.java
+++ b/src/fitnesse/testrunner/Stoppable.java
@@ -4,5 +4,5 @@ package fitnesse.testrunner;
 
 
 public interface Stoppable {
-    public void stop();
+    void stop();
 }

--- a/src/fitnesse/testsystems/slim/TableScanner.java
+++ b/src/fitnesse/testsystems/slim/TableScanner.java
@@ -5,10 +5,10 @@ package fitnesse.testsystems.slim;
 import java.util.Iterator;
 
 public interface TableScanner<T extends Table> extends Iterable<T> {
-  public int getTableCount();
+  int getTableCount();
 
-  public T getTable(int i);
+  T getTable(int i);
 
   @Override
-  public Iterator<T> iterator();
+  Iterator<T> iterator();
 }

--- a/src/fitnesse/updates/Update.java
+++ b/src/fitnesse/updates/Update.java
@@ -5,11 +5,11 @@ package fitnesse.updates;
 import java.io.IOException;
 
 public interface Update {
-  public String getName();
+  String getName();
 
-  public String getMessage();
+  String getMessage();
 
-  public boolean shouldBeApplied() throws IOException;
+  boolean shouldBeApplied() throws IOException;
 
-  public void doUpdate() throws IOException;
+  void doUpdate() throws IOException;
 }

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -6,7 +6,6 @@ import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 import java.util.SortedMap;

--- a/src/fitnesse/wiki/search/CompositePageFinder.java
+++ b/src/fitnesse/wiki/search/CompositePageFinder.java
@@ -1,0 +1,7 @@
+package fitnesse.wiki.search;
+
+public interface CompositePageFinder extends PageFinder {
+
+  public abstract void add(PageFinder finder);
+
+}

--- a/src/fitnesse/wiki/search/CompositePageFinder.java
+++ b/src/fitnesse/wiki/search/CompositePageFinder.java
@@ -2,6 +2,6 @@ package fitnesse.wiki.search;
 
 public interface CompositePageFinder extends PageFinder {
 
-  public abstract void add(PageFinder finder);
+  void add(PageFinder finder);
 
 }

--- a/src/fitnesse/wiki/search/CompositePageFinder.java
+++ b/src/fitnesse/wiki/search/CompositePageFinder.java
@@ -1,7 +1,0 @@
-package fitnesse.wiki.search;
-
-public interface CompositePageFinder extends PageFinder {
-
-  public abstract void add(PageFinder finder);
-
-}

--- a/src/fitnesse/wiki/search/PageFinder.java
+++ b/src/fitnesse/wiki/search/PageFinder.java
@@ -4,6 +4,6 @@ import fitnesse.wiki.WikiPage;
 
 public interface PageFinder {
 
-  public abstract void search(WikiPage page);
+  abstract void search(WikiPage page);
 
 }

--- a/test/fit/FitServerTest.java
+++ b/test/fit/FitServerTest.java
@@ -316,7 +316,7 @@ public class FitServerTest {
   }
 
   private String readWholeResponse() throws Exception {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     String block = readFromFitServer();
     while (!block.isEmpty()) {
       buffer.append(block);

--- a/test/fit/FixtureTest.java
+++ b/test/fit/FixtureTest.java
@@ -195,7 +195,7 @@ public class FixtureTest {
   }
 
   private static String makeFixtureTable(String table[][]) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("<table>\n");
     for (String[] row : table) {
       buf.append("  <tr>");

--- a/test/fitnesse/components/PluginsClassLoaderTest.java
+++ b/test/fitnesse/components/PluginsClassLoaderTest.java
@@ -5,6 +5,7 @@ import static util.RegexTestCase.assertMatches;
 import static util.RegexTestCase.assertNotSubString;
 import static util.RegexTestCase.assertSubString;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import java.io.File;
 import java.net.URL;
@@ -73,10 +74,7 @@ public class PluginsClassLoaderTest {
 
   private String classpathAsString(URLClassLoader classLoader) {
     URL[] urls = classLoader.getURLs();
-    StringBuffer urlString = new StringBuffer();
-    for (int i = 0; i < urls.length; i++)
-      urlString.append(urls[i].toString()).append(":");
-    return urlString.toString();
+    return StringUtils.join(urls, ":");
   }
 
 

--- a/test/fitnesse/plugins/PluginsLoaderTest.java
+++ b/test/fitnesse/plugins/PluginsLoaderTest.java
@@ -303,7 +303,7 @@ public class PluginsLoaderTest {
     }
   }
 
-  static public class DummyPlugin {
+  public static class DummyPlugin {
 
     public static void registerResponders(ResponderFactory factory) {
       factory.addResponder("custom1", WikiPageResponder.class);
@@ -315,7 +315,7 @@ public class PluginsLoaderTest {
     }
   }
 
-  static public class InstantiableDummyPlugin {
+  public static class InstantiableDummyPlugin {
 
     public final ComponentFactory componentFactory;
 

--- a/test/fitnesse/responders/NameWikiPageResponderTest.java
+++ b/test/fitnesse/responders/NameWikiPageResponderTest.java
@@ -129,7 +129,7 @@ public class NameWikiPageResponderTest {
     assertHasRegexp("FrontPage 2", response.getContent());
   }
 
-  static private int CountLines(String s) {
+  private static int CountLines(String s) {
     if(s == null) { return 0; }
     return s.split("\r\n|\r|\n").length;
   }

--- a/test/fitnesse/responders/run/TestResponderTest.java
+++ b/test/fitnesse/responders/run/TestResponderTest.java
@@ -337,7 +337,7 @@ public class TestResponderTest {
   public void slimScenarioXmlFormat() throws Exception {
     responder.turnOffChunking();
     request.addInput("format", "xml");
-    doSimpleRun(XmlChecker.slimScenarioTable);
+    doSimpleRun(XmlChecker.SLIM_SCENARIO_TABLE);
     xmlChecker.assertXmlReportOfSlimScenarioTableIsCorrect();
   }
 
@@ -703,7 +703,7 @@ public class TestResponderTest {
       checkExpectation(instructionList, 4, "decisionTable_0_10", "1", "3", "pass", "ReturnedValueExpectation", null, null, "wow");
     }
 
-    public final static String slimScenarioTable =
+    private static final String SLIM_SCENARIO_TABLE =
       "!define TEST_SYSTEM {slim}\n" +
         "\n" +
         "!|scenario|f|a|\n" +

--- a/test/fitnesse/responders/search/ExecuteSearchPropertiesResponderTest.java
+++ b/test/fitnesse/responders/search/ExecuteSearchPropertiesResponderTest.java
@@ -28,6 +28,7 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageUtil;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -134,21 +135,9 @@ public class ExecuteSearchPropertiesResponderTest {
   private void assertPageTypesMatch(PageType... pageTypes) {
     MockRequest request = new MockRequest();
     List<PageType> types = Arrays.asList(pageTypes);
-    final String commaSeparatedPageTypes = buildPageTypeListForRequest(pageTypes);
+    final String commaSeparatedPageTypes = StringUtils.join(pageTypes, ",");
     request.addInput(PAGE_TYPE_ATTRIBUTE, commaSeparatedPageTypes);
     assertEquals(types, responder.getPageTypesFromInput(request));
-  }
-
-  private String buildPageTypeListForRequest(PageType... pageTypes) {
-    StringBuffer buffer = new StringBuffer();
-    for (PageType type: pageTypes) {
-      buffer.append(type.toString());
-      buffer.append(',');
-    }
-    buffer.deleteCharAt(buffer.length()-1);
-
-    final String commaSeparatedPageTypes = buffer.toString();
-    return commaSeparatedPageTypes;
   }
 
   @Test

--- a/test/fitnesse/slim/SlimGetSymbolTestBase.java
+++ b/test/fitnesse/slim/SlimGetSymbolTestBase.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 // Extracted Test class to be implemented by all Java based Slim ports
 
-abstract public class SlimGetSymbolTestBase {
+public abstract class SlimGetSymbolTestBase {
   protected StatementExecutorInterface caller;
 
   @Before

--- a/test/fitnesse/slim/SlimMethodInvocationTestBase.java
+++ b/test/fitnesse/slim/SlimMethodInvocationTestBase.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 // Extracted Test class to be implemented by all Java based Slim ports
 // The tests for PhpSlim and JsSlim implement this class
 
-abstract public class SlimMethodInvocationTestBase {
+public abstract class SlimMethodInvocationTestBase {
   protected StatementExecutorInterface caller;
   protected TestSlimInterface testSlim;
   protected String testClass = "TestSlim";

--- a/test/fitnesse/slim/StatementExecutorTestBase.java
+++ b/test/fitnesse/slim/StatementExecutorTestBase.java
@@ -35,26 +35,26 @@ public abstract class StatementExecutorTestBase {
 
   protected int library = 0;
 
-  public interface Echo {
-    public void echo();
+  interface Echo {
+    void echo();
 
-    public boolean echoCalled();
+    boolean echoCalled();
   }
 
-  public interface Speak {
-    public void speak();
+  interface Speak {
+    void speak();
 
-    public boolean speakCalled();
+    boolean speakCalled();
   }
 
-  public interface Delete {
-    public void delete(String fileName);
+  interface Delete {
+    void delete(String fileName);
 
-    public boolean deleteCalled();
+    boolean deleteCalled();
   }
 
-  public interface SystemUnderTestFixture {
-    public MySystemUnderTestBase getSystemUnderTest();
+  interface SystemUnderTestFixture {
+    MySystemUnderTestBase getSystemUnderTest();
   }
 
   abstract static class MySystemUnderTestBase implements Speak, Echo {

--- a/test/fitnesse/slim/StatementExecutorTestBase.java
+++ b/test/fitnesse/slim/StatementExecutorTestBase.java
@@ -57,24 +57,24 @@ public abstract class StatementExecutorTestBase {
     public MySystemUnderTestBase getSystemUnderTest();
   }
 
-  public abstract static class MySystemUnderTestBase implements Speak, Echo {
+  abstract static class MySystemUnderTestBase implements Speak, Echo {
   }
 
-  public static abstract class MyAnnotatedSystemUnderTestFixture implements Echo,
+  abstract static class MyAnnotatedSystemUnderTestFixture implements Echo,
       SystemUnderTestFixture {
   }
 
-  public static abstract class FixtureWithNamedSystemUnderTestBase implements Echo,
+  abstract static class FixtureWithNamedSystemUnderTestBase implements Echo,
       SystemUnderTestFixture {
   }
 
-  public static abstract class SimpleFixture implements Echo {
+  abstract static class SimpleFixture implements Echo {
   }
 
-  public static abstract class EchoSupport implements Echo, Speak {
+  abstract static class EchoSupport implements Echo, Speak {
   }
 
-  public static abstract class FileSupport implements Delete {
+  abstract static class FileSupport implements Delete {
   }
 
   public abstract void init() throws Exception;

--- a/test/fitnesse/socketservice/SocketServiceTest.java
+++ b/test/fitnesse/socketservice/SocketServiceTest.java
@@ -19,8 +19,7 @@ public class SocketServiceTest {
   private int connections = 0;
   private SocketServer connectionCounter;
   private SocketService ss;
-  private final static int portNumber = 1999;
-
+  private static final int PORT_NUMBER = 1999;
 
   public SocketServiceTest() {
     connectionCounter = new SocketServer() {
@@ -37,32 +36,32 @@ public class SocketServiceTest {
 
   @Test
   public void testNoConnections() throws Exception {
-    ss = new SocketService(portNumber, connectionCounter);
+    ss = new SocketService(PORT_NUMBER, connectionCounter);
     ss.close();
     assertEquals(0, connections);
   }
 
   @Test
   public void testOneConnection() throws Exception {
-    ss = new SocketService(portNumber, connectionCounter);
-    connect(portNumber);
+    ss = new SocketService(PORT_NUMBER, connectionCounter);
+    connect(PORT_NUMBER);
     ss.close();
     assertEquals(1, connections);
   }
 
   @Test
   public void testManyConnections() throws Exception {
-    ss = new SocketService(portNumber, connectionCounter);
+    ss = new SocketService(PORT_NUMBER, connectionCounter);
     for (int i = 0; i < 10; i++)
-      connect(portNumber);
+      connect(PORT_NUMBER);
     ss.close();
     assertEquals(10, connections);
   }
 
   @Test
   public void testSendMessage() throws Exception {
-    ss = new SocketService(portNumber, new HelloService());
-    Socket s = new Socket("localhost", portNumber);
+    ss = new SocketService(PORT_NUMBER, new HelloService());
+    Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     String answer = br.readLine();
     s.close();
@@ -72,8 +71,8 @@ public class SocketServiceTest {
 
   @Test
   public void testReceiveMessage() throws Exception {
-    ss = new SocketService(portNumber, new EchoService());
-    Socket s = new Socket("localhost", portNumber);
+    ss = new SocketService(PORT_NUMBER, new EchoService());
+    Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
     ps.println("MyMessage");
@@ -85,12 +84,12 @@ public class SocketServiceTest {
 
   @Test
   public void testMultiThreaded() throws Exception {
-    ss = new SocketService(portNumber, new EchoService());
-    Socket s = new Socket("localhost", portNumber);
+    ss = new SocketService(PORT_NUMBER, new EchoService());
+    Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
 
-    Socket s2 = new Socket("localhost", portNumber);
+    Socket s2 = new Socket("localhost", PORT_NUMBER);
     BufferedReader br2 = GetBufferedReader(s2);
     PrintStream ps2 = GetPrintStream(s2);
 

--- a/test/fitnesse/socketservice/SslSocketServiceTest.java
+++ b/test/fitnesse/socketservice/SslSocketServiceTest.java
@@ -19,8 +19,7 @@ public class SslSocketServiceTest {
   private int connections = 0;
   private SocketServer connectionCounter;
   private SocketService ss;
-  private final static int portNumber = 1999;
-
+  private static final int PORT_NUMBER = 1999;
 
   public SslSocketServiceTest() {
     connectionCounter = new SocketServer() {
@@ -37,25 +36,25 @@ public class SslSocketServiceTest {
 
   @Test
   public void testNoConnections() throws Exception {
-    ss = new SocketService(portNumber, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
+    ss = new SocketService(PORT_NUMBER, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
     ss.close();
     assertEquals(0, connections);
   }
 
   @Test
   public void testOneConnection() throws Exception {
-	 ss = new SocketService(portNumber, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
-    connect(portNumber);
+	 ss = new SocketService(PORT_NUMBER, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
+    connect(PORT_NUMBER);
     ss.close();
     assertEquals(1, connections);
   }
 
   @Test
   public void testManyConnections() throws Exception {
-     ss = new SocketService(portNumber, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
+     ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
     String answer = ""; 
     for (int i = 0; i < 10; i++){
-        Socket s = SocketFactory.tryCreateClientSocket("localhost", portNumber, true, "fitnesse.socketservice.SslParametersWiki");
+        Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
     	System.out.print("Peer: " + SocketFactory.peerName(s) + "\n");
         BufferedReader br = GetBufferedReader(s);
         PrintStream ps = GetPrintStream(s);
@@ -70,9 +69,9 @@ public class SslSocketServiceTest {
 
   @Test
   public void testSendMessage() throws Exception {
-	ss = new SocketService(portNumber, true, new HelloService(),"fitnesse.socketservice.SslParametersWiki");
+	ss = new SocketService(PORT_NUMBER, true, new HelloService(),"fitnesse.socketservice.SslParametersWiki");
 
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", portNumber, true, "fitnesse.socketservice.SslParametersWiki");
+    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
 
     BufferedReader br = GetBufferedReader(s);
     String answer = br.readLine();
@@ -83,8 +82,8 @@ public class SslSocketServiceTest {
 
   @Test
   public void testReceiveMessage() throws Exception {
-	ss = new SocketService(portNumber, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", portNumber, true, "fitnesse.socketservice.SslParametersWiki");
+	ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
+    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
     ps.println("MyMessage");
@@ -96,12 +95,12 @@ public class SslSocketServiceTest {
 
   @Test
   public void testMultiThreaded() throws Exception {
-	ss = new SocketService(portNumber, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", portNumber, true, "fitnesse.socketservice.SslParametersWiki");
+	ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
+    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
 
-    Socket s2 = SocketFactory.tryCreateClientSocket("localhost", portNumber, true, "fitnesse.socketservice.SslParametersWiki");
+    Socket s2 = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
     BufferedReader br2 = GetBufferedReader(s2);
     PrintStream ps2 = GetPrintStream(s2);
 

--- a/test/fitnesse/testsystems/fit/FitClientTest.java
+++ b/test/fitnesse/testsystems/fit/FitClientTest.java
@@ -160,9 +160,10 @@ public class FitClientTest implements FitClientListener {
     client.join();
 
     assertFalse(exceptionOccurred);
-    StringBuffer buffer = new StringBuffer();
-    for (Iterator<String> iterator = outputs.iterator(); iterator.hasNext();)
-      buffer.append(iterator.next());
+    StringBuilder buffer = new StringBuilder();
+    for (String output : outputs) {
+      buffer.append(output);
+    }
 
     assertSubString("\uba80\uba81\uba82\uba83", buffer.toString());
   }

--- a/test/fitnesse/testsystems/fit/FitClientTest.java
+++ b/test/fitnesse/testsystems/fit/FitClientTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static util.RegexTestCase.assertSubString;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import fitnesse.testsystems.CompositeExecutionLogListener;

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
@@ -140,7 +140,7 @@ public class ScenarioTableExtensionTest {
    * parameters having to be specified in the first row also.
    */
   public static class AutoArgScenarioTable extends ScenarioTable {
-    private final static Pattern ARG_PATTERN = Pattern.compile("@\\{(.+?)\\}");
+    private static final Pattern ARG_PATTERN = Pattern.compile("@\\{(.+?)\\}");
     private static final Pattern OUT_PATTERN = Pattern.compile("\\$(.+?)=");
 
     private Set<String> inputs;

--- a/test/fitnesse/wiki/RecentChangesWikiPageTest.java
+++ b/test/fitnesse/wiki/RecentChangesWikiPageTest.java
@@ -63,9 +63,10 @@ public class RecentChangesWikiPageTest {
   @Test
   public void testMaxSize() throws Exception {
     for (int i = 0; i < 101; i++) {
-      StringBuffer b = new StringBuffer("LotsOfAs");
-      for (int j = 0; j < i; j++)
+      StringBuilder b = new StringBuilder("LotsOfAs");
+      for (int j = 0; j < i; j++) {
         b.append("a");
+      }
       WikiPage page = rootPage.addChildPage(b.toString());
       recentChangesWikiPage.updateRecentChanges(page);
     }

--- a/test/fitnesse/wiki/fs/FileSystemPageTest.java
+++ b/test/fitnesse/wiki/fs/FileSystemPageTest.java
@@ -74,7 +74,7 @@ public class FileSystemPageTest {
 
   @Test
   public void testBigContent() throws Exception {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (int i = 0; i < 1000; i++)
       buffer.append("abcdefghijklmnopqrstuvwxyz");
     WikiPageUtil.addPage(root, PathParser.parse("BigPage"), buffer.toString());

--- a/test/util/StreamReaderTest.java
+++ b/test/util/StreamReaderTest.java
@@ -71,7 +71,7 @@ public class StreamReaderTest {
   @Test
   public void testReadNumberOfBytesAsString() throws Exception {
     startReading(new ReadCount(100));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (int i = 0; i < 100; i++) {
       buffer.append("*");
       writeToPipe("*");
@@ -84,7 +84,7 @@ public class StreamReaderTest {
   @Test
   public void testReadNumberOfBytes() throws Exception {
     startReading(new ReadCountBytes(100));
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     for (int i = 0; i < 100; i++) {
       buffer.append("*");
       writeToPipe("*");


### PR DESCRIPTION
Mostly concerning modifiers:
* List modifiers in consistent order
* Removed implicit modifiers from interfaces. Implementations will need to set the Overriden methods as publicly visible in order to fullfil the interface contract, so they are mostly redundant. I did leave the static modifiers though, since they may count as an implementation hint even though it isn't strictly enforceable.

As I mentioned in #812, it seems I was missing out on testscope locally, so I've went over and did some more StringBuffer -> StringBuilder fixes there. In a couple of cases it was used to provide similar functionality to StringUtils.join() so I simply replaced these.

Otherwise see individual commit messages for (more) details.
Particularly note the interface CompositePageFinder which is unused, and everything builds fine without it. It is part of the public API though and may have external use, so I'm a bit vary of simply removing it.