### PR TITLE
Tells SonarQube the project uses Java7

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.java.source=1.6
+sonar.java.source=1.7
 sonar.sources=src
 sonar.exclusions=**/*.min.js,src/**/bootstrap.js,src/**/codemirror.js,src/**/jquery.tagsinput.js


### PR DESCRIPTION
Now that FitNesse is targeting Java7 we can also take advantage of the Java7-
checks in SonarQube. The next report should report some new issues which
should be easy to resolve by using new features in Java7.

(I would at least expect it warns about instances where diamonds (<>) can
be used instead of explicit types.)