### PR TITLE
Ensured loggers are private static final

### DIFF
--- a/src/fitnesse/reporting/BaseFormatter.java
+++ b/src/fitnesse/reporting/BaseFormatter.java
@@ -9,10 +9,8 @@ import fitnesse.testsystems.TestSystem;
 import fitnesse.wiki.WikiPage;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 public abstract class BaseFormatter implements Formatter {
-  protected final Logger LOG = Logger.getLogger(getClass().getName());
 
   private final WikiPage page;
 

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -27,8 +27,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListener, Closeable {
+  private static final Logger LOG = Logger.getLogger(TestXmlFormatter.class.getName());
+
   private final FitNesseContext context;
   private final WriterFactory writerFactory;
   private TimeMeasurement currentTestStartTime;

--- a/src/fitnesse/responders/ChunkingResponder.java
+++ b/src/fitnesse/responders/ChunkingResponder.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class ChunkingResponder implements Responder, ChunkedDataProvider {
-  private final Logger LOG = Logger.getLogger(ChunkingResponder.class.getName());
+  private static final Logger LOG = Logger.getLogger(ChunkingResponder.class.getName());
 
   protected WikiPage root;
   public WikiPage page;

--- a/src/fitnesse/responders/ImportAndViewResponder.java
+++ b/src/fitnesse/responders/ImportAndViewResponder.java
@@ -16,7 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class ImportAndViewResponder implements SecureResponder, WikiImporterClient {
-  private final Logger LOG = Logger.getLogger(ImportAndViewResponder.class.getName());
+  private static final Logger LOG = Logger.getLogger(ImportAndViewResponder.class.getName());
 
   private WikiPage page;
 

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -59,7 +59,7 @@ import static fitnesse.responders.WikiImportingTraverser.ImportError;
 import static fitnesse.wiki.WikiImportProperty.isAutoUpdated;
 
 public class SuiteResponder extends ChunkingResponder implements SecureResponder {
-  private final Logger LOG = Logger.getLogger(SuiteResponder.class.getName());
+  private static final Logger LOG = Logger.getLogger(SuiteResponder.class.getName());
 
   private static final String NOT_FILTER_ARG = "excludeSuiteFilter";
   private static final String AND_FILTER_ARG = "runTestsMatchingAllTags";

--- a/src/fitnesse/testrunner/RunningTestingTracker.java
+++ b/src/fitnesse/testrunner/RunningTestingTracker.java
@@ -8,7 +8,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class RunningTestingTracker {
-  public static final Logger LOG = Logger.getLogger(RunningTestingTracker.class.getName());
+  private static final Logger LOG = Logger.getLogger(RunningTestingTracker.class.getName());
 
   private Map<String, Stoppable> processes = new ConcurrentHashMap<String, Stoppable>();
   private int nextTicketNumber = 1;

--- a/src/fitnesse/testrunner/SuiteContentsFinder.java
+++ b/src/fitnesse/testrunner/SuiteContentsFinder.java
@@ -9,7 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SuiteContentsFinder {
-  public static final Logger LOG = Logger.getLogger(SuiteContentsFinder.class.getName());
+  private static final Logger LOG = Logger.getLogger(SuiteContentsFinder.class.getName());
 
   private final WikiPage pageToRun;
   private final WikiPage wikiRootPage;

--- a/src/fitnesse/updates/WikiContentUpdater.java
+++ b/src/fitnesse/updates/WikiContentUpdater.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 
 public class WikiContentUpdater implements Updater {
 
-  protected static final Logger LOG = Logger.getLogger(WikiContentUpdater.class.getName());
+  private static final Logger LOG = Logger.getLogger(WikiContentUpdater.class.getName());
 
   protected final FitNesseContext context;
   private Properties rootProperties;


### PR DESCRIPTION
As found by SonarQube, made loggers private static final. This is to ensure that 1) other classes cannot use them to write log messages, 2) there is a common logger for the class regardless of the number of objects and that 3) it is initialized in one place only.

Note that a couple of these were protected, but not used in subclasses in FitNesse itself. Though of course it is possible that external subclasse may have picked them up. Normally I'd be wary of breaking existing public API, but I think creating a more specific logger in those subclasses should be reasonably straigth-forward. 

Note that ContextConfigurator and FitNesseContext both have additional fields which holds loggers, but I haven't touched these.