### PR TITLE
Warnings

### DIFF
--- a/src/fit/SummaryFixture.java
+++ b/src/fit/SummaryFixture.java
@@ -22,10 +22,10 @@ public class SummaryFixture extends Fixture {
 
   protected Parse rows(Iterator<String> keys) {
     if (keys.hasNext()) {
-      Object key = keys.next();
+      String key = keys.next();
       Parse result =
         tr(
-          td(key.toString(),
+          td(key,
             td(summary.get(key).toString(),
               null)),
           rows(keys));

--- a/src/fit/decorator/FixtureDecorator.java
+++ b/src/fit/decorator/FixtureDecorator.java
@@ -72,7 +72,7 @@ public abstract class FixtureDecorator extends Fixture {
       columnValue = escapeExpectedAndActualString(columnValue);
       argumentList.add(columnValue);
     }
-    args = (String[]) argumentList.toArray(new String[argumentList.size()]);
+    args = argumentList.toArray(new String[argumentList.size()]);
   }
 
   private String escapeExpectedAndActualString(String columnValue) {

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -93,6 +93,7 @@ public class FitNesse {
       namePrefix = "server-thread-";
     }
 
+    @Override
     public Thread newThread(Runnable r) {
       Thread t = new Thread(group, r,
               namePrefix + threadNumber.getAndIncrement(),

--- a/src/fitnesse/html/HtmlTag.java
+++ b/src/fitnesse/html/HtmlTag.java
@@ -162,7 +162,7 @@ public class HtmlTag extends HtmlElement implements Iterable<HtmlElement> {
     }
 
     private String makeChildFromTag(HtmlTag element) {
-      return (childShouldStartWithNewLine() ? endl : "") + ((HtmlTag) element).html(depth + 1);
+      return (childShouldStartWithNewLine() ? endl : "") + element.html(depth + 1);
     }
 
     private boolean childShouldStartWithNewLine() {

--- a/src/fitnesse/responders/ErrorResponder.java
+++ b/src/fitnesse/responders/ErrorResponder.java
@@ -45,12 +45,14 @@ public class ErrorResponder implements Responder {
   }
 
   public static String makeExceptionString(Throwable e) {
-    StringBuilder buffer = new StringBuilder();
-    buffer.append(e.toString()).append("\n");
+    StringBuilder builder = new StringBuilder();
+    builder.append(e.toString()).append("\n");
     for (StackTraceElement stackTraceElement : e.getStackTrace()) {
-      buffer.append("\t" + stackTraceElement).append("\n");
+      builder.append("\t")
+              .append(stackTraceElement)
+              .append("\n");
     }
 
-    return buffer.toString();
+    return builder.toString();
   }
 }

--- a/src/fitnesse/responders/NameWikiPageResponder.java
+++ b/src/fitnesse/responders/NameWikiPageResponder.java
@@ -22,7 +22,7 @@ public class NameWikiPageResponder extends BasicResponder {
   protected String contentFrom(FitNesseContext context, Request request, WikiPage requestedPage) {
     List<String> lines = addLines(request, requestedPage, "");
 
-    String format = (String) request.getInput("format");
+    String format = request.getInput("format");
     if ("json".equalsIgnoreCase(format)) {
       JSONArray jsonPages = new JSONArray(lines);
       return jsonPages.toString();

--- a/src/fitnesse/responders/PacketResponder.java
+++ b/src/fitnesse/responders/PacketResponder.java
@@ -31,7 +31,7 @@ public class PacketResponder implements SecureResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) {
     response = new SimpleResponse();
-    jsonpFunction = (String) request.getInput("jsonp");
+    jsonpFunction = request.getInput("jsonp");
     String pageName = request.getResource();
     PageCrawler pageCrawler = context.getRootPage().getPageCrawler();
     WikiPagePath resourcePath = PathParser.parse(pageName);

--- a/src/fitnesse/responders/ResponderFactory.java
+++ b/src/fitnesse/responders/ResponderFactory.java
@@ -123,7 +123,7 @@ public class ResponderFactory {
   public String getResponderKey(Request request) {
     String fullQuery;
     if (request.hasInput("responder"))
-      fullQuery = (String) request.getInput("responder");
+      fullQuery = request.getInput("responder");
     else
       fullQuery = request.getQueryString();
 

--- a/src/fitnesse/responders/WikiImportingResponder.java
+++ b/src/fitnesse/responders/WikiImportingResponder.java
@@ -49,7 +49,7 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
   }
 
   public WikiImportingTraverser initializeImporter() throws Exception {
-    String remoteUrl = (String) request.getInput("remoteUrl");
+    String remoteUrl = request.getInput("remoteUrl");
     setRemoteUserCredentialsOnImporter(importer);
     importer.setAutoUpdateSetting(request.hasInput("autoUpdate"));
     return new WikiImportingTraverser(importer, page, remoteUrl);
@@ -57,9 +57,9 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
 
   private void setRemoteUserCredentialsOnImporter(WikiImporter importer) {
     if (request.hasInput("remoteUsername"))
-      importer.setRemoteUsername((String) request.getInput("remoteUsername"));
+      importer.setRemoteUsername(request.getInput("remoteUsername"));
     if (request.hasInput("remotePassword"))
-      importer.setRemotePassword((String) request.getInput("remotePassword"));
+      importer.setRemotePassword(request.getInput("remotePassword"));
   }
 
   private HtmlPage makeHtml() throws Exception {

--- a/src/fitnesse/responders/editing/AddChildPageResponder.java
+++ b/src/fitnesse/responders/editing/AddChildPageResponder.java
@@ -43,20 +43,20 @@ public class AddChildPageResponder implements SecureResponder {
 
   private void parseRequest(FitNesseContext context, Request request) {
 	  user = request.getAuthorizationUsername();
-    childName = (String) request.getInput(EditResponder.PAGE_NAME);
+    childName = request.getInput(EditResponder.PAGE_NAME);
     childName = childName == null ? "null" : childName;
     childPath = PathParser.parse(childName);
     WikiPagePath currentPagePath = PathParser.parse(request.getResource());
     PageCrawler pageCrawler = context.getRootPage().getPageCrawler();
     currentPage = pageCrawler.getPage(currentPagePath);
     if (request.hasInput(NewPageResponder.PAGE_TEMPLATE)) {
-      pageTemplate = pageCrawler.getPage(PathParser.parse((String) request.getInput(NewPageResponder.PAGE_TEMPLATE)));
+      pageTemplate = pageCrawler.getPage(PathParser.parse(request.getInput(NewPageResponder.PAGE_TEMPLATE)));
     } else {
-      pageType = (String) request.getInput(EditResponder.PAGE_TYPE);
+      pageType = request.getInput(EditResponder.PAGE_TYPE);
     }
-    childContent = (String) request.getInput(EditResponder.CONTENT_INPUT_NAME);
-    helpText = (String) request.getInput(EditResponder.HELP_TEXT);
-    suites = (String) request.getInput(EditResponder.SUITES);
+    childContent = request.getInput(EditResponder.CONTENT_INPUT_NAME);
+    helpText = request.getInput(EditResponder.HELP_TEXT);
+    suites = request.getInput(EditResponder.SUITES);
     if (childContent == null)
       childContent = "!contents\n";
     if (pageTemplate == null && pageType == null)

--- a/src/fitnesse/responders/editing/ContentFilterResponder.java
+++ b/src/fitnesse/responders/editing/ContentFilterResponder.java
@@ -20,7 +20,7 @@ public class ContentFilterResponder implements Responder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     String resource = request.getResource();
-    String content = (String) request.getInput(EditResponder.CONTENT_INPUT_NAME);
+    String content = request.getInput(EditResponder.CONTENT_INPUT_NAME);
 
     if (!contentFilter.isContentAcceptable(content, resource))
       return makeBannedContentResponse(context, resource);

--- a/src/fitnesse/responders/editing/MergeResponder.java
+++ b/src/fitnesse/responders/editing/MergeResponder.java
@@ -35,7 +35,7 @@ public class MergeResponder implements Responder {
     WikiPagePath path = PathParser.parse(resource);
     WikiPage page = context.getRootPage().getPageCrawler().getPage(path);
     existingContent = page.getData().getContent();
-    newContent = (String) this.request.getInput(EditResponder.CONTENT_INPUT_NAME);
+    newContent = this.request.getInput(EditResponder.CONTENT_INPUT_NAME);
 
     response.setContent(makePageHtml(context));
 

--- a/src/fitnesse/responders/editing/NewPageResponder.java
+++ b/src/fitnesse/responders/editing/NewPageResponder.java
@@ -54,13 +54,13 @@ public class NewPageResponder implements Responder {
     html.put(EditResponder.TEMPLATE_MAP, TemplateUtil.getTemplateMap(parentWikiPage));
     if (request.hasInput(PAGE_TEMPLATE)) {
       PageCrawler crawler = context.getRootPage().getPageCrawler();
-      String pageTemplate = (String) request.getInput(PAGE_TEMPLATE);
+      String pageTemplate = request.getInput(PAGE_TEMPLATE);
       WikiPage template = crawler.getPage(PathParser.parse(pageTemplate));
       html.put(EditResponder.CONTENT_INPUT_NAME, template.getData().getContent());
       html.put(EditResponder.PAGE_TYPE, PageType.fromWikiPage(template));
       html.put(PAGE_TEMPLATE, pageTemplate);
     } else if (request.hasInput(PAGE_TYPE)) {
-      String pageType = (String) request.getInput(PAGE_TYPE);
+      String pageType = request.getInput(PAGE_TYPE);
       // Validate page type:
       PageType.fromString(pageType);
       html.put(EditResponder.PAGE_TYPE, pageType);

--- a/src/fitnesse/responders/editing/SavePropertiesResponder.java
+++ b/src/fitnesse/responders/editing/SavePropertiesResponder.java
@@ -53,10 +53,10 @@ public class SavePropertiesResponder implements SecureResponder {
         data.removeAttribute(attribute);
     }
 
-    String suites = (String) request.getInput("Suites");
+    String suites = request.getInput("Suites");
     data.setOrRemoveAttribute(PageData.PropertySUITES, suites);
 
-    String helpText = (String) request.getInput("HelpText");
+    String helpText = request.getInput("HelpText");
     data.setOrRemoveAttribute(PageData.PropertyHELP, helpText);
   }
 
@@ -77,7 +77,7 @@ public class SavePropertiesResponder implements SecureResponder {
   }
 
   private String getPageType(Request request) {
-    return (String) request.getInput(PageData.PAGE_TYPE_ATTRIBUTE);
+    return request.getInput(PageData.PAGE_TYPE_ATTRIBUTE);
   }
 
   private boolean isChecked(Request request, String name) {

--- a/src/fitnesse/responders/editing/SaveResponder.java
+++ b/src/fitnesse/responders/editing/SaveResponder.java
@@ -67,14 +67,14 @@ public class SaveResponder implements SecureResponder {
   private long getTicketId(Request request) {
     if (!request.hasInput(EditResponder.TICKET_ID))
       return 0;
-    String ticketIdString = (String) request.getInput(EditResponder.TICKET_ID);
+    String ticketIdString = request.getInput(EditResponder.TICKET_ID);
     return Long.parseLong(ticketIdString);
   }
 
   private long getEditTime(Request request) {
     if (!request.hasInput(EditResponder.TIME_STAMP))
       return 0;
-    String editTimeStampString = (String) request.getInput(EditResponder.TIME_STAMP);
+    String editTimeStampString = request.getInput(EditResponder.TIME_STAMP);
     return Long.parseLong(editTimeStampString);
   }
 

--- a/src/fitnesse/responders/editing/SymbolicLinkResponder.java
+++ b/src/fitnesse/responders/editing/SymbolicLinkResponder.java
@@ -68,7 +68,7 @@ public class SymbolicLinkResponder implements Responder {
   }
 
   private void removeSymbolicLink(Request request, WikiPage page) {
-    String linkToRemove = (String) request.getInput("removal");
+    String linkToRemove = request.getInput("removal");
 
     PageData data = page.getData();
     WikiPageProperties properties = data.getProperties();
@@ -81,8 +81,8 @@ public class SymbolicLinkResponder implements Responder {
   }
 
   private void  renameSymbolicLink(Request request, WikiPage page) {
-    String linkToRename = (String) request.getInput("rename"),
-    newName = (String) request.getInput("newname");
+    String linkToRename = request.getInput("rename"),
+    newName = request.getInput("newname");
 
     PageData data = page.getData();
     WikiPageProperties properties = data.getProperties();
@@ -98,8 +98,8 @@ public class SymbolicLinkResponder implements Responder {
   }
 
   private void addSymbolicLink(Request request, WikiPage page) throws IOException {
-    String linkName = StringUtils.trim((String) request.getInput("linkName"));
-    String linkPath = StringUtils.trim((String) request.getInput("linkPath"));
+    String linkName = StringUtils.trim(request.getInput("linkName"));
+    String linkPath = StringUtils.trim(request.getInput("linkPath"));
 
     PageData data = page.getData();
     WikiPageProperties properties = data.getProperties();

--- a/src/fitnesse/responders/files/CreateDirectoryResponder.java
+++ b/src/fitnesse/responders/files/CreateDirectoryResponder.java
@@ -23,7 +23,7 @@ public class CreateDirectoryResponder implements SecureResponder {
     SimpleResponse response = new SimpleResponse();
 
     String resource = request.getResource();
-    String dirname = (String) request.getInput("dirname");
+    String dirname = request.getInput("dirname");
     final File file = new File(new File(context.getRootPagePath(), resource), dirname);
 
     if (!FileResponder.isInFilesDirectory(new File(context.getRootPagePath()), file)) {

--- a/src/fitnesse/responders/files/DeleteConfirmationResponder.java
+++ b/src/fitnesse/responders/files/DeleteConfirmationResponder.java
@@ -21,7 +21,7 @@ public class DeleteConfirmationResponder implements SecureResponder {
   public Response makeResponse(FitNesseContext context, Request request) {
     SimpleResponse response = new SimpleResponse();
     resource = request.getResource();
-    String filename = (String) request.getInput("filename");
+    String filename = request.getInput("filename");
     response.setContent(makeDirectoryListingPage(resource, filename, context));
     return response;
   }

--- a/src/fitnesse/responders/files/DeleteFileResponder.java
+++ b/src/fitnesse/responders/files/DeleteFileResponder.java
@@ -24,7 +24,7 @@ public class DeleteFileResponder implements SecureResponder {
   public Response makeResponse(FitNesseContext context, final Request request) throws IOException {
     Response response = new SimpleResponse();
     resource = request.getResource();
-    String filename = (String) request.getInput("filename");
+    String filename = request.getInput("filename");
 
     final File pathName = new File(new File(context.getRootPagePath(), resource), filename);
 

--- a/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
+++ b/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
@@ -17,7 +17,7 @@ public class RenameFileConfirmationResponder implements SecureResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) {
     String resource = request.getResource();
-    String filename = (String) request.getInput("filename");
+    String filename = request.getInput("filename");
     
     HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Rename " + filename);

--- a/src/fitnesse/responders/files/RenameFileResponder.java
+++ b/src/fitnesse/responders/files/RenameFileResponder.java
@@ -30,8 +30,8 @@ public class RenameFileResponder implements SecureResponder {
       return new ErrorResponder("Invalid path: " + resource).makeResponse(context, request);
     }
 
-    final String oldFileName = (String) request.getInput("filename");
-    final String newFileName = ((String) request.getInput("newName")).trim();
+    final String oldFileName = request.getInput("filename");
+    final String newFileName = request.getInput("newName").trim();
 
     final File oldFile = new File(pathName, oldFileName);
     final File newFile = new File(pathName, newFileName);

--- a/src/fitnesse/responders/refactoring/RenamePageResponder.java
+++ b/src/fitnesse/responders/refactoring/RenamePageResponder.java
@@ -21,7 +21,7 @@ public class RenamePageResponder extends PageMovementResponder {
 
   @Override
   protected boolean getAndValidateRefactoringParameters(Request request) {
-    newName = (String) request.getInput("newName");
+    newName = request.getInput("newName");
     return (newName != null && PathParser.isSingleWikiWord(newName) && !"FrontPage".equals(oldNameOfPageToBeMoved));
   }
 

--- a/src/fitnesse/responders/search/ResultResponder.java
+++ b/src/fitnesse/responders/search/ResultResponder.java
@@ -41,7 +41,7 @@ public abstract class ResultResponder extends ChunkingResponder implements
   }
 
   protected WikiPage getSearchScope() {
-    String searchScope = (String) request.getInput("searchScope");
+    String searchScope = request.getInput("searchScope");
 
     if (searchScope == null || searchScope.isEmpty())
       return page;

--- a/src/fitnesse/responders/versions/RollbackResponder.java
+++ b/src/fitnesse/responders/versions/RollbackResponder.java
@@ -21,7 +21,7 @@ public class RollbackResponder implements SecureResponder {
     SimpleResponse response = new SimpleResponse();
 
     String resource = request.getResource();
-    String version = (String) request.getInput("version");
+    String version = request.getInput("version");
     if (version == null)
       return new ErrorResponder("Missing version.").makeResponse(context, request);
 

--- a/src/fitnesse/testrunner/WikiTestPage.java
+++ b/src/fitnesse/testrunner/WikiTestPage.java
@@ -13,7 +13,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.SymbolicPage;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
-import fitnesse.wiki.WikitextPage;
 import fitnesse.wikitext.parser.HtmlTranslator;
 import fitnesse.wikitext.parser.Parser;
 import fitnesse.wikitext.parser.ParsingPage;

--- a/src/fitnesse/testsystems/ClientBuilder.java
+++ b/src/fitnesse/testsystems/ClientBuilder.java
@@ -3,7 +3,6 @@ package fitnesse.testsystems;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;

--- a/src/fitnesse/testsystems/slim/InProcessSlimClient.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClient.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import fitnesse.slim.SlimError;
 import fitnesse.slim.SlimServer;
 import fitnesse.slim.SlimStreamReader;
 import fitnesse.slim.SlimVersion;

--- a/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
@@ -16,6 +16,7 @@ public class InProcessSlimClientBuilder extends ClientBuilder<SlimClient> {
     super(descriptor);
   }
 
+  @Override
   public SlimClient build() throws IOException {
     SlimServer slimServer = createSlimServer(1000, isDebug());
     return new InProcessSlimClient(getTestSystemName(), slimServer, getExecutionLogListener());

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -11,7 +11,6 @@ import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import fitnesse.slim.SlimError;
 import fitnesse.slim.instructions.AssignInstruction;
 import fitnesse.slim.instructions.Instruction;
 import fitnesse.testsystems.Assertion;

--- a/src/fitnesse/wiki/UrlPathVariableSource.java
+++ b/src/fitnesse/wiki/UrlPathVariableSource.java
@@ -25,7 +25,7 @@ public class UrlPathVariableSource implements VariableSource {
 
   public Maybe<String> findUrlVariable(String name) {
     if(urlParams != null && urlParams.containsKey(name)) {
-      return new Maybe<String>((String)urlParams.get(name));
+      return new Maybe<String>(urlParams.get(name));
     }
 
     return Maybe.noString;

--- a/test/fitnesse/http/RequestTest.java
+++ b/test/fitnesse/http/RequestTest.java
@@ -264,7 +264,7 @@ public class RequestTest {
     parseMessage();
 
     String expected = buffer.toString();
-    String actual = (String)request.getInput("content");
+    String actual = request.getInput("content");
     assertEquals(expected.length(), actual.length());
     assertEquals(expected, actual);
   }

--- a/test/fitnesse/plugins/slimcoverage/SlimCoverageTestContextImpl.java
+++ b/test/fitnesse/plugins/slimcoverage/SlimCoverageTestContextImpl.java
@@ -23,6 +23,7 @@ public class SlimCoverageTestContextImpl extends SlimTestContextImpl {
     super.addScenario(scenarioName, scenarioTable);
   }
 
+  @Override
   public ScenarioTable getScenario(String scenarioName) {
     ScenarioTable scenarioTable = super.getScenario(scenarioName);
     if (usage != null && scenarioTable != null) {

--- a/test/fitnesse/responders/editing/MergeResponderTest.java
+++ b/test/fitnesse/responders/editing/MergeResponderTest.java
@@ -17,13 +17,12 @@ import org.junit.Test;
 
 public class MergeResponderTest {
   private FitNesseContext context;
-  private WikiPage source;
   private MockRequest request;
 
   @Before
   public void setUp() throws Exception {
     context = FitNesseUtil.makeTestContext();
-    source = context.getRootPage();
+    WikiPage source = context.getRootPage();
     WikiPageUtil.addPage(source, PathParser.parse("SimplePage"), "this is SimplePage");
     request = new MockRequest();
     request.setResource("SimplePage");

--- a/test/fitnesse/responders/run/slimResponder/SlimResponder.java
+++ b/test/fitnesse/responders/run/slimResponder/SlimResponder.java
@@ -18,7 +18,6 @@ import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.*;
 import fitnesse.testsystems.slim.SlimTestSystem;
 import fitnesse.wiki.PageCrawler;
-import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;

--- a/test/fitnesse/responders/versions/RollbackResponderTest.java
+++ b/test/fitnesse/responders/versions/RollbackResponderTest.java
@@ -19,13 +19,11 @@ import fitnesse.wiki.WikiPageUtil;
 import org.junit.Test;
 
 public class RollbackResponderTest {
-  private WikiPage page;
-  private Response response;
 
   @Test
   public void testStuff() throws Exception {
     FitNesseContext context = FitNesseUtil.makeTestContext();
-    page = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("PageOne"), "original content");
+    WikiPage page = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("PageOne"), "original content");
     PageData data = page.getData();
     data.setContent("new stuff");
     data.setProperties(new WikiPageProperties());
@@ -37,7 +35,7 @@ public class RollbackResponderTest {
     request.addInput("version", commitRecord.getName());
 
     Responder responder = new RollbackResponder();
-    response = responder.makeResponse(context, request);
+    Response response = responder.makeResponse(context, request);
 
     assertEquals(303, response.getStatus());
     assertEquals("/PageOne", response.getHeader("Location"));

--- a/test/fitnesse/responders/versions/VersionSelectionResponderTest.java
+++ b/test/fitnesse/responders/versions/VersionSelectionResponderTest.java
@@ -19,13 +19,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class VersionSelectionResponderTest {
-  private WikiPage page;
   private FitNesseContext context;
 
   @Before
   public void setUp() throws Exception {
     context = FitNesseUtil.makeTestContext();
-    page = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("PageOne"), "some content");
+    WikiPage page = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("PageOne"), "some content");
     PageData data = page.getData();
     WikiPageProperties properties = data.getProperties();
     properties.set(PageData.PropertySUITES, "Page One tags");

--- a/test/fitnesse/slim/SlimMethodInvocationTestBase.java
+++ b/test/fitnesse/slim/SlimMethodInvocationTestBase.java
@@ -99,7 +99,8 @@ public abstract class SlimMethodInvocationTestBase {
   @Test
   public void passOneDate() throws Exception {
     caller.call("testSlim", "oneDate", "5-May-2009");
-    assertEquals((Date) new DateConverter().fromString("5-May-2009"), testSlim.getDateArg());
+    Date expected = new DateConverter().fromString("5-May-2009");
+    assertEquals(expected, testSlim.getDateArg());
   }
 
   @Test

--- a/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
+++ b/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
@@ -26,17 +26,16 @@ public class MultipleTestsRunnerTest {
   private FitNesseContext context;
 
   private TestSystemFactory testSystemFactory;
-  private TestSystem testSystem;
 
   @Before
   public void setUp() throws Exception {
     testSystemFactory = mock(TestSystemFactory.class);
-    testSystem = mock(TestSystem.class);
+    TestSystem testSystem = mock(TestSystem.class);
     when(testSystemFactory.create(any(Descriptor.class))).thenReturn(testSystem);
 
     context = FitNesseUtil.makeTestContext();
     suite = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("SuitePage"), "This is the test suite\n");
- }
+  }
 
   @Test
   public void shouldExecuteTestPagesGroupedByTestSystem() throws IOException, InterruptedException {

--- a/test/fitnesse/testsystems/fit/FitClientTest.java
+++ b/test/fitnesse/testsystems/fit/FitClientTest.java
@@ -57,7 +57,7 @@ public class FitClientTest implements FitClientListener {
     assertFalse(exceptionOccurred);
     assertEquals(1, outputs.size());
     assertEquals(1, counts.size());
-    assertSubString("class", (String) outputs.get(0));
+    assertSubString("class", outputs.get(0));
     assertEquals(1, counts.get(0).getRight());
   }
 

--- a/test/fitnesse/testsystems/slim/SslSlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/SslSlimClientBuilderTest.java
@@ -1,6 +1,5 @@
 package fitnesse.testsystems.slim;
 
-import java.io.File;
 import java.io.IOException;
 
 import fitnesse.testrunner.WikiPageDescriptor;

--- a/test/fitnesse/wiki/fs/FileSystemPageZipFileVersioningTest.java
+++ b/test/fitnesse/wiki/fs/FileSystemPageZipFileVersioningTest.java
@@ -37,11 +37,10 @@ public class FileSystemPageZipFileVersioningTest {
   private VersionInfo firstVersion;
   private VersionInfo secondVersion;
   private WikiPage root;
-  private ZipFileVersionsController versionsController;
 
   @Before
   public void setUp() throws Exception {
-    versionsController = new ZipFileVersionsController(MAX_HISTORY_DEPTH);
+    ZipFileVersionsController versionsController = new ZipFileVersionsController(MAX_HISTORY_DEPTH);
     FileSystemPageFactory fileSystemPageFactory = new FileSystemPageFactory(new DiskFileSystem(), versionsController);
     root = fileSystemPageFactory.makePage(new File("TestDir/RooT"), "RooT", null, new SystemVariableSource());
     page = (FileSystemPage) WikiPageUtil.addPage(root, PathParser.parse("PageOne"), "original content");


### PR DESCRIPTION
Various minor fixes, warnings and minor improvements. See commit messages for more details.

While working on this, I stumbled across one thing which should be looked more into. Thre places in the code calls `request.getinput("newname")`, and one of these immediately trims the result. Is this expected, or should the other places trim the newname as well? I haven't followed the flow where the requests are coming from, but I find it suspiscious that they are treated differently.