### PR TITLE
Change json content type from text/json to applicatioin/json

### DIFF
--- a/src/fitnesse/http/Response.java
+++ b/src/fitnesse/http/Response.java
@@ -18,7 +18,7 @@ public abstract class Response {
     XML("text/xml"),
     HTML("text/html; charset=" + FileUtil.CHARENCODING),
     TEXT("text/text"),
-    JSON("text/json"),
+    JSON("application/json"),
     JUNIT("text/junit");
     
     private final String contentType;


### PR DESCRIPTION
At this moment all json data has incorrect content type, text/json. 
The MIME media type for JSON text is application/json. Source: http://www.ietf.org/rfc/rfc4627.txt