### PR TITLE
Disallow uploading to files/fitnesse.

### DIFF
--- a/FitNesseRoot/files/fitnesse/README.txt
+++ b/FitNesseRoot/files/fitnesse/README.txt
@@ -1,6 +1,9 @@
-This section will contain the resources.
+This section will contain custom resources (css, templates).
 
-Users can override files in files/fitnesse or add their own (e.g. a custom
+NOTE: You can not upload files to files/fitnesse via FitNesse. Instead add
+files directly.
+
+You can override files in files/fitnesse or add your own (e.g. a custom
 theme). Both the render engine (Velocity) and the FileResponder check
 files/fitnesse and the fitnesse.resources package when looking for a particular
 file.

--- a/src/fitnesse/responders/files/FileResponder.java
+++ b/src/fitnesse/responders/files/FileResponder.java
@@ -166,6 +166,11 @@ public class FileResponder implements SecureResponder {
             file.getCanonicalFile());
   }
 
+  public static boolean isInFilesFitNesseDirectory(File rootPath, File file) throws IOException {
+    return isInSubDirectory(new File(new File(rootPath, "files"), "fitnesse").getCanonicalFile(),
+            file.getCanonicalFile());
+  }
+
   private static boolean isInSubDirectory(File dir, File file) {
     return file != null && (file.equals(dir) || isInSubDirectory(dir, file.getParentFile()));
   }

--- a/src/fitnesse/responders/files/UploadResponder.java
+++ b/src/fitnesse/responders/files/UploadResponder.java
@@ -45,6 +45,9 @@ public class UploadResponder implements SecureResponder {
       if (!FileResponder.isInFilesDirectory(new File(rootPath), file)) {
         return new ErrorResponder("Invalid path: " + uploadedFile.getName()).makeResponse(context, request);
       }
+      if (FileResponder.isInFilesFitNesseDirectory(new File(rootPath), file)) {
+        return new ErrorResponder("It is not allowed to upload files in the files/fitnesse section.").makeResponse(context, request);
+      }
 
       context.versionsController.makeVersion(new FileVersion() {
 

--- a/test/fitnesse/responders/files/UploadResponderTest.java
+++ b/test/fitnesse/responders/files/UploadResponderTest.java
@@ -139,4 +139,14 @@ public class UploadResponderTest {
   }
 
 
+  @Test
+  public void canNotUploadInFilesFitNesseFolder() throws Exception {
+    request.addUploadedFile("file", new UploadedFile("sourceFilename.txt", "plain/text", testFile));
+    request.setResource("files/fitnesse/");
+
+    SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+    assertTrue("Not the correct error message", response.getContent().contains("It is not allowed to upload files in the files/fitnesse section."));
+  }
+
 }


### PR DESCRIPTION
You can possibly upload css, javascript and page templates to that location and those resources are used for page creation. By not allowing upload to `files/fitnesse`, there is less change of abuse.

Fixes #702