### PR TITLE
Make FitNesse buildable with openJDK9

### DIFF
--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -49,9 +49,8 @@ public class ConverterRegistry {
     }
   }
 
-  public static <T> Converter<T> getConverterForClass(Class<? extends T> clazz) {
-    // While the casting may be redundant, it is required for JDK9.
-    return (Converter<T>) getConverterForClass(clazz, null);
+  public static <T> Converter<T> getConverterForClass(Class<T> clazz) {
+    return getConverterForClass(clazz, null);
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -50,7 +50,7 @@ public class ConverterRegistry {
   }
 
   public static <T> Converter<T> getConverterForClass(Class<? extends T> clazz) {
-    return getConverterForClass(clazz, null);
+    return (Converter<T>) getConverterForClass(clazz, null);
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/fitnesse/slim/converters/ConverterRegistry.java
+++ b/src/fitnesse/slim/converters/ConverterRegistry.java
@@ -50,6 +50,7 @@ public class ConverterRegistry {
   }
 
   public static <T> Converter<T> getConverterForClass(Class<? extends T> clazz) {
+    // While the casting may be redundant, it is required for JDK9.
     return (Converter<T>) getConverterForClass(clazz, null);
   }
 


### PR DESCRIPTION
Adding a cast in order to build with openJDK9 (tested with 9~b88-1 on Ubuntu Xenial)

While FitNesse now builds, there are test failures, so #746 isn't completely fixed by this. I'm looking more into what's causing the failing tests.

Also built successfully with openJDK 8 to verify it also work for older JDKs. 