### PR TITLE
In-process Slim

### DIFF
--- a/src/fitnesse/slim/JavaSlimFactory.java
+++ b/src/fitnesse/slim/JavaSlimFactory.java
@@ -35,7 +35,11 @@ public class JavaSlimFactory extends SlimFactory {
   }
 
   public static SlimFactory createJavaSlimFactory(SlimService.Options options) {
-    return new JavaSlimFactory(options.statementTimeout, options.verbose);
+    return createJavaSlimFactory(options.statementTimeout, options.verbose);
+  }
+
+  public static SlimFactory createJavaSlimFactory(Integer timeout, boolean verbose) {
+    return new JavaSlimFactory(timeout, verbose);
   }
 
   public static SlimFactory createJavaSlimFactory() {

--- a/src/fitnesse/slim/SlimException.java
+++ b/src/fitnesse/slim/SlimException.java
@@ -117,6 +117,6 @@ public class SlimException extends Exception {
   }
 
   public static boolean isStopSuiteException(Throwable t) {
-    return t != null && t.getClass().toString().contains("StopSuite");
+    return t != null && t.getClass().toString().contains("StopSuite") || t instanceof InterruptedException;
   }
 }

--- a/src/fitnesse/slim/SlimServer.java
+++ b/src/fitnesse/slim/SlimServer.java
@@ -38,18 +38,14 @@ public class SlimServer implements SocketServer {
   }
 
   @Override
-  public void serve(Socket s) {
-    SocketFactory.printSocketInfo(s);
+  public void serve(Socket s) throws IOException {
+//    SocketFactory.printSocketInfo(s);
     SlimStreamReader reader = null;
     OutputStream writer = null;
     try {
       reader = SlimStreamReader.getReader(s);
       writer = SlimStreamReader.getByteWriter(s);
       tryProcessInstructions(reader, writer);
-    } catch (Throwable e) { // NOSONAR
-      // Intentional catch-all, since this is the last point we can communicate failures back to FitNesse
-      System.err.println("Error while executing SLIM instructions: " + e.getMessage());
-      e.printStackTrace(System.err);
     } finally {
       slimFactory.stop();
       try {

--- a/src/fitnesse/slim/SlimServer.java
+++ b/src/fitnesse/slim/SlimServer.java
@@ -40,7 +40,7 @@ public class SlimServer implements SocketServer {
 
   @Override
   public void serve(Socket s) throws IOException {
-//    SocketFactory.printSocketInfo(s);
+    SocketFactory.printSocketInfo(s);
     SlimStreamReader reader = null;
     OutputStream writer = null;
     try {
@@ -82,8 +82,7 @@ public class SlimServer implements SocketServer {
   private String executeInstructions(ListExecutor executor, String instructions) {
     List<Object> statements = SlimDeserializer.deserialize(instructions);
     List<Object> results = executor.execute(statements);
-    String resultString = SlimSerializer.serialize(results);
-    return resultString;
+    return SlimSerializer.serialize(results);
   }
 
 }

--- a/src/fitnesse/slim/SlimServer.java
+++ b/src/fitnesse/slim/SlimServer.java
@@ -6,6 +6,7 @@ import fitnesse.slim.protocol.SlimDeserializer;
 import fitnesse.slim.protocol.SlimSerializer;
 import fitnesse.socketservice.SocketFactory;
 import fitnesse.socketservice.SocketServer;
+import util.FileUtil;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -48,12 +49,8 @@ public class SlimServer implements SocketServer {
       tryProcessInstructions(reader, writer);
     } finally {
       slimFactory.stop();
-      try {
-        if (reader != null) reader.close();
-        if (writer != null) writer.close();
-      } catch (Exception e) {
-
-      }
+      FileUtil.close(reader);
+      FileUtil.close(writer);
     }
   }
 

--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -78,6 +78,7 @@ public class SlimService {
   }
 
   // For testing only -- for now
+  @Deprecated
   public static synchronized int startWithFactoryAsync(SlimFactory slimFactory, Options options) throws IOException {
     if (service != null && service.isAlive()) {
       service.interrupt();
@@ -100,6 +101,7 @@ public class SlimService {
   }
 
   // For testing, mainly.
+  @Deprecated
   public static void waitForServiceToStopAsync() throws InterruptedException {
     // wait for service to close.
     for (int i = 0; i < 1000; i++) {

--- a/src/fitnesse/slim/SlimService.java
+++ b/src/fitnesse/slim/SlimService.java
@@ -48,7 +48,6 @@ public class SlimService {
   private final SlimServer slimServer;
   private final boolean daemon;
   private final Executor executor = Executors.newFixedThreadPool(5);
-  static Thread service;
 
   public static void main(String[] args) throws IOException {
     Options options = parseCommandLine(args);
@@ -75,40 +74,6 @@ public class SlimService {
   public static void startWithFactory(SlimFactory slimFactory, Options options) throws IOException {
     SlimService slimservice = new SlimService(slimFactory.getSlimServer(), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
     slimservice.accept();
-  }
-
-  // For testing only -- for now
-  @Deprecated
-  public static synchronized int startWithFactoryAsync(SlimFactory slimFactory, Options options) throws IOException {
-    if (service != null && service.isAlive()) {
-      service.interrupt();
-      throw new SlimError("Already an in-process server running: " + service.getName() + " (alive=" + service.isAlive() + ")");
-    }
-    final SlimService slimservice = new SlimService(slimFactory.getSlimServer(), options.port, options.interaction, options.daemon, options.useSSL, options.sslParameterClassName);
-    int actualPort = slimservice.getPort();
-    service = new Thread() {
-      @Override
-      public void run() {
-        try {
-          slimservice.accept();
-        } catch (IOException e) {
-          throw new SlimError(e);
-        }
-      }
-    };
-    service.start();
-    return actualPort;
-  }
-
-  // For testing, mainly.
-  @Deprecated
-  public static void waitForServiceToStopAsync() throws InterruptedException {
-    // wait for service to close.
-    for (int i = 0; i < 1000; i++) {
-      if (!service.isAlive())
-        break;
-      Thread.sleep(50);
-    }
   }
 
   public static Options parseCommandLine(String[] args) {

--- a/src/fitnesse/slim/StatementTimeoutExecutor.java
+++ b/src/fitnesse/slim/StatementTimeoutExecutor.java
@@ -99,7 +99,7 @@ public class StatementTimeoutExecutor implements StatementExecutorInterface {
     } catch (TimeoutException e) {
       throw new SlimException(Integer.toString(timeout), SlimServer.TIMED_OUT, true);
     } catch (InterruptedException e) {
-      throw new SlimException(e);
+      throw new SlimError("Statement execution was interrupted", e);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof SlimException) {

--- a/src/fitnesse/slim/instructions/Instruction.java
+++ b/src/fitnesse/slim/instructions/Instruction.java
@@ -1,7 +1,6 @@
 package fitnesse.slim.instructions;
 
 import fitnesse.slim.SlimException;
-import fitnesse.slim.SlimServer;
 import fitnesse.slim.instructions.SystemExitSecurityManager.SystemExitException;
 
 public abstract class Instruction {

--- a/src/fitnesse/slim/instructions/Instruction.java
+++ b/src/fitnesse/slim/instructions/Instruction.java
@@ -1,6 +1,7 @@
 package fitnesse.slim.instructions;
 
 import fitnesse.slim.SlimException;
+import fitnesse.slim.SlimServer;
 import fitnesse.slim.instructions.SystemExitSecurityManager.SystemExitException;
 
 public abstract class Instruction {

--- a/src/fitnesse/slim/protocol/SlimListBuilder.java
+++ b/src/fitnesse/slim/protocol/SlimListBuilder.java
@@ -1,0 +1,83 @@
+package fitnesse.slim.protocol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fitnesse.slim.SlimError;
+import fitnesse.slim.SlimException;
+import fitnesse.slim.instructions.AssignInstruction;
+import fitnesse.slim.instructions.CallAndAssignInstruction;
+import fitnesse.slim.instructions.CallInstruction;
+import fitnesse.slim.instructions.ImportInstruction;
+import fitnesse.slim.instructions.Instruction;
+import fitnesse.slim.instructions.InstructionExecutor;
+import fitnesse.slim.instructions.MakeInstruction;
+
+import static java.util.Arrays.asList;
+
+public class SlimListBuilder {
+
+  private final double slimVersion;
+
+  public SlimListBuilder(double slimVersion) {
+    this.slimVersion = slimVersion;
+  }
+
+  private interface ToListExecutor extends InstructionExecutor {
+
+  }
+
+  public List<Object> toList(List<Instruction> instructions) {
+    final List<Object> statementsAsList = new ArrayList<Object>(instructions.size());
+    for (final Instruction instruction : instructions) {
+      ToListExecutor executor = new ToListExecutor() {
+
+        private List<Object> mergeAsList(Object[] a, Object[] b) {
+          List<Object> l = new ArrayList<Object>(a.length + b.length);
+          l.addAll(asList(a));
+          l.addAll(asList(b));
+          return l;
+        }
+
+        @Override
+        public void addPath(String path) throws SlimException {
+          statementsAsList.add(asList(instruction.getId(), ImportInstruction.INSTRUCTION, path));
+        }
+
+        @Override
+        public Object callAndAssign(String symbolName, String instanceName, String methodsName, Object... arguments) throws SlimException {
+          Object[] list = new Object[]{instruction.getId(), CallAndAssignInstruction.INSTRUCTION, symbolName, instanceName, methodsName};
+          statementsAsList.add(mergeAsList(list, arguments));
+
+          return null;
+        }
+
+        @Override
+        public Object call(String instanceName, String methodName, Object... arguments) throws SlimException {
+          Object[] list = new Object[]{instruction.getId(), CallInstruction.INSTRUCTION, instanceName, methodName};
+          statementsAsList.add(mergeAsList(list, arguments));
+          return null;
+        }
+
+        @Override
+        public void create(String instanceName, String className, Object... constructorArgs) throws SlimException {
+          Object[] list = new Object[]{instruction.getId(), MakeInstruction.INSTRUCTION, instanceName, className};
+          statementsAsList.add(mergeAsList(list, constructorArgs));
+        }
+
+        @Override
+        public void assign(String symbolName, Object value) {
+          if (slimVersion < 0.4) {
+            throw new SlimError("The assign instruction is available as of SLIM protocol version 0.4");
+          }
+          Object[] list = new Object[]{instruction.getId(), AssignInstruction.INSTRUCTION, symbolName, value};
+          statementsAsList.add(asList(list));
+        }
+      };
+
+      instruction.execute(executor);
+    }
+    return statementsAsList;
+  }
+
+}

--- a/src/fitnesse/socketservice/SocketFactory.java
+++ b/src/fitnesse/socketservice/SocketFactory.java
@@ -122,23 +122,30 @@ public final class SocketFactory {
 
   public static void printSocketInfo(Socket theSocket) {
 
+    if (LOG.isLoggable(Level.FINER)) {
+      LOG.log(Level.FINER, "Socket class: " + theSocket.getClass());
+      LOG.log(Level.FINER, "   Remote address = " + theSocket.getRemoteSocketAddress().toString());
+      LOG.log(Level.FINER, "   Local socket address = " + theSocket.getLocalSocketAddress().toString());
+    }
 
-    LOG.log(Level.FINER, "Socket class: " + theSocket.getClass());
-    LOG.log(Level.FINER, "   Remote address = " + theSocket.getRemoteSocketAddress().toString());
-    LOG.log(Level.FINER, "   Local socket address = " + theSocket.getLocalSocketAddress().toString());
-    LOG.log(Level.FINEST, "   Closed = " + theSocket.isClosed());
-    LOG.log(Level.FINEST, "   Connected = " + theSocket.isConnected());
-    LOG.log(Level.FINEST, "   Bound = " + theSocket.isBound());
-    LOG.log(Level.FINEST, "   isInputShutdown = " + theSocket.isInputShutdown());
-    LOG.log(Level.FINEST, "   isOutputShutdown = " + theSocket.isOutputShutdown());
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "   Closed = " + theSocket.isClosed());
+      LOG.log(Level.FINEST, "   Connected = " + theSocket.isConnected());
+      LOG.log(Level.FINEST, "   Bound = " + theSocket.isBound());
+      LOG.log(Level.FINEST, "   isInputShutdown = " + theSocket.isInputShutdown());
+      LOG.log(Level.FINEST, "   isOutputShutdown = " + theSocket.isOutputShutdown());
+    }
+
     if (isSSLSocket(theSocket)) {
       SSLSocket s = (SSLSocket) theSocket;
-      LOG.log(Level.FINEST, "   Need client authentication = " + s.getNeedClientAuth());
-      LOG.log(Level.FINEST, "   Want client authentication = " + s.getWantClientAuth());
-      LOG.log(Level.FINEST, "   Use client mode = " + s.getUseClientMode());
+      SSLSession ss = s.getSession();
 
-      try {
-        SSLSession ss = s.getSession();
+      if (LOG.isLoggable(Level.FINEST)) {
+        LOG.log(Level.FINEST, "   Need client authentication = " + s.getNeedClientAuth());
+
+        LOG.log(Level.FINEST, "   Want client authentication = " + s.getWantClientAuth());
+        LOG.log(Level.FINEST, "   Use client mode = " + s.getUseClientMode());
+
         LOG.log(Level.FINEST, "Session class: " + ss.getClass());
         LOG.log(Level.FINEST, "   ID is " + new BigInteger(ss.getId()));
         LOG.log(Level.FINEST, "   Session created in " + ss.getCreationTime());
@@ -146,18 +153,29 @@ public final class SocketFactory {
         LOG.log(Level.FINEST, "   Cipher suite = " + ss.getCipherSuite());
         LOG.log(Level.FINEST, "   Protocol = " + ss.getProtocol());
         LOG.log(Level.FINEST, "   LocalPrincipal = " + ss.getLocalPrincipal().getName());
-        LOG.log(Level.FINEST, "   PeerPrincipal = " + ss.getPeerPrincipal().getName());
-        LOG.log(Level.FINE, "   PeerName = " + peerName(s));
+        try {
+          LOG.log(Level.FINEST, "   PeerPrincipal = " + ss.getPeerPrincipal().getName());
+        } catch (SSLPeerUnverifiedException e) {
+          LOG.warning("Could not retrieve Peer principal information: " + e.getMessage());
+        }
+      }
 
-        Certificate[] cchain = ss.getPeerCertificates();
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.log(Level.FINE, "   PeerName = " + peerName(s));
+      }
+
+      if (LOG.isLoggable(Level.FINEST)) {
+        Certificate[] cchain = new Certificate[0];
+        try {
+          cchain = ss.getPeerCertificates();
+        } catch (SSLPeerUnverifiedException e) {
+          LOG.warning("Could not retrieve certeficate for peer: " + e.getMessage());
+        }
         LOG.log(Level.FINEST, "The Certificates used by peer");
         for (Certificate aCchain : cchain) {
           LOG.log(Level.FINEST, "   " + aCchain.toString());
           LOG.log(Level.FINEST, "   " + ((X509Certificate) aCchain).getSubjectDN());
         }
-
-      } catch (Exception e) {
-        LOG.warning(e.toString());
       }
     }
   }

--- a/src/fitnesse/testrunner/MultipleTestSystemFactory.java
+++ b/src/fitnesse/testrunner/MultipleTestSystemFactory.java
@@ -14,6 +14,7 @@ import fitnesse.testsystems.fit.InProcessFitClientBuilder;
 import fitnesse.testsystems.slim.CustomComparatorRegistry;
 import fitnesse.testsystems.slim.HtmlSlimTestSystem;
 import fitnesse.testsystems.slim.InProcessSlimClientBuilder;
+import fitnesse.testsystems.slim.SlimClient;
 import fitnesse.testsystems.slim.SlimClientBuilder;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.testsystems.slim.tables.SlimTableFactory;
@@ -89,7 +90,7 @@ public class MultipleTestSystemFactory implements TestSystemFactory, TestSystemF
     @Override
     public TestSystem create(Descriptor descriptor) throws IOException {
       InProcessSlimClientBuilder clientBuilder = new InProcessSlimClientBuilder(descriptor);
-      SlimCommandRunningClient slimClient = clientBuilder.build();
+      SlimClient slimClient = clientBuilder.build();
       HtmlSlimTestSystem testSystem = new HtmlSlimTestSystem(clientBuilder.getTestSystemName(), slimClient,
               slimTableFactory.copy(), customComparatorRegistry);
 

--- a/src/fitnesse/testsystems/slim/InProcessSlimClient.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClient.java
@@ -1,0 +1,120 @@
+package fitnesse.testsystems.slim;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import fitnesse.slim.SlimError;
+import fitnesse.slim.SlimServer;
+import fitnesse.slim.SlimStreamReader;
+import fitnesse.slim.SlimVersion;
+import fitnesse.slim.instructions.Instruction;
+import fitnesse.slim.protocol.SlimDeserializer;
+import fitnesse.slim.protocol.SlimListBuilder;
+import fitnesse.slim.protocol.SlimSerializer;
+import fitnesse.testsystems.ExecutionLogListener;
+import fitnesse.util.MockSocket;
+
+public class InProcessSlimClient implements SlimClient {
+  private final String testSystemName;
+  private final SlimServer slimServer;
+  private final ExecutionLogListener executionLogListener;
+  private MockSocket socket;
+  private PipedOutputStream clientOutput;
+  private Thread slimServerThread;
+  private SlimStreamReader reader;
+  private double slimServerVersion;
+
+  public InProcessSlimClient(String testSystemName, SlimServer slimServer, ExecutionLogListener executionLogListener) {
+    this.testSystemName = testSystemName;
+    this.slimServer = slimServer;
+    this.executionLogListener = executionLogListener;
+  }
+
+  @Override
+  public void start() throws IOException {
+    commandStarted();
+
+    PipedInputStream socketInput = new PipedInputStream();
+    clientOutput = new PipedOutputStream(socketInput);
+    PipedInputStream clientInput = new PipedInputStream();
+    PipedOutputStream socketOutput = new PipedOutputStream(clientInput);
+    reader = new SlimStreamReader(clientInput);
+    socket = new MockSocket(socketInput, socketOutput);
+    // Start SlimServer in a separate thread
+
+    slimServerThread = new Thread(new Runnable() {
+      @Override public void run() {
+        try {
+          slimServer.serve(socket);
+          executionLogListener.exitCode(0);
+        } catch (Throwable t) {
+          // This point is not reached since no errors bubble up this far
+          executionLogListener.exceptionOccurred(t);
+        }
+      }
+    });
+    slimServerThread.start();
+    connect();
+  }
+
+  private void commandStarted() {
+    executionLogListener.commandStarted(new ExecutionLogListener.ExecutionContext() {
+      @Override
+      public String getCommand() {
+        return "";
+      }
+
+      @Override
+      public String getTestSystemName() {
+        return testSystemName;
+      }
+    });
+  }
+
+  @Override
+  public Map<String, Object> invokeAndGetResponse(List<Instruction> statements) throws IOException {
+    if (statements.isEmpty())
+      return Collections.emptyMap();
+    String instructions = SlimSerializer.serialize(new SlimListBuilder(slimServerVersion).toList(statements));
+    SlimStreamReader.sendSlimMessage(clientOutput, instructions);
+    String results = reader.getSlimMessage();
+    List<Object> resultList = SlimDeserializer.deserialize(results);
+    return SlimCommandRunningClient.resultToMap(resultList);
+  }
+
+  @Override
+  public void connect() throws IOException {
+    String slimServerVersionMessage = reader.readLine();
+    if (!isConnected(slimServerVersionMessage)) {
+      throw new SlimError("Got invalid slim header from client. Read the following: " + slimServerVersionMessage);
+    }
+
+    slimServerVersion = Double.parseDouble(slimServerVersionMessage.replace(SlimVersion.SLIM_HEADER, ""));
+    if (slimServerVersion == SlimCommandRunningClient.NO_SLIM_SERVER_CONNECTION_FLAG) {
+      throw new SlimError("Slim Protocol Version Error: Server did not respond with a valid version number.");
+    } else if (slimServerVersion < SlimCommandRunningClient.MINIMUM_REQUIRED_SLIM_VERSION) {
+      throw new SlimError(String.format("Slim Protocol Version Error: Expected V%s but was V%s", SlimCommandRunningClient.MINIMUM_REQUIRED_SLIM_VERSION, slimServerVersion));
+    }
+  }
+
+  public boolean isConnected(String slimServerVersionMessage) {
+    return slimServerVersionMessage.startsWith(SlimVersion.SLIM_HEADER);
+  }
+
+  @Override
+  public void bye() throws IOException {
+    // Close slimServer thread
+    if (slimServerThread.isAlive()) {
+      SlimStreamReader.sendSlimMessage(clientOutput, SlimVersion.BYEMESSAGE);
+    }
+  }
+
+  @Override
+  public void kill() throws IOException {
+    slimServerThread.interrupt();
+  }
+}

--- a/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
@@ -5,7 +5,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import fitnesse.slim.JavaSlimFactory;
+import fitnesse.slim.SlimServer;
 import fitnesse.slim.SlimService;
+import fitnesse.testsystems.ClientBuilder;
 import fitnesse.testsystems.CommandRunner;
 import fitnesse.testsystems.Descriptor;
 import fitnesse.testsystems.MockCommandRunner;
@@ -13,48 +15,25 @@ import fitnesse.testsystems.MockCommandRunner;
 /**
  * In-process version, mainly for testing FitNesse itself.
  */
-public class InProcessSlimClientBuilder extends SlimClientBuilder {
+public class InProcessSlimClientBuilder extends ClientBuilder<SlimClient> {
   private static final Logger LOG = Logger.getLogger(InProcessSlimClientBuilder.class.getName());
 
   public InProcessSlimClientBuilder(Descriptor descriptor) {
     super(descriptor);
   }
 
-  @Override
-  public SlimCommandRunningClient build() throws IOException {
-    CommandRunner commandRunner = new MockCommandRunner(getExecutionLogListener());
-    final String[] slimArguments = buildArguments();
-    createSlimService(slimArguments);
-
-    return new SlimCommandRunningClient(commandRunner, determineSlimHost(), getSlimPort(), determineTimeout(), getSlimVersion(), determineSSL(), determineHostSSLParameterClass());
+  public SlimClient build() throws IOException {
+    SlimServer slimServer = createSlimServer(1000, isDebug());
+    return new InProcessSlimClient(getTestSystemName(), slimServer, getExecutionLogListener());
   }
 
   @Override
-  protected int getNextSlimPort() {
-    return 0;
+  protected String defaultTestRunner() {
+    return "in-process";
   }
 
-  void createSlimService(String[] args) throws IOException {
-    while (!tryCreateSlimService(args))
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        LOG.log(Level.WARNING, "Interrupted while waiting for Slim server to come on line", e);
-      }
-  }
-
-  private boolean tryCreateSlimService(String[] args) throws IOException {
-    try {
-      SlimService.Options options = SlimService.parseCommandLine(args);
-      int actualPort = SlimService.startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
-      setSlimPort(actualPort);
-      return true;
-    } catch (IOException e) {
-      throw e;
-    } catch (Exception e) {
-      LOG.log(Level.WARNING, "Could not start async Slim service", e);
-      return false;
-    }
+  protected SlimServer createSlimServer(int timeout, boolean verbose) {
+    return JavaSlimFactory.createJavaSlimFactory(timeout, verbose).getSlimServer();
   }
 
 }

--- a/src/fitnesse/util/MockSocket.java
+++ b/src/fitnesse/util/MockSocket.java
@@ -81,6 +81,13 @@ public class MockSocket extends Socket {
 
   @Override
   public SocketAddress getRemoteSocketAddress() {
+    // Mock a socket address, to keep the logging happy.
+    return new InetSocketAddress(host != null ? host : "internal", 123);
+  }
+
+  @Override
+  public SocketAddress getLocalSocketAddress() {
+    // Mock a socket address, to keep the logging happy.
     return new InetSocketAddress(host != null ? host : "internal", 123);
   }
 }

--- a/src/fitnesse/util/MockSocket.java
+++ b/src/fitnesse/util/MockSocket.java
@@ -21,8 +21,8 @@ import util.FileUtil;
 public class MockSocket extends Socket {
   private static final Logger LOG = Logger.getLogger(MockSocket.class.getName());
 
-  InputStream input;
-  OutputStream output;
+  private final InputStream input;
+  private final OutputStream output;
   private String host;
   private boolean closed;
 
@@ -81,6 +81,6 @@ public class MockSocket extends Socket {
 
   @Override
   public SocketAddress getRemoteSocketAddress() {
-    return new InetSocketAddress(host, 123);
+    return new InetSocketAddress(host != null ? host : "internal", 123);
   }
 }

--- a/src/util/FileUtil.java
+++ b/src/util/FileUtil.java
@@ -22,6 +22,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import fitnesse.slim.SlimStreamReader;
+
 public class FileUtil {
 
   public static final String CHARENCODING = "UTF-8";
@@ -246,4 +248,13 @@ public class FileUtil {
     }
   }
 
+  public static void close(StreamReader reader) {
+    if (reader != null) {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to close stream reader", e);
+      }
+    }
+  }
 }

--- a/test/fitnesse/responders/run/SuiteResponderTest.java
+++ b/test/fitnesse/responders/run/SuiteResponderTest.java
@@ -336,7 +336,7 @@ public class SuiteResponderTest {
     assertHasRegexp("<td>fitnesse.testutil.PassFixture</td>", results);
     assertHasRegexp("<td><span class=\"pass\">wow</span></td>", results);
     assertHasRegexp("<h3>fit:fit.FitServer</h3>", results);
-    assertHasRegexp("<h3>slim:fitnesse.slim.SlimService", results);
+    assertHasRegexp("<h3>slim:in-process", results);
   }
 
   @Test

--- a/test/fitnesse/responders/run/TestResponderTest.java
+++ b/test/fitnesse/responders/run/TestResponderTest.java
@@ -430,7 +430,7 @@ public class TestResponderTest {
     if (semaphore.exists())
       semaphore.delete();
 
-    new Thread(makeStopTestsRunnable(semaphore)).start();
+    new Thread(new WaitForSemaphoreThenStopProcesses(semaphore)).start();
 
     doSimpleRun(createAndWaitFixture(semaphoreName));
     assertHasRegexp("Testing was interrupted", results);
@@ -440,10 +440,6 @@ public class TestResponderTest {
   private String createAndWaitFixture(String semaphoreName) {
     return "!define TEST_SYSTEM {slim}\n" +
       "!|fitnesse.testutil.CreateFileAndWaitFixture|" + semaphoreName + "|\n";
-  }
-
-  private Runnable makeStopTestsRunnable(File semaphore) {
-    return new WaitForSemaphoreThenStopProcesses(semaphore);
   }
 
   private class WaitForSemaphoreThenStopProcesses implements Runnable {

--- a/test/fitnesse/responders/run/slimResponder/HtmlSlimResponder.java
+++ b/test/fitnesse/responders/run/slimResponder/HtmlSlimResponder.java
@@ -3,6 +3,7 @@
 package fitnesse.responders.run.slimResponder;
 
 import fitnesse.testsystems.slim.CustomComparatorRegistry;
+import fitnesse.testsystems.slim.SlimClient;
 import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.testsystems.slim.HtmlSlimTestSystem;
 import fitnesse.testsystems.slim.InProcessSlimClientBuilder;
@@ -22,7 +23,7 @@ public class HtmlSlimResponder extends SlimResponder {
   @Override
   protected SlimTestSystem getTestSystem() throws IOException {
 
-    SlimCommandRunningClient slimClient;
+    SlimClient slimClient;
     if (fastTest) {
       slimClient = new InProcessSlimClientBuilder(getDescriptor()).build();
     } else {

--- a/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
+++ b/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
@@ -26,7 +26,7 @@ public class HtmlSlimResponderTest {
 
   private void assertTestResultsContain(String fragment) {
     String unescapedResults = unescape(testResults);
-    assertTrue(unescapedResults, unescapedResults.contains(fragment));
+    assertTrue("'" + fragment + "' not found in: " +unescapedResults, unescapedResults.contains(fragment));
   }
 
   private void assertTestResultsDoNotContain(String fragment) {

--- a/test/fitnesse/slim/SlimServiceTest.java
+++ b/test/fitnesse/slim/SlimServiceTest.java
@@ -18,13 +18,13 @@ public class SlimServiceTest extends SlimServiceTestBase {
   @Override
   protected void startSlimService() throws IOException {
     SlimService.Options options = SlimService.parseCommandLine(new String[]{"8099"});
-    SlimService.startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
+    startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
   }
 
   @Override
   protected void closeSlimService() throws InterruptedException {
-    SlimService.waitForServiceToStopAsync();
-    assertFalse(SlimService.service.isAlive());
+    waitForServiceToStopAsync();
+    assertFalse(service.isAlive());
   }
 
   @Override

--- a/test/fitnesse/slim/SslSlimServiceTest.java
+++ b/test/fitnesse/slim/SslSlimServiceTest.java
@@ -26,7 +26,7 @@ public class SslSlimServiceTest extends SlimServiceTestBase {
   @Override
   protected void startSlimService() throws IOException {
     SlimService.Options options = SlimService.parseCommandLine(new String[]{ /* "-v", */ "-ssl", "fitnesse.socketservice.SslParametersWiki", "8099"});
-    SlimService.startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
+    startWithFactoryAsync(JavaSlimFactory.createJavaSlimFactory(options), options);
   }
 
   @Override
@@ -40,8 +40,8 @@ public class SslSlimServiceTest extends SlimServiceTestBase {
 
   @Override
   protected void closeSlimService() throws InterruptedException {
-    SlimService.waitForServiceToStopAsync();
-    assertFalse(SlimService.service.isAlive());
+    waitForServiceToStopAsync();
+    assertFalse(service.isAlive());
   }
 
   @Override

--- a/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
@@ -95,19 +95,19 @@ public class SlimClientBuilderTest {
     assertEquals("somehost", new SlimClientBuilder(descriptor).determineSlimHost());
   }
 
-  @Test(expected = IOException.class)
-  public void createSlimServiceFailsFastWhenSlimPortIsNotAvailable() throws Exception {
-    final int slimServerPort = 10258;
-    Descriptor descriptor = mock(Descriptor.class);
-    ServerSocket slimSocket = SocketFactory.createServerSocket(slimServerPort);
-    try {
-      InProcessSlimClientBuilder sys = new InProcessSlimClientBuilder(descriptor);
-      String[] slimArguments = new String[] { Integer.toString(slimServerPort) };
-      sys.createSlimService(slimArguments);
-    } finally {
-      slimSocket.close();
-    }
-  }
+//  @Test(expected = IOException.class)
+//  public void createSlimServiceFailsFastWhenSlimPortIsNotAvailable() throws Exception {
+//    final int slimServerPort = 10258;
+//    Descriptor descriptor = mock(Descriptor.class);
+//    ServerSocket slimSocket = SocketFactory.createServerSocket(slimServerPort);
+//    try {
+//      SlimClientBuilder sys = new SlimClientBuilder(descriptor);
+//      String[] slimArguments = new String[] { Integer.toString(slimServerPort) };
+//      sys.build(slimArguments);
+//    } finally {
+//      slimSocket.close();
+//    }
+//  }
 
   @Test
   public void slimDefaultTimeoutIs10Seconds() throws Exception {

--- a/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/SlimClientBuilderTest.java
@@ -95,20 +95,6 @@ public class SlimClientBuilderTest {
     assertEquals("somehost", new SlimClientBuilder(descriptor).determineSlimHost());
   }
 
-//  @Test(expected = IOException.class)
-//  public void createSlimServiceFailsFastWhenSlimPortIsNotAvailable() throws Exception {
-//    final int slimServerPort = 10258;
-//    Descriptor descriptor = mock(Descriptor.class);
-//    ServerSocket slimSocket = SocketFactory.createServerSocket(slimServerPort);
-//    try {
-//      SlimClientBuilder sys = new SlimClientBuilder(descriptor);
-//      String[] slimArguments = new String[] { Integer.toString(slimServerPort) };
-//      sys.build(slimArguments);
-//    } finally {
-//      slimSocket.close();
-//    }
-//  }
-
   @Test
   public void slimDefaultTimeoutIs10Seconds() throws Exception {
     Descriptor descriptor = mock(Descriptor.class);


### PR DESCRIPTION
This PR makes Slim work really in-process (with the `&debug` option or when executed from JUnit). Previously a socket was opened to communicate between FitNesse and the SUT, although they were running in the same process. The socket has been replaced by a `MockSocket`.