### PR TITLE
Break cycles created by Symlinks.

### DIFF
--- a/src/fitnesse/wiki/PageCrawlerImpl.java
+++ b/src/fitnesse/wiki/PageCrawlerImpl.java
@@ -126,8 +126,6 @@ public class PageCrawlerImpl implements PageCrawler {
   }
 
   private void traverse(WikiPage page, TraversalListener<? super WikiPage> listener) {
-    if (page.getClass() == SymbolicPage.class)
-      return;
     listener.process(page);
     for (WikiPage wikiPage : page.getChildren()) {
       traverse(wikiPage, listener);

--- a/src/fitnesse/wiki/SymbolicPage.java
+++ b/src/fitnesse/wiki/SymbolicPage.java
@@ -12,13 +12,13 @@ import fitnesse.wikitext.parser.Symbol;
 public class SymbolicPage extends BaseWikitextPage {
 
   public static final String PROPERTY_NAME = "SymbolicLinks";
+  public static final String SHORT_CIRCUIT_BREAK_MESSAGE = "Short circuit! This page references %s, which is already one of the parent pages of this page.";
 
   private final WikiPage realPage;
 
   public SymbolicPage(String name, WikiPage realPage, WikiPage parent) {
     super(name, parent);
     this.realPage = realPage;
-    // Perform a cyclic dependency check
   }
 
   public WikiPage getRealPage() {
@@ -43,9 +43,8 @@ public class SymbolicPage extends BaseWikitextPage {
   public WikiPage getChildPage(String name) {
     WikiPage childPage = realPage.getChildPage(name);
     if (childPage != null) {
-      childPage = new SymbolicPage(name, childPage, this);
+      childPage = createChildPage(childPage);
     }
-
     return childPage;
   }
 
@@ -58,11 +57,28 @@ public class SymbolicPage extends BaseWikitextPage {
   public List<WikiPage> getChildren() {
     List<WikiPage> children = realPage.getChildren();
     List<WikiPage> symChildren = new LinkedList<WikiPage>();
-    //TODO: -AcD- we need a better cyclic infinite recursion algorithm here.
     for (WikiPage child : children) {
-      symChildren.add(new SymbolicPage(child.getName(), child, this));
+      symChildren.add(createChildPage(child));
     }
     return symChildren;
+  }
+
+  private WikiPage createChildPage(WikiPage child) {
+    WikiPage cyclicReference = findCyclicReference(child);
+    if (cyclicReference != null) {
+      return new WikiPageDummy(child.getName(), String.format(SHORT_CIRCUIT_BREAK_MESSAGE, cyclicReference.getPageCrawler().getFullPath().toString()), this);
+    } else {
+      return new SymbolicPage(child.getName(), child, this);
+    }
+  }
+
+  private WikiPage findCyclicReference(WikiPage childPage) {
+    for (WikiPage parentPage = getParent(); !parentPage.isRoot(); parentPage = parentPage.getParent()) {
+      if (childPage.equals(parentPage)) {
+        return parentPage;
+      }
+    }
+    return null;
   }
 
   @Override
@@ -116,6 +132,17 @@ public class SymbolicPage extends BaseWikitextPage {
       return super.getSyntaxTree();
     }
     return Symbol.emptySymbol;
+  }
+
+  @Override
+  @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+  public boolean equals(Object other) {
+    return realPage.equals(other);
+  }
+
+  @Override
+  public int hashCode() {
+    return realPage.hashCode();
   }
 
   public static boolean containsWikitext(WikiPage wikiPage) {

--- a/src/fitnesse/wiki/WikiPageDummy.java
+++ b/src/fitnesse/wiki/WikiPageDummy.java
@@ -42,7 +42,7 @@ public class WikiPageDummy extends BaseWikiPage {
 
   @Override
   public List<WikiPage> getChildren() {
-    return new ArrayList<WikiPage>();
+    return new ArrayList<>();
   }
 
   @Override
@@ -52,7 +52,7 @@ public class WikiPageDummy extends BaseWikiPage {
 
   @Override
   public String getHtml() {
-    return "";
+    return String.format("<em>%s</em>", pageData.getContent());
   }
 
   @Override

--- a/test/fitnesse/wiki/PageCrawlerTest.java
+++ b/test/fitnesse/wiki/PageCrawlerTest.java
@@ -156,21 +156,30 @@ public class PageCrawlerTest implements TraversalListener<WikiPage> {
     assertTrue(traversedPages.contains("ChildOne"));
   }
 
-  @Override
-  public void process(WikiPage page) {
-    traversedPages.add(page.getName());
-  }
-
   @Test
-  public void testdoesntTraverseSymbolicPages() throws Exception {
+  public void doesTraverseSymbolicPages() throws Exception {
     PageData data = page1.getData();
-    data.getProperties().set(SymbolicPage.PROPERTY_NAME).set("SymLink", "PageTwo");
+    data.getProperties().set(SymbolicPage.PROPERTY_NAME).set("SymLink", page2.getName());
     page1.commit(data);
 
     crawler.traverse(this);
-    assertEquals(6, traversedPages.size());
+    assertEquals(7, traversedPages.size());
 
-    assertFalse(traversedPages.contains("SymLink"));
+    assertTrue(traversedPages.contains("SymLink"));
+  }
+
+  @Test
+  public void doesNotTraverseCyclicPageReferences() {
+    PageData data = child1.getData();
+    data.getProperties().set(SymbolicPage.PROPERTY_NAME).set("SymLink", "." + page1.getName());
+    child1.commit(data);
+
+    crawler = new PageCrawlerImpl(page1);
+    crawler.traverse(this);
+
+    assertEquals(traversedPages.toString(), 5, traversedPages.size());
+
+    assertTrue(traversedPages.contains("SymLink"));
   }
 
   @Test
@@ -189,5 +198,10 @@ public class PageCrawlerTest implements TraversalListener<WikiPage> {
     assertTrue(uncles.contains(unclePage));
     assertTrue(uncles.contains(brotherPage));
 
+  }
+
+  @Override
+  public void process(WikiPage page) {
+    traversedPages.add(page.getName());
   }
 }


### PR DESCRIPTION
Previously, the PageCrawler refused to traverse symlinks. This caused some odd behaviour (see #488).

I changed the logic in a sense that there is some cycle detection and the user is informed if pages a (sym)linked in such a way that a cycle (infinite loop) of pages exists.

Fixes #488