### PR TITLE
Set Java version for SonarQube to disable checks only relevant for ne…

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
+sonar.java.source=1.6
 sonar.sources=src
 sonar.exclusions=**/*.min.js,**/textinputs_jquery.js


### PR DESCRIPTION
…wer Java versions, e.g. diamond operators ("<>")

The SonarQube instance which scans the FitNesse code from time to time has various rules to take advantage of Java 7 and 8 features/functionality. For examples, see java7 and java8 in the issue tag cloud on the dashboard http://nemo.sonarqube.org/dashboard/index?id=org.fitnesse%3Afitnesse. Since FitNesse targets Java 6 these don't help that much though.

Therefore I've added the Java version to SonarQube properties so that checking for these kind of issues will be skipped. It's untested since my local SonarQube instance didn't seem to have the diamond operator issue at least, but I believe it should be easy to see once the next scan is performed.