### PR TITLE
Code cleanup and use of ExecutorService

### DIFF
--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -2,6 +2,19 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.BindException;
+import java.net.ServerSocket;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import fitnesse.http.MockRequestBuilder;
 import fitnesse.http.MockResponseSender;
 import fitnesse.http.Request;
@@ -10,21 +23,6 @@ import fitnesse.socketservice.SocketFactory;
 import fitnesse.socketservice.SocketService;
 import fitnesse.util.MockSocket;
 import fitnesse.util.SerialExecutorService;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.Method;
-import java.net.BindException;
-import java.net.ServerSocket;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class FitNesse {
   private static final Logger LOG = Logger.getLogger(FitNesse.class.getName());

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -45,13 +45,6 @@ public class FitNesse {
       filesDir.mkdir();
   }
 
-  public static void main(String[] args) throws Exception {
-    System.out.println("DEPRECATED:  use java -jar fitnesse.jar or java -cp fitnesse.jar fitnesseMain.FitNesseMain");
-    Class<?> mainClass = Class.forName("fitnesseMain.FitNesseMain");
-    Method mainMethod = mainClass.getMethod("main", String[].class);
-    mainMethod.invoke(null, new Object[]{args});
-  }
-
   public boolean start() {
     if (makeDirs) {
       establishRequiredDirectories();

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -58,7 +58,9 @@ public class FitNesse {
     }
     try {
       if (context.port > 0) {
-        ServerSocket serverSocket = SocketFactory.tryCreateServerSocket(context.port, context.useHTTPS, context.sslClientAuth, context.sslParameterClassName);
+        ServerSocket serverSocket = context.useHTTPS
+                ? SocketFactory.createSslServerSocket(context.port, context.sslClientAuth, context.sslParameterClassName)
+                : SocketFactory.createServerSocket(context.port);
         theService = new SocketService(new FitNesseServer(context), false, serverSocket);
       }
       return true;

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -91,7 +91,7 @@ public class FitNesse {
         throw new Exception("error loading page: " + response.getStatus());
     }
     response.withoutHttpHeaders();
-    MockResponseSender sender = new MockResponseSender.OutputStreamSender(out);
+    MockResponseSender sender = new MockResponseSender(out);
     sender.doSending(response);
   }
 }

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -90,11 +90,6 @@ public class FitNesseExpediter implements ResponseSender {
     }
   }
 
-  @Override
-  public Socket getSocket() {
-    return socket;
-  }
-
   public Request makeRequest() {
     request = new Request(input);
     request.setPeerDn(SocketFactory.peerDn(socket));

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -75,7 +75,7 @@ public class FitNesseExpediter implements ResponseSender {
       output.flush();
     }
     catch (IOException e) {
-      LOG.log(Level.INFO, "Output stream closed unexpectedly (Stop button pressed?)", e);
+      LOG.log(Level.INFO, format("Output stream closed unexpectedly: %s (Stop button pressed?)", e.getMessage()));
     }
   }
 

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -103,6 +103,7 @@ public class FitNesseExpediter implements ResponseSender {
 
   private Response makeResponse(Request request) throws SocketException {
     try {
+      // TODO: change to Future with ExecutionService
       Thread parseThread = createParsingThread(request);
       parseThread.start();
 
@@ -144,7 +145,7 @@ public class FitNesseExpediter implements ResponseSender {
     while (!hasError && !request.hasBeenParsed()) {
       Thread.sleep(10);
       if (timeIsUp() && parsingIsUnproductive(request))
-        reportError(408, "The client request has been unproductive for too long. It has timed out and will now longer be processed.");
+        reportError(408, "The client request has been unproductive for too long. It has timed out and will no longer be processed.");
     }
   }
 

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -39,16 +39,20 @@ public class FitNesseExpediter implements ResponseSender {
   private final OutputStream output;
   private final FitNesseContext context;
   private final ExecutorService executorService = new ForkJoinPool(1);
-  private long requestParsingTimeLimit;
+  private final long requestParsingTimeLimit;
   private Request request;
   private Response response;
 
-  public FitNesseExpediter(Socket s, FitNesseContext context) throws IOException {
+  public FitNesseExpediter(Socket socket, FitNesseContext context) throws IOException {
+    this(socket, context, 10000);
+  }
+
+  public FitNesseExpediter(Socket socket, FitNesseContext context, long requestParsingTimeLimit) throws IOException {
     this.context = context;
-    socket = s;
-    input = s.getInputStream();
-    output = s.getOutputStream();
-    requestParsingTimeLimit = 10000;
+    this.socket = socket;
+    input = socket.getInputStream();
+    output = socket.getOutputStream();
+    this.requestParsingTimeLimit = requestParsingTimeLimit;
   }
 
   public void start() {
@@ -65,14 +69,6 @@ public class FitNesseExpediter implements ResponseSender {
       // This catch is intentional, since it's the last point where we can catch exceptions that occur in this thread.
       LOG.log(Level.WARNING, "Unexpected exception", e);
     }
-  }
-
-  public void setRequestParsingTimeLimit(long t) {
-    requestParsingTimeLimit = t;
-  }
-
-  public long getRequestParsingTimeLimit() {
-    return requestParsingTimeLimit;
   }
 
   @Override

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -2,6 +2,20 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.GregorianCalendar;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import fitnesse.components.LogData;
 import fitnesse.http.HttpException;
 import fitnesse.http.Request;
@@ -11,24 +25,6 @@ import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ErrorResponder;
 import fitnesse.socketservice.SocketFactory;
 import org.apache.commons.lang.StringUtils;
-import fitnesse.util.Clock;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.SocketException;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static java.lang.String.format;
 

--- a/src/fitnesse/FitNesseExpediter.java
+++ b/src/fitnesse/FitNesseExpediter.java
@@ -40,7 +40,7 @@ public class FitNesseExpediter implements ResponseSender {
   private Request request;
   private Response response;
   private final FitNesseContext context;
-  protected long requestParsingTimeLimit;
+  private long requestParsingTimeLimit;
   private final ExecutorService executorService = new ForkJoinPool(1);
 
   public FitNesseExpediter(Socket s, FitNesseContext context) throws IOException {

--- a/src/fitnesse/FitNesseServer.java
+++ b/src/fitnesse/FitNesseServer.java
@@ -24,8 +24,7 @@ public class FitNesseServer implements SocketServer {
 
   public void serve(Socket s, long requestTimeout) {
     try {
-      FitNesseExpediter sender = new FitNesseExpediter(s, context);
-      sender.setRequestParsingTimeLimit(requestTimeout);
+      FitNesseExpediter sender = new FitNesseExpediter(s, context, requestTimeout);
       sender.start();
     }
     catch (Exception e) {

--- a/src/fitnesse/FitNesseServer.java
+++ b/src/fitnesse/FitNesseServer.java
@@ -3,6 +3,7 @@
 package fitnesse;
 
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -12,9 +13,11 @@ public class FitNesseServer implements SocketServer {
   private static final Logger LOG = Logger.getLogger(FitNesseServer.class.getName());
 
   private FitNesseContext context;
+  private ExecutorService executorService;
 
-  public FitNesseServer(FitNesseContext context) {
+  public FitNesseServer(FitNesseContext context, ExecutorService executorService) {
     this.context = context;
+    this.executorService = executorService;
   }
 
   @Override
@@ -24,8 +27,8 @@ public class FitNesseServer implements SocketServer {
 
   public void serve(Socket s, long requestTimeout) {
     try {
-      FitNesseExpediter sender = new FitNesseExpediter(s, context, requestTimeout);
-      sender.start();
+      FitNesseExpediter sender = new FitNesseExpediter(s, context, executorService, requestTimeout);
+      executorService.submit(sender);
     }
     catch (Exception e) {
       LOG.log(Level.SEVERE, "Error while serving socket " + s, e);

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -5,6 +5,18 @@ package fitnesse.fixtures;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import fitnesse.FitNesseExpediter;
+import fitnesse.http.MockRequest;
+import fitnesse.http.MockResponseSender;
+import fitnesse.responders.editing.EditResponder;
+import fitnesse.util.MockSocket;
+import fitnesse.util.SerialExecutorService;
+import fitnesse.wiki.PageCrawler;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.SymbolicPage;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPagePath;
 import org.htmlparser.Node;
 import org.htmlparser.NodeFilter;
 import org.htmlparser.Parser;
@@ -16,18 +28,6 @@ import org.htmlparser.lexer.Lexer;
 import org.htmlparser.lexer.Page;
 import org.htmlparser.util.NodeList;
 import org.json.JSONObject;
-
-import fitnesse.FitNesseExpediter;
-import fitnesse.http.MockRequest;
-import fitnesse.http.MockResponseSender;
-import fitnesse.responders.editing.EditResponder;
-import fitnesse.util.MockSocket;
-import fitnesse.wiki.PageCrawler;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.PathParser;
-import fitnesse.wiki.SymbolicPage;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPagePath;
 
 public class PageDriver {
   private PageCreator creator = new PageCreator();
@@ -69,7 +69,7 @@ public class PageDriver {
     request.parseRequestUri("/" + pageName);
     WikiPagePath path = PathParser.parse(request.getResource()); // uri;
     FitnesseFixtureContext.page = FitnesseFixtureContext.context.getRootPage().getPageCrawler().getPage(path);
-    FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(""), FitnesseFixtureContext.context);
+    FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(""), FitnesseFixtureContext.context, new SerialExecutorService());
     FitnesseFixtureContext.response = expediter.createGoodResponse(request);
     FitnesseFixtureContext.sender = new MockResponseSender();
     FitnesseFixtureContext.sender.doSending(FitnesseFixtureContext.response);

--- a/src/fitnesse/fixtures/ResponseRequester.java
+++ b/src/fitnesse/fixtures/ResponseRequester.java
@@ -8,6 +8,7 @@ import fitnesse.html.HtmlUtil;
 import fitnesse.http.MockRequest;
 import fitnesse.http.MockResponseSender;
 import fitnesse.util.MockSocket;
+import fitnesse.util.SerialExecutorService;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPagePath;
 
@@ -34,7 +35,7 @@ public class ResponseRequester extends ColumnFixture {
     request.parseRequestUri("/" + uri);
     WikiPagePath path = PathParser.parse(request.getResource()); // uri;
     FitnesseFixtureContext.page = FitnesseFixtureContext.context.getRootPage().getPageCrawler().getPage(path);
-    FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(""), FitnesseFixtureContext.context);
+    FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(""), FitnesseFixtureContext.context, new SerialExecutorService());
     FitnesseFixtureContext.response = expediter.createGoodResponse(request);
     FitnesseFixtureContext.sender = new MockResponseSender();
     FitnesseFixtureContext.sender.doSending(FitnesseFixtureContext.response);

--- a/src/fitnesse/http/MockResponseSender.java
+++ b/src/fitnesse/http/MockResponseSender.java
@@ -38,11 +38,6 @@ public class MockResponseSender implements ResponseSender {
     closed = true;
   }
 
-  @Override
-  public Socket getSocket() {
-    return new MockSocket(new PipedInputStream(), output);
-  }
-
   public String sentData() {
     try {
       return ((ByteArrayOutputStream) output).toString(FileUtil.CHARENCODING);

--- a/src/fitnesse/http/MockResponseSender.java
+++ b/src/fitnesse/http/MockResponseSender.java
@@ -2,25 +2,32 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.http;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 
 import fitnesse.util.MockSocket;
+import util.FileUtil;
 
 public class MockResponseSender implements ResponseSender {
-  public MockSocket socket;
+  private final OutputStream output;
   protected boolean closed;
 
   public MockResponseSender() {
-    socket = new MockSocket("Mock");
+    this(new ByteArrayOutputStream());
+  }
+
+  public MockResponseSender(OutputStream output) {
+    this.output = output;
   }
 
   @Override
   public void send(byte[] bytes) {
     try {
-      socket.getOutputStream().write(bytes);
+      output.write(bytes);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -33,11 +40,15 @@ public class MockResponseSender implements ResponseSender {
 
   @Override
   public Socket getSocket() {
-    return socket;
+    return new MockSocket(new PipedInputStream(), output);
   }
 
   public String sentData() {
-    return socket.getOutput();
+    try {
+      return ((ByteArrayOutputStream) output).toString(FileUtil.CHARENCODING);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("Unable to decode output stream", e);
+    }
   }
 
   public void doSending(Response response) throws IOException {
@@ -48,16 +59,4 @@ public class MockResponseSender implements ResponseSender {
   public boolean isClosed() {
     return closed;
   }
-
-  public static class OutputStreamSender extends MockResponseSender {
-    public OutputStreamSender(OutputStream out) {
-      socket = new MockSocket(new PipedInputStream(), out);
-    }
-
-    @Override
-    public void doSending(Response response) throws IOException {
-      response.sendTo(this);
-      assert closed;
-    }
   }
-}

--- a/src/fitnesse/http/ResponseSender.java
+++ b/src/fitnesse/http/ResponseSender.java
@@ -2,12 +2,8 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.http;
 
-import java.net.Socket;
-
 public interface ResponseSender {
   void send(byte[] bytes);
 
   void close();
-
-  Socket getSocket(); //TODO-MdM maybe get rid of this method.
 }

--- a/src/fitnesse/http/SimpleResponse.java
+++ b/src/fitnesse/http/SimpleResponse.java
@@ -2,6 +2,7 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.http;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 public class SimpleResponse extends Response {

--- a/src/fitnesse/slim/JavaSlimFactory.java
+++ b/src/fitnesse/slim/JavaSlimFactory.java
@@ -2,11 +2,13 @@ package fitnesse.slim;
 
 public class JavaSlimFactory extends SlimFactory {
 
-  private NameTranslator identityTranslator = new NameTranslatorIdentity();
-  private Integer timeout;
+  private final NameTranslator identityTranslator = new NameTranslatorIdentity();
+  private final Integer timeout;
+  private final boolean verbose;
 
-  private JavaSlimFactory(Integer timeout) {
+  private JavaSlimFactory(Integer timeout, boolean verbose) {
     this.timeout = timeout;
+    this.verbose = verbose;
   }
 
   @Override
@@ -23,15 +25,20 @@ public class JavaSlimFactory extends SlimFactory {
     return getIdentityTranslator();
   }
 
+  @Override
+  public boolean isVerbose() {
+    return verbose;
+  }
+
   private NameTranslator getIdentityTranslator() {
     return identityTranslator;
   }
 
   public static SlimFactory createJavaSlimFactory(SlimService.Options options) {
-    return new JavaSlimFactory(options.statementTimeout);
+    return new JavaSlimFactory(options.statementTimeout, options.verbose);
   }
 
   public static SlimFactory createJavaSlimFactory() {
-    return new JavaSlimFactory(null);
+    return new JavaSlimFactory(null, false);
   }
 }

--- a/src/fitnesse/slim/SlimFactory.java
+++ b/src/fitnesse/slim/SlimFactory.java
@@ -1,17 +1,17 @@
 package fitnesse.slim;
 
-import fitnesse.slim.StatementExecutorInterface;
-
 public abstract class SlimFactory {
 
   public abstract NameTranslator getMethodNameTranslator();
 
-  public SlimServer getSlimServer(boolean verbose) {
-    return new SlimServer(verbose, this);
+  public abstract boolean isVerbose();
+
+  public SlimServer getSlimServer() {
+    return new SlimServer(this);
   }
 
-  public ListExecutor getListExecutor(boolean verbose) {
-    return new ListExecutor(verbose, this);
+  public ListExecutor getListExecutor() {
+    return new ListExecutor(isVerbose(), this);
   }
 
   public abstract StatementExecutorInterface getStatementExecutor();

--- a/src/fitnesse/slim/SlimServer.java
+++ b/src/fitnesse/slim/SlimServer.java
@@ -31,11 +31,9 @@ public class SlimServer implements SocketServer {
   public static final String EXCEPTION_STOP_TEST_TAG = "__EXCEPTION__:ABORT_SLIM_TEST:";
   public static final String EXCEPTION_STOP_SUITE_TAG = "__EXCEPTION__:ABORT_SLIM_SUITE:";
 
-  private final boolean verbose;
   private final SlimFactory slimFactory;
 
-  public SlimServer(boolean verbose, SlimFactory slimFactory) {
-    this.verbose = verbose;
+  public SlimServer(SlimFactory slimFactory) {
     this.slimFactory = slimFactory;
   }
 
@@ -64,7 +62,7 @@ public class SlimServer implements SocketServer {
   }
 
   private void tryProcessInstructions(SlimStreamReader reader, OutputStream writer) throws IOException {
-    ListExecutor executor = slimFactory.getListExecutor(verbose);
+    ListExecutor executor = slimFactory.getListExecutor();
     String header = SlimVersion.SLIM_HEADER + SlimVersion.VERSION + "\n";
     SlimStreamReader.sendSlimHeader(writer, header);
 

--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -132,7 +132,7 @@ public class SlimService {
     this.slimServer = slimServer;
 
     try {
-      serverSocket = SocketFactory.tryCreateServerSocket(port, useSSL, useSSL, sslParameterClassName);
+      serverSocket = useSSL ? SocketFactory.createSslServerSocket(port, useSSL, sslParameterClassName) : SocketFactory.createServerSocket(port);
     } catch (java.lang.OutOfMemoryError e) {
       System.err.println("Out of Memory. Aborting.");
       e.printStackTrace();

--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -73,7 +73,7 @@ public class SlimService {
   }
 
   public static void startWithFactory(SlimFactory slimFactory, Options options) throws IOException {
-    SlimService slimservice = new SlimService(slimFactory.getSlimServer(options.verbose), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
+    SlimService slimservice = new SlimService(slimFactory.getSlimServer(), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
     slimservice.accept();
   }
 
@@ -83,7 +83,7 @@ public class SlimService {
       service.interrupt();
       throw new SlimError("Already an in-process server running: " + service.getName() + " (alive=" + service.isAlive() + ")");
     }
-    final SlimService slimservice = new SlimService(slimFactory.getSlimServer(options.verbose), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
+    final SlimService slimservice = new SlimService(slimFactory.getSlimServer(), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
     int actualPort = slimservice.getPort();
     service = new Thread() {
       @Override

--- a/src/fitnesse/socketservice/SocketFactory.java
+++ b/src/fitnesse/socketservice/SocketFactory.java
@@ -28,31 +28,24 @@ public final class SocketFactory {
 
   }
 
-  public static ServerSocket tryCreateServerSocket(int port) throws IOException {
-    return tryCreateServerSocket(port, false, false, null);
+  public static ServerSocket createServerSocket(int port) throws IOException {
+    LOG.log(Level.FINER, "Creating plain socket on port: " + port);
+    return new ServerSocket(port);
   }
 
-
-  @SuppressWarnings("resource")
-  public static ServerSocket tryCreateServerSocket(int port, boolean useSSL, boolean needClientAuth, String sslParameterClassName) throws IOException {
+  public static ServerSocket createSslServerSocket(int port, boolean needClientAuth, String sslParameterClassName) throws IOException {
     ServerSocket socket;
-    if (!useSSL) {
-      LOG.log(Level.FINER, "Creating plain socket on port: " + port);
-      socket = new ServerSocket(port);
-    } else {
-      LOG.log(Level.FINER, "Creating SSL socket on port: " + port);
+    LOG.log(Level.FINER, "Creating SSL socket on port: " + port);
 
-      SSLServerSocketFactory ssf = SslParameters.setSslParameters(sslParameterClassName).createSSLServerSocketFactory();
-      socket = ssf.createServerSocket(port);
-      if (needClientAuth) {
-        ((SSLServerSocket) socket).setNeedClientAuth(true);
-      }
+    SSLServerSocketFactory ssf = SslParameters.setSslParameters(sslParameterClassName).createSSLServerSocketFactory();
+    socket = ssf.createServerSocket(port);
+    if (needClientAuth) {
+      ((SSLServerSocket) socket).setNeedClientAuth(true);
     }
-
     return socket;
   }
 
-  public static Socket tryCreateClientSocket(String hostName, int port, boolean useSSL, String sslParameterClassName) throws IOException {
+  public static Socket createClientSocket(String hostName, int port, boolean useSSL, String sslParameterClassName) throws IOException {
     if (!useSSL) {
       LOG.log(Level.FINER, "Creating plain client: " + hostName + ":" + port);
       return new Socket(hostName, port);

--- a/src/fitnesse/socketservice/SocketServer.java
+++ b/src/fitnesse/socketservice/SocketServer.java
@@ -12,7 +12,7 @@ import java.net.Socket;
 
 public interface SocketServer {
 
-  public void serve(Socket s) throws IOException;
+  void serve(Socket s) throws IOException;
 
   //TODO: Hm, how does static inner classes in interfaces work...
   static class StreamUtility {

--- a/src/fitnesse/socketservice/SocketServer.java
+++ b/src/fitnesse/socketservice/SocketServer.java
@@ -14,8 +14,7 @@ public interface SocketServer {
 
   void serve(Socket s) throws IOException;
 
-  //TODO: Hm, how does static inner classes in interfaces work...
-  static class StreamUtility {
+  class StreamUtility {
     public static PrintStream GetPrintStream(Socket s) throws IOException {
       OutputStream os = s.getOutputStream();
       return new PrintStream(os);

--- a/src/fitnesse/socketservice/SocketService.java
+++ b/src/fitnesse/socketservice/SocketService.java
@@ -6,11 +6,8 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
-import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,34 +23,22 @@ public class SocketService {
   private final ExecutorService executorService = new ForkJoinPool();
   private volatile boolean everRan = false;
 
-  public SocketService(int port, boolean useHTTPS, SocketServer server, String sslParameterClassName ) throws IOException {
-	    this(port, useHTTPS, server, false, sslParameterClassName);
-}
-  public SocketService(int port, SocketServer server) throws IOException {
-    this(port, false, server, false, null);
-  }
-  public SocketService(int port, SocketServer server, boolean daemon) throws IOException {
-	  this(port, false, server, daemon, null);
-  }
-  
-  public SocketService(int port, boolean useHTTPS, SocketServer server, boolean daemon, String sslParameterClassName) throws IOException {
-    this(server, daemon, SocketFactory.tryCreateServerSocket(port, useHTTPS, false,  sslParameterClassName));
-  }
-
   public SocketService(SocketServer server, boolean daemon, ServerSocket serverSocket) throws IOException {
     this.server = server;
     this.serverSocket = serverSocket;
     serviceThread = new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                serviceThread();
-              }
-            }
+      new Runnable() {
+        @Override
+        public void run() {
+          serviceThread();
+        }
+      }
     );
     serviceThread.setDaemon(daemon);
     serviceThread.start();
   }
+
+  @Deprecated
   public int getPort() {
     return serverSocket.getLocalPort();
   }

--- a/src/fitnesse/socketservice/SocketService.java
+++ b/src/fitnesse/socketservice/SocketService.java
@@ -38,11 +38,6 @@ public class SocketService {
     serviceThread.start();
   }
 
-  @Deprecated
-  public int getPort() {
-    return serverSocket.getLocalPort();
-  }
-
   public void close() throws IOException {
     waitForServiceThreadToStart();
     running = false;

--- a/src/fitnesse/testsystems/fit/CommandRunningFitClient.java
+++ b/src/fitnesse/testsystems/fit/CommandRunningFitClient.java
@@ -4,12 +4,14 @@ package fitnesse.testsystems.fit;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import fitnesse.socketservice.SocketFactory;
 import fitnesse.socketservice.SocketService;
 import fitnesse.testsystems.CommandRunner;
 import fitnesse.testsystems.ExecutionLogListener;
@@ -36,8 +38,9 @@ public class CommandRunningFitClient extends FitClient {
   }
 
   public void start() throws IOException {
-    server = new SocketService(0, new SocketCatcher(this, ticketNumber), true);
-    int port = server.getPort();
+    ServerSocket serverSocket = SocketFactory.createServerSocket(0);
+    server = new SocketService(new SocketCatcher(this, ticketNumber), true, serverSocket);
+    int port = serverSocket.getLocalPort();
     try {
       commandRunningStrategy.start(this, port, ticketNumber);
       waitForConnection();

--- a/src/fitnesse/testsystems/fit/FitTestSystem.java
+++ b/src/fitnesse/testsystems/fit/FitTestSystem.java
@@ -36,7 +36,6 @@ public class FitTestSystem implements TestSystem, FitClientListener {
 
   @Override
   public void start() throws IOException {
-    // TODO: start a server socket (thread) here
     client.start();
     testSystemStarted(this);
   }

--- a/src/fitnesse/testsystems/slim/SlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/SlimClientBuilder.java
@@ -113,7 +113,7 @@ public class SlimClientBuilder extends ClientBuilder<SlimCommandRunningClient> {
   private int findFreePort() {
     int port;
     try {
-      ServerSocket socket = SocketFactory.tryCreateServerSocket(0);
+      ServerSocket socket = SocketFactory.createServerSocket(0);
       port = socket.getLocalPort();
       socket.close();
     } catch (Exception e) {

--- a/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
+++ b/src/fitnesse/testsystems/slim/SlimCommandRunningClient.java
@@ -95,7 +95,7 @@ public class SlimCommandRunningClient implements SlimClient {
       	throw new SlimError(slimErrorMessage);
       }
       try {
-        client = SocketFactory.tryCreateClientSocket(hostName, port, useSSL, sslParameterClassName);
+        client = SocketFactory.createClientSocket(hostName, port, useSSL, sslParameterClassName);
       } catch (IOException e) {
         if (Clock.currentTimeInMillis() > timeOut) {
           throw new SlimError("Error connecting to SLiM server on " + hostName + ":" + port, e);

--- a/src/fitnesse/util/MockSocket.java
+++ b/src/fitnesse/util/MockSocket.java
@@ -75,17 +75,6 @@ public class MockSocket extends Socket {
     return closed;
   }
 
-  public String getOutput() {
-    if (output instanceof ByteArrayOutputStream) {
-      try {
-        return ((ByteArrayOutputStream) output).toString(FileUtil.CHARENCODING);
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    } else
-      return "";
-  }
-
   public void setHost(String host) {
     this.host = host;
   }

--- a/src/fitnesse/util/SerialExecutorService.java
+++ b/src/fitnesse/util/SerialExecutorService.java
@@ -1,0 +1,135 @@
+package fitnesse.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.commons.lang.NotImplementedException;
+
+/**
+ * This implementation of {@link java.util.concurrent.ExecutorService} is a dummy/debug version of an execution
+ * service. The tasks are executed instantly, in the current execution thread.
+ */
+public class SerialExecutorService implements ExecutorService {
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    try {
+      return new FutureIsNow<T>(task.call());
+    } catch (Exception e) {
+      return new FutureIsNow<T>(e);
+    }
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    task.run();
+    return new FutureIsNow<T>(result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    task.run();
+    return new FutureIsNow<Object>(null);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+
+  @Override
+  public void shutdown() {
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return true;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return true;
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return true;
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    throw new NotImplementedException();
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    throw new NotImplementedException();
+  }
+
+}
+
+class FutureIsNow<T> implements Future<T> {
+
+  private final T result;
+  private final Exception exc;
+
+  public FutureIsNow(T result) {
+    this.result = result;
+    this.exc = null;
+  }
+
+  public FutureIsNow(Exception exc) {
+    this.result = null;
+    this.exc = exc;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return true;
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    if (exc != null) {
+      throw new ExecutionException(exc);
+    }
+    return result;
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return get();
+  }
+}

--- a/test/fit/FitServerTest.java
+++ b/test/fit/FitServerTest.java
@@ -208,7 +208,7 @@ public class FitServerTest {
   }
 
   private void establishConnection() throws Exception {
-    serverSocket = SocketFactory.tryCreateServerSocket(PORT_NUMBER);
+    serverSocket = SocketFactory.createServerSocket(PORT_NUMBER);
     socket = null;
 
     listenForConnectionSocket();

--- a/test/fitnesse/FitNesseExpediterTest.java
+++ b/test/fitnesse/FitNesseExpediterTest.java
@@ -70,7 +70,7 @@ public class FitNesseExpediterTest {
     senderThread.start();
     Thread parseResponseThread = makeParsingThread();
     parseResponseThread.start();
-    Thread.sleep(sender.requestParsingTimeLimit + 100);
+    Thread.sleep(sender.getRequestParsingTimeLimit() + 100);
 
     parseResponseThread.join();
 
@@ -84,7 +84,7 @@ public class FitNesseExpediterTest {
     PipedOutputStream socketOutput = new PipedOutputStream(clientInput);
     MockSocket socket = new MockSocket(socketInput, socketOutput);
     final FitNesseExpediter sender = new FitNesseExpediter(socket, context);
-    sender.requestParsingTimeLimit = 200;
+    sender.setRequestParsingTimeLimit(200);
     return sender;
   }
 

--- a/test/fitnesse/FitNesseExpediterTest.java
+++ b/test/fitnesse/FitNesseExpediterTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FitNesseExpediterTest {
+  public static final int REQUEST_PARSING_TIME_LIMIT = 200;
   private FitNesseExpediter expediter;
   private MockSocket socket;
   private FitNesseContext context;
@@ -70,7 +71,7 @@ public class FitNesseExpediterTest {
     senderThread.start();
     Thread parseResponseThread = makeParsingThread();
     parseResponseThread.start();
-    Thread.sleep(sender.getRequestParsingTimeLimit() + 100);
+    Thread.sleep(REQUEST_PARSING_TIME_LIMIT + 100);
 
     parseResponseThread.join();
 
@@ -83,8 +84,7 @@ public class FitNesseExpediterTest {
     clientInput = new PipedInputStream();
     PipedOutputStream socketOutput = new PipedOutputStream(clientInput);
     MockSocket socket = new MockSocket(socketInput, socketOutput);
-    final FitNesseExpediter sender = new FitNesseExpediter(socket, context);
-    sender.setRequestParsingTimeLimit(200);
+    final FitNesseExpediter sender = new FitNesseExpediter(socket, context, REQUEST_PARSING_TIME_LIMIT);
     return sender;
   }
 

--- a/test/fitnesse/FitNesseExpediterTest.java
+++ b/test/fitnesse/FitNesseExpediterTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Executors;
 
 import fitnesse.authentication.Authenticator;
 import fitnesse.authentication.UnauthorizedResponder;
@@ -35,7 +35,7 @@ public class FitNesseExpediterTest {
   @Before
   public void setUp() throws Exception {
     context = FitNesseUtil.makeTestContext();
-    executorService = new ForkJoinPool(2);
+    executorService = Executors.newFixedThreadPool(2);
     WikiPage root = context.getRootPage();
     root.addChildPage("FrontPage");
     socket = new MockSocket();

--- a/test/fitnesse/FitNesseServerTest.java
+++ b/test/fitnesse/FitNesseServerTest.java
@@ -3,7 +3,7 @@
 package fitnesse;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
+import java.util.concurrent.ExecutorService;
 import java.util.regex.Pattern;
 
 import fitnesse.components.LogData;
@@ -11,9 +11,9 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.util.MockSocket;
+import fitnesse.util.SerialExecutorService;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPageDummy;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
 import org.junit.Before;
@@ -21,6 +21,7 @@ import org.junit.Test;
 import util.FileUtil;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 import static util.RegexTestCase.assertSubString;
 
 public class FitNesseServerTest {
@@ -43,7 +44,7 @@ public class FitNesseServerTest {
   @Test
   public void testSimple() throws Exception {
     WikiPageUtil.addPage(root, PathParser.parse("SomePage"), "some string");
-    String output = getSocketOutput("GET /SomePage HTTP/1.1\r\n\r\n", root);
+    String output = getSocketOutput("GET /SomePage HTTP/1.1\r\n\r\n");
     String statusLine = "HTTP/1.1 200 OK\r\n";
     assertTrue("Should have statusLine", Pattern.compile(statusLine, Pattern.MULTILINE).matcher(output).find());
     assertTrue("Should have canned Content", hasSubString("some string", output));
@@ -51,14 +52,14 @@ public class FitNesseServerTest {
 
   @Test
   public void testNotFound() throws Exception {
-    String output = getSocketOutput("GET /WikiWord HTTP/1.1\r\n\r\n", new WikiPageDummy());
+    String output = getSocketOutput("GET /WikiWord HTTP/1.1\r\n\r\n");
 
     assertSubString("Page doesn't exist.", output);
   }
 
   @Test
   public void testBadRequest() throws Exception {
-    String output = getSocketOutput("Bad Request \r\n\r\n", new WikiPageDummy());
+    String output = getSocketOutput("Bad Request \r\n\r\n");
 
     assertSubString("400 Bad Request", output);
     assertSubString("The request string is malformed and can not be parsed", output);
@@ -67,7 +68,7 @@ public class FitNesseServerTest {
   @Test
   public void testSomeOtherPage() throws Exception {
     WikiPageUtil.addPage(root, pageOnePath, "Page One Content");
-    String output = getSocketOutput("GET /PageOne HTTP/1.1\r\n\r\n", root);
+    String output = getSocketOutput("GET /PageOne HTTP/1.1\r\n\r\n");
     String expected = "Page One Content";
     assertTrue("Should have page one", hasSubString(expected, output));
   }
@@ -76,7 +77,7 @@ public class FitNesseServerTest {
   public void testSecondLevelPage() throws Exception {
     WikiPageUtil.addPage(root, pageOnePath, "Page One Content");
     WikiPageUtil.addPage(root, pageOneTwoPath, "Page Two Content");
-    String output = getSocketOutput("GET /PageOne.PageTwo HTTP/1.1\r\n\r\n", root);
+    String output = getSocketOutput("GET /PageOne.PageTwo HTTP/1.1\r\n\r\n");
 
     String expected = "Page Two Content";
     assertTrue("Should have page Two", hasSubString(expected, output));
@@ -86,13 +87,13 @@ public class FitNesseServerTest {
   public void testRelativeAndAbsoluteLinks() throws Exception {
     WikiPageUtil.addPage(root, pageOnePath, "PageOne");
     WikiPageUtil.addPage(root, pageOneTwoPath, "PageTwo");
-    String output = getSocketOutput("GET /PageOne.PageTwo HTTP/1.1\r\n\r\n", root);
+    String output = getSocketOutput("GET /PageOne.PageTwo HTTP/1.1\r\n\r\n");
     String expected = "href=\"PageOne.PageTwo\".*PageTwo";
     assertTrue("Should have relative link", hasSubString(expected, output));
 
     WikiPageUtil.addPage(root, PathParser.parse("PageTwo"), "PageTwo at root");
     WikiPageUtil.addPage(root, PathParser.parse("PageOne.PageThree"), "PageThree has link to .PageTwo at the root");
-    output = getSocketOutput("GET /PageOne.PageThree HTTP/1.1\r\n\r\n", root);
+    output = getSocketOutput("GET /PageOne.PageThree HTTP/1.1\r\n\r\n");
     expected = "href=\"PageTwo\".*[.]PageTwo";
     assertTrue("Should have absolute link", hasSubString(expected, output));
   }
@@ -118,9 +119,11 @@ public class FitNesseServerTest {
     assertEquals("billy", data.username);
   }
 
-  private String getSocketOutput(String requestLine, WikiPage page) throws Exception {
+  private String getSocketOutput(String requestLine) throws Exception {
     MockSocket s = new MockSocket(requestLine);
-    FitNesseServer server = new FitNesseServer(context);
+    ExecutorService executorService = new SerialExecutorService();
+
+    FitNesseServer server = new FitNesseServer(context, executorService);
     server.serve(s, 1000);
     return ((ByteArrayOutputStream) s.getOutputStream()).toString(FileUtil.CHARENCODING);
   }
@@ -128,4 +131,5 @@ public class FitNesseServerTest {
   private static boolean hasSubString(String expected, String output) {
     return Pattern.compile(expected, Pattern.MULTILINE).matcher(output).find();
   }
+
 }

--- a/test/fitnesse/FitNesseServerTest.java
+++ b/test/fitnesse/FitNesseServerTest.java
@@ -2,6 +2,8 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse;
 
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
 
 import fitnesse.components.LogData;
@@ -16,6 +18,7 @@ import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
 import org.junit.Before;
 import org.junit.Test;
+import util.FileUtil;
 
 import static org.junit.Assert.*;
 import static util.RegexTestCase.assertSubString;
@@ -119,8 +122,7 @@ public class FitNesseServerTest {
     MockSocket s = new MockSocket(requestLine);
     FitNesseServer server = new FitNesseServer(context);
     server.serve(s, 1000);
-    String output = s.getOutput();
-    return output;
+    return ((ByteArrayOutputStream) s.getOutputStream()).toString(FileUtil.CHARENCODING);
   }
 
   private static boolean hasSubString(String expected, String output) {

--- a/test/fitnesse/http/ChunkedResponseTest.java
+++ b/test/fitnesse/http/ChunkedResponseTest.java
@@ -37,11 +37,6 @@ public class ChunkedResponseTest implements ResponseSender {
     closed = true;
   }
 
-  @Override
-  public Socket getSocket() {
-    return null;
-  }
-
   @Before
   public void setUp() throws Exception {
     buffer = new StringBuffer();

--- a/test/fitnesse/http/ExposeThreadingIssueInMockResponseTest.java
+++ b/test/fitnesse/http/ExposeThreadingIssueInMockResponseTest.java
@@ -2,6 +2,7 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.http;
 
+import java.io.ByteArrayOutputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,6 +15,7 @@ import fitnesse.wiki.WikiPageUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import util.FileUtil;
 
 public class ExposeThreadingIssueInMockResponseTest {
   private WikiPage root;
@@ -55,10 +57,11 @@ public class ExposeThreadingIssueInMockResponseTest {
     request.setResource(testPage.getName());
 
     Response response = responder.makeResponse(context, request);
-    MockResponseSender sender = new MockResponseSender();
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    MockResponseSender sender = new MockResponseSender(output);
     sender.doSending(response);
 
-    results = sender.sentData();
+    results = output.toString(FileUtil.CHARENCODING);
   }
 
   private String classpathWidgets() {

--- a/test/fitnesse/http/InputStreamResponseTest.java
+++ b/test/fitnesse/http/InputStreamResponseTest.java
@@ -121,10 +121,4 @@ public class InputStreamResponseTest implements ResponseSender {
   public void close() {
     closed = true;
   }
-
-  @Override
-  public Socket getSocket() //TODO-MdM maybe get rid of this method.
-  {
-    return null;
-  }
 }

--- a/test/fitnesse/http/SimpleResponseTest.java
+++ b/test/fitnesse/http/SimpleResponseTest.java
@@ -33,11 +33,6 @@ public class SimpleResponseTest implements ResponseSender {
     closed = true;
   }
 
-  @Override
-  public Socket getSocket() {
-    return null;
-  }
-
   @Before
   public void setUp() throws Exception {
     buffer = new StringBuffer();

--- a/test/fitnesse/slim/ListExecutorTest.java
+++ b/test/fitnesse/slim/ListExecutorTest.java
@@ -7,7 +7,7 @@ public class ListExecutorTest extends ListExecutorTestBase {
   @Override
   protected ListExecutor getListExecutor() throws Exception {
     SlimFactory slimFactory = JavaSlimFactory.createJavaSlimFactory();
-    return slimFactory.getListExecutor(false);
+    return slimFactory.getListExecutor();
   }
 
   @Override

--- a/test/fitnesse/socketservice/SocketServiceTest.java
+++ b/test/fitnesse/socketservice/SocketServiceTest.java
@@ -37,14 +37,19 @@ public class SocketServiceTest {
 
   @Test
   public void testNoConnections() throws Exception {
-    ss = new SocketService(PORT_NUMBER, connectionCounter);
+    SocketServer connectionCounter1 = this.connectionCounter;
+    ss = createSocketService(connectionCounter1);
     ss.close();
     assertEquals(0, connections);
   }
 
+  public SocketService createSocketService(SocketServer socketServer) throws IOException {
+    return new SocketService(socketServer, false, SocketFactory.createServerSocket(PORT_NUMBER));
+  }
+
   @Test
   public void testOneConnection() throws Exception {
-    ss = new SocketService(PORT_NUMBER, connectionCounter);
+    ss = createSocketService(connectionCounter);
     connect(PORT_NUMBER);
     ss.close();
     assertEquals(1, connections);
@@ -52,7 +57,7 @@ public class SocketServiceTest {
 
   @Test
   public void testManyConnections() throws Exception {
-    ss = new SocketService(PORT_NUMBER, connectionCounter);
+    ss = createSocketService(connectionCounter);
     for (int i = 0; i < 10; i++)
       connect(PORT_NUMBER);
     ss.close();
@@ -61,7 +66,7 @@ public class SocketServiceTest {
 
   @Test
   public void testSendMessage() throws Exception {
-    ss = new SocketService(PORT_NUMBER, new HelloService());
+    ss = createSocketService(new HelloService());
     Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     String answer = br.readLine();
@@ -72,7 +77,7 @@ public class SocketServiceTest {
 
   @Test
   public void testReceiveMessage() throws Exception {
-    ss = new SocketService(PORT_NUMBER, new EchoService());
+    ss = createSocketService(new EchoService());
     Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
@@ -85,7 +90,7 @@ public class SocketServiceTest {
 
   @Test
   public void testMultiThreaded() throws Exception {
-    ss = new SocketService(PORT_NUMBER, new EchoService());
+    ss = createSocketService(new EchoService());
     Socket s = new Socket("localhost", PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);

--- a/test/fitnesse/socketservice/SocketServiceTest.java
+++ b/test/fitnesse/socketservice/SocketServiceTest.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 import java.net.Socket;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SocketServiceTest {
@@ -86,30 +87,6 @@ public class SocketServiceTest {
     s.close();
     ss.close();
     assertEquals("MyMessage", answer);
-  }
-
-  @Test
-  public void testMultiThreaded() throws Exception {
-    ss = createSocketService(new EchoService());
-    Socket s = new Socket("localhost", PORT_NUMBER);
-    BufferedReader br = GetBufferedReader(s);
-    PrintStream ps = GetPrintStream(s);
-
-    Socket s2 = new Socket("localhost", PORT_NUMBER);
-    BufferedReader br2 = GetBufferedReader(s2);
-    PrintStream ps2 = GetPrintStream(s2);
-
-    ps2.println("MyMessage2");
-    String answer2 = br2.readLine();
-    s2.close();
-
-    ps.println("MyMessage1");
-    String answer = br.readLine();
-    s.close();
-
-    ss.close();
-    assertEquals("MyMessage2", answer2);
-    assertEquals("MyMessage1", answer);
   }
 
   private void connect(int port) {

--- a/test/fitnesse/socketservice/SslSocketServiceTest.java
+++ b/test/fitnesse/socketservice/SslSocketServiceTest.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 import java.net.Socket;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SslSocketServiceTest {
@@ -101,31 +102,6 @@ public class SslSocketServiceTest {
     s.close();
     ss.close();
     assertEquals("MyMessage", answer);
-  }
-
-  @Test
-  public void testMultiThreaded() throws Exception {
-	  ss = createSslSocketService(new EchoService());
-    Socket s = createClientSocket(PORT_NUMBER);
-    BufferedReader br = GetBufferedReader(s);
-    PrintStream ps = GetPrintStream(s);
-
-    Socket s2 = createClientSocket(PORT_NUMBER);
-    BufferedReader br2 = GetBufferedReader(s2);
-    PrintStream ps2 = GetPrintStream(s2);
-
-    ps2.println("MyMessage2");
-    String answer2 = br2.readLine();
-    s2.close();
-
-    ps.println("MyMessage1");
-    String answer = br.readLine();
-    s.close();
-
-    ss.close();
-    System.out.print("Got Messages 1: " +answer +", 2: " + answer2 + ".\n");
-    assertEquals("MyMessage2", answer2);
-    assertEquals("MyMessage1", answer);
   }
 
   private void connect(int port) {

--- a/test/fitnesse/socketservice/SslSocketServiceTest.java
+++ b/test/fitnesse/socketservice/SslSocketServiceTest.java
@@ -37,14 +37,23 @@ public class SslSocketServiceTest {
 
   @Test
   public void testNoConnections() throws Exception {
-    ss = new SocketService(PORT_NUMBER, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
+    SocketServer connectionCounter1 = this.connectionCounter;
+    ss = createSslSocketService(connectionCounter1);
     ss.close();
     assertEquals(0, connections);
   }
 
+  public SocketService createSslSocketService(SocketServer socketServer) throws IOException {
+    return new SocketService(socketServer, true, SocketFactory.createSslServerSocket(PORT_NUMBER, false, "fitnesse.socketservice.SslParametersWiki"));
+  }
+
+  private Socket createClientSocket(int port) throws IOException {
+    return SocketFactory.createClientSocket("localhost", port, true, "fitnesse.socketservice.SslParametersWiki");
+  }
+
   @Test
   public void testOneConnection() throws Exception {
-	 ss = new SocketService(PORT_NUMBER, true, connectionCounter,"fitnesse.socketservice.SslParametersWiki");
+	  ss = createSslSocketService(connectionCounter);
     connect(PORT_NUMBER);
     ss.close();
     assertEquals(1, connections);
@@ -52,27 +61,27 @@ public class SslSocketServiceTest {
 
   @Test
   public void testManyConnections() throws Exception {
-     ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
-    String answer = ""; 
+    ss = createSslSocketService(new EchoService());
+    String answer = "";
     for (int i = 0; i < 10; i++){
-        Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
-    	System.out.print("Peer: " + SocketFactory.peerName(s) + "\n");
+        Socket s = createClientSocket(PORT_NUMBER);
+    	  System.out.print("Peer: " + SocketFactory.peerName(s) + "\n");
         BufferedReader br = GetBufferedReader(s);
         PrintStream ps = GetPrintStream(s);
         ps.println(i + ",");
         answer = answer + br.readLine();
     }
     ss.close();
-    
+
    System.out.print("Got Messages : " +answer +"\n");
    assertEquals("0,1,2,3,4,5,6,7,8,9,", answer);
   }
 
   @Test
   public void testSendMessage() throws Exception {
-	ss = new SocketService(PORT_NUMBER, true, new HelloService(),"fitnesse.socketservice.SslParametersWiki");
+	  ss = createSslSocketService(new HelloService());
 
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
+    Socket s = createClientSocket(PORT_NUMBER);
 
     BufferedReader br = GetBufferedReader(s);
     String answer = br.readLine();
@@ -83,8 +92,8 @@ public class SslSocketServiceTest {
 
   @Test
   public void testReceiveMessage() throws Exception {
-	ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
+	  ss = createSslSocketService(new EchoService());
+    Socket s = createClientSocket(PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
     ps.println("MyMessage");
@@ -96,12 +105,12 @@ public class SslSocketServiceTest {
 
   @Test
   public void testMultiThreaded() throws Exception {
-	ss = new SocketService(PORT_NUMBER, true, new EchoService(),"fitnesse.socketservice.SslParametersWiki");
-    Socket s = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
+	  ss = createSslSocketService(new EchoService());
+    Socket s = createClientSocket(PORT_NUMBER);
     BufferedReader br = GetBufferedReader(s);
     PrintStream ps = GetPrintStream(s);
 
-    Socket s2 = SocketFactory.tryCreateClientSocket("localhost", PORT_NUMBER, true, "fitnesse.socketservice.SslParametersWiki");
+    Socket s2 = createClientSocket(PORT_NUMBER);
     BufferedReader br2 = GetBufferedReader(s2);
     PrintStream ps2 = GetPrintStream(s2);
 
@@ -121,7 +130,7 @@ public class SslSocketServiceTest {
 
   private void connect(int port) {
     try {
-      Socket s = SocketFactory.tryCreateClientSocket("localhost", port, true, "fitnesse.socketservice.SslParametersWiki");
+      Socket s = createClientSocket(port);
       sleep(30);
       s.close();
     }

--- a/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
@@ -99,7 +99,7 @@ public class SlimClientBuilderTest {
   public void createSlimServiceFailsFastWhenSlimPortIsNotAvailable() throws Exception {
     final int slimServerPort = 10258;
     Descriptor descriptor = mock(Descriptor.class);
-    ServerSocket slimSocket = SocketFactory.tryCreateServerSocket(slimServerPort);
+    ServerSocket slimSocket = SocketFactory.createServerSocket(slimServerPort);
     try {
       InProcessSlimClientBuilder sys = new InProcessSlimClientBuilder(descriptor);
       String[] slimArguments = new String[] { Integer.toString(slimServerPort) };


### PR DESCRIPTION
Changed the web end to use ExecutorService instead of the custom thread handling logic.

This means the amount of requests handled in parallel is now capped.

In order to make this work, FitNesseServer is provided an ExecutorService and all requests are handled via this service. SocketService only takes care of accepting requests and telling the SocketServer to handle them.

I added a SerialExecutorService that just executes requests on the same thread. This version is used by fixtures and single requests, simplifying the logic.
