### PR TITLE
Resetting min. Java version needed to 1.7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 
     <property environment="env"/>
     <property name="env.FITNESSE_TEST_PORT" value="8080"/>
-    <property name="min.java.version" value="1.8"/>
+    <property name="min.java.version" value="1.7"/>
     <property name="src.dir" location="src"/>
     <property name="test.src.dir" location="test"/>
     <property name="classes.dir" location="classes"/>


### PR DESCRIPTION
Many of our enteprise projects are still using Java 7 (and even Java 6). Upgrades to java 8 are planned but not in the near future as they are related to major changes in our runtime and application stacks.
That´s why we would appreciate to postpone the upgrade of FitNesse to Java 8 as it would push us either to stick to the december release or to fork FitNesse. We think that both ways are not necessary and not wished.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/unclebob/fitnesse/877)
<!-- Reviewable:end -->
