### PR TITLE
Make negative tests more readable

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/ScenarioLibrary/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/ScenarioLibrary/content.txt
@@ -4,6 +4,7 @@
 
 !|scenario|given page|page|
 |given page|@page|with content|nothing|
+|$CONTENT=|echo||
 
 !|scenario|given test page|page|
 |given page|@page|
@@ -100,3 +101,63 @@
 
 !|scenario|pass|
 |check|echo|pass|pass|
+
+!|scenario|show collapsed|content|
+|show|@content|
+
+|scenario| show Symbol  | result|
+#NO ACTION in this scenario
+# the symbol is printed in the call of the scenario
+
+!|scenario|then |pass | assertions pass, | fail| fail, | ignore| are ignored | exception | exceptions thrown|
+|ensure|content matches|Assertions:<[^<]*@pass right, @fail wrong, @ignore ignored, @exception exceptions|
+|show|extract match;|Assertions:<[^<]*exceptions|contents|0|
+
+!|scenario|and cell |text | has result | result|
+|ensure|content matches| class="@result">@text<|
+|show|extract match;| class="[^"]+">@text<|contents|0|
+
+!define TestSTART {@@@START: Test specific content} 
+!define TestEND {@@@END: Test specific content} 
+
+!|scenario |and TestSystem setup is|content                                       |
+|$CONTENT=|echo|$CONTENT!-
+-!@content|
+
+!|scenario |and setup content is|content                                       |
+|$CONTENT=|echo|$CONTENT!-
+-!@content|
+
+!|scenario |and test content is|content                                       |
+|given page|$IT           |with content|$CONTENT ${TestSTART}!-@content-!${TestEND}|
+|make      |$IT           |a test page                                   |
+
+!|scenario| get HTML result  |
+|start |Response Examiner.|
+|setType | contents|
+|setPattern |${TestSTART}[^<]*(.*>)\s*${TestEND}|
+|setGroup|1|
+|$HTML_Result= |found|
+
+|scenario| get HTML input  |
+|start |Response Examiner.|
+|setType | pageHtml|
+|setPattern |${TestSTART}[^<]*(.*>)\s*${TestEND}|
+|setGroup|1|
+|$HTML_Input= |found|
+|show collapsed| get value|
+
+
+!|scenario|get collapsed executon log for page|source|
+|check                |request page    |@source?executionLog|200                                     |
+|show |content|
+
+!|scenario|when page|source| is tested|
+|check|request page|@source?test|200|
+|show collapsed|content|
+
+!|scenario|when page|source| is tested and HTML is extracted|
+|when page|@source| is tested|
+|get HTML result| 
+|get HTML input |
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
@@ -4,12 +4,10 @@ See also: >TestPage.
 
 !| script                          |
 |given test page|${TestPageName}|
-|and Test System setup is|!define TEST_SYSTEM {slim}|
+|and Test System setup is|!define TEST_SYSTEM {slim}${SUT_PATH}|
 |and Setup content is|!-
 !|import|
 |fitnesse.slim.test|
-
-${SUT_PATH}
 
 !|Scenario|Stop Test|
 |start|ConstructorThrows|stop test|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
@@ -1,10 +1,11 @@
 See also: >TestPage.
 
-!| script |
-|given page|TestPage|with content|${SUT_PATH} !-
+!define TestPageName {Testpage}
 
-!define TEST_SYSTEM {slim}
-
+!| script                          |
+|given test page|${TestPageName}|
+|and Test System setup is|!define TEST_SYSTEM {slim}|
+|and Setup content is|!-
 !|import|
 |fitnesse.slim.test|
 
@@ -14,17 +15,20 @@ See also: >TestPage.
 !|Scenario|Not Executed|MESSAGE |
 |check|echo|@MESSAGE|cannot fail @MESSAGE|
 
+-!|
+|and Test content is                    |!-
 !|Script|
 |Stop Test|
 |Not Executed and should be ignored|
-
 !|Script|
 |Not Executed and should be ignored as well|
 -!|
-|test results for page|TestPage|should contain|Test not run|
-
-!|Response Examiner. |
-|type |pattern |matches?|
-|contents|class="ignore"\W+Test not run|true |
-|contents|class="pass">Not Executed |false |
-|contents|class="ignore">Not Executed |true |
+|when page|${TestPageName}| is tested and HTML is extracted|
+|then |\d | assertions pass, | 0| fail, | 0| are ignored | 1 | exceptions thrown|
+|and cell |Stop Test| has result | error|
+|and cell |Not Executed and should be ignored | has result | ignore|
+|and cell |Not Executed and should be ignored as well| has result | ignore|
+|and cell |Test not run | has result | ignore|
+|show Symbol |$HTML_Input|
+|show Symbol |$HTML_Result|
+|get collapsed executon log for page|${TestPageName}|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/IgnoredTestsShouldColorGray/content.txt
@@ -9,6 +9,8 @@ See also: >TestPage.
 !|import|
 |fitnesse.slim.test|
 
+${SUT_PATH}
+
 !|Scenario|Stop Test|
 |start|ConstructorThrows|stop test|
 

--- a/src/fitnesse/fixtures/PageDriver.java
+++ b/src/fitnesse/fixtures/PageDriver.java
@@ -125,6 +125,12 @@ public class PageDriver {
     return examiner.matches();
   }
 
+  public String extractMatch(String pattern, String type, int group) throws Exception {
+    examiner.type = type;
+    examiner.pattern = pattern;
+    return examiner.found(group);
+  }
+
   public boolean contentContains(String subString) throws Exception {
     examiner.type = "contents";
     examiner.extractValueFromResponse();

--- a/src/fitnesse/fixtures/ResponseExaminer.java
+++ b/src/fitnesse/fixtures/ResponseExaminer.java
@@ -17,7 +17,8 @@ public class ResponseExaminer extends ColumnFixture {
   public int number;
   private Matcher matcher;
   private int currentLine = 0;
-    private int currentPosition = 0;
+  private int currentPosition = 0;
+  private int group =0;
 
   // Content is escaped, since it's used by both FIT and SLiM.
   public String contents() throws Exception {
@@ -74,12 +75,24 @@ public class ResponseExaminer extends ColumnFixture {
     return matches;
   }
 
+
+
   public void extractValueFromResponse() throws Exception {
     setValue(null);
     if (type.equals("contents"))
       setValue(HtmlUtil.unescapeHTML(FitnesseFixtureContext.sender.sentData()));
     else if (type.equals("fullContents"))
       setValue(fullContents());
+    else if (type.equals("rawContents"))
+      setValue(FitnesseFixtureContext.sender.sentData());
+    else if (type.equals("stringContents"))
+      setValue(FitnesseFixtureContext.sender.toString());
+    else if (type.equals("pageContents"))
+      setValue(FitnesseFixtureContext.page.toString());
+    else if (type.equals("pageHtml"))
+      setValue(FitnesseFixtureContext.page.getHtml());
+    else if (type.equals("matchers"))
+      setValue(matcher.group(group));
     else if (type.equals("status"))
       setValue("" + FitnesseFixtureContext.response.getStatus());
     else if (type.equals("headers")) {
@@ -126,8 +139,20 @@ public class ResponseExaminer extends ColumnFixture {
     return lineizedContent;
   }
 
-  public String found() {
-    return matcher.group(0);
+  public String found() throws Exception {
+    return found(this.group);
+  }
+  
+  public String found(int group) throws Exception {
+    Pattern p = Pattern.compile(pattern, Pattern.MULTILINE + Pattern.DOTALL);
+    extractValueFromResponse();
+
+    matcher = p.matcher(getValue());
+   return matcher.find() ?  matcher.group(group) : null; 
+  }
+
+  public Matcher matcher(){ 
+   return matcher; 
   }
 
   public String source() {
@@ -154,6 +179,10 @@ public class ResponseExaminer extends ColumnFixture {
 
   public void setNumber(int number) {
     this.number = number;
+  }
+
+  public void setGroup(int number) {
+    this.group = number;
   }
 
   public String getValue() {


### PR DESCRIPTION
As a FitNesse developer
To test and see the behaviour of FitNesse with negative tests 
I run FitNesse in a sub instance 
and I need an easy way to see if the test did what I expected.

Added a scenario to extract the result of a single cell
Added a scenario to extract and match the result summary  
Added a scenario to show the result and input of a negativ test case in
HTML format
Added helper scenarios to hide the setup of the sub instance