### PR TITLE
Ignore thirdparty JS libraries in SonarQube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.java.source=1.6
 sonar.sources=src
-sonar.exclusions=**/*.min.js,**/textinputs_jquery.js
+sonar.exclusions=**/*.min.js,**/textinputs_jquery.js,src/**/bootstrap.js,src/**/codemirror.js,src/**/jquery.tagsinput.js


### PR DESCRIPTION
Looking at the issues in SonarQube, the JavaScript ones make up a substantial part even though most of them come from third party libraries. I see that some have already been ignored, so I've taken the liberty of adding some more. I left the wysiwyg one alone though, since it seems to have been edited from the original and may be considered part of FitNesse.

By ignoring these JavaScript files, I hope it will be easier to get an overview over the issues. Hopefully it should be easier to get some useful information out of the "bubble diagram" on http://nemo.sonarqube.org/overview/debt?id=org.fitnesse%3Afitnesse which currently lump most of the Java-files in the bottom right corner.

Some (un)related questions:
1. I saw that JQuery was updatd recently. It looks like the various other JavaScript libraries have newer versions out as well, though I am not sure how frequently these are upgraded. (Most of the files contain the version number, so it is easy to tell, except codemirror where I was unable to figure out which version is included.) Are the other JS libraries something which will be looked into now that JQuery has been updated?

2. I assume there are some tests for the JavaScript parts, are these run as part of the ant build, or do they need to be run manually?