### PR TITLE
SystemUnderTest now accepts method calls from subclasses.

### DIFF
--- a/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
+++ b/src/fitnesse/slim/SystemUnderTestMethodExecutor.java
@@ -18,7 +18,7 @@ public class SystemUnderTestMethodExecutor extends MethodExecutor {
     } catch (SlimError e) {
       return MethodExecutionResult.noInstance(instanceName + "." + methodName);
     }
-    Field field = findSystemUnderTest(methodName, instance.getClass(), args);
+    Field field = findSystemUnderTest(methodName, instance, instance.getClass(), args);
     if (field != null) {
       Object systemUnderTest = field.get(instance);
       return findAndInvoke(methodName, args, systemUnderTest);
@@ -26,11 +26,13 @@ public class SystemUnderTestMethodExecutor extends MethodExecutor {
     return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
   }
 
-  private Field findSystemUnderTest(String methodName, Class<?> k, Object[] args) {
+  private Field findSystemUnderTest(String methodName, Object instance, Class<?> k, Object[] args) throws Throwable{
     Field[] fields = k.getDeclaredFields();
     for (Field field : fields) {
       if (isSystemUnderTest(field)) {
-        if (null != findMatchingMethod(methodName, field.getType(), args.length)) {
+        Object o = field.get(instance);
+        Class type = o == null ? field.getType() : o.getClass();
+        if (null != findMatchingMethod(methodName, type, args.length)) {
           return field;
         }
       }

--- a/test/fitnesse/slim/StatementExecutorTest.java
+++ b/test/fitnesse/slim/StatementExecutorTest.java
@@ -7,6 +7,7 @@ public class StatementExecutorTest extends StatementExecutorTestBase {
   public static class MySystemUnderTestJava extends MySystemUnderTestBase {
     private boolean echoCalled = false;
     private boolean speakCalled;
+    private boolean shoutCalled = false;
 
     @Override
     public void speak() {
@@ -27,6 +28,11 @@ public class StatementExecutorTest extends StatementExecutorTestBase {
     public boolean echoCalled() {
       return echoCalled;
     }
+
+    public void shout() {shoutCalled = true;}
+
+    public boolean shoutCalled() {return shoutCalled;}
+
   }
 
   public static class MyAnnotatedSystemUnderTestFixtureJava extends

--- a/test/fitnesse/slim/StatementExecutorTestBase.java
+++ b/test/fitnesse/slim/StatementExecutorTestBase.java
@@ -58,6 +58,7 @@ public abstract class StatementExecutorTestBase {
   }
 
   abstract static class MySystemUnderTestBase implements Speak, Echo {
+
   }
 
   abstract static class MyAnnotatedSystemUnderTestFixture implements Echo,
@@ -87,6 +88,17 @@ public abstract class StatementExecutorTestBase {
     assertTrue(myInstance.echoCalled());
     assertFalse(myInstance.getSystemUnderTest().speakCalled());
   }
+
+  @Test
+  public void shouldCallMethodOnFieldAnnotatedWithSystemUnderTestWhenFixtureDoesNotHaveMethodAndMethodIsInSubclass() throws Exception {
+    MyAnnotatedSystemUnderTestFixture myFixture = createAnnotatedFixture();
+    executeShoutStatementAndVerifyResultIsVoid();
+    assertFalse(myFixture.echoCalled());
+    assertTrue((((StatementExecutorTest.MySystemUnderTestJava)myFixture.getSystemUnderTest())).shoutCalled());
+    assertFalse(myFixture.getSystemUnderTest().speakCalled());
+  }
+
+
 
   @Test
   public void shouldCallMethodOnFieldAnnotatedWithSystemUnderTestWhenFixtureDoesNotHaveMethod() throws Exception {
@@ -238,6 +250,11 @@ public abstract class StatementExecutorTestBase {
 
   protected void executeStatementAndVerifyResultIsVoid() throws Exception {
     Object result = statementExecutor.call(INSTANCE_NAME, "speak");
+    assertEquals(voidMessage(), result);
+  }
+
+  protected void executeShoutStatementAndVerifyResultIsVoid() throws Exception {
+    Object result = statementExecutor.call(INSTANCE_NAME, "shout");
     assertEquals(voidMessage(), result);
   }
 }


### PR DESCRIPTION
Dear FitNesse team,

I've used @SystemUnderTest a while ago. This enables to construct a complex object model in a readable manner. While dusting off this project and use this again with the current version of fitnesse I discovered @SystemUnderTest only accepts calls to the declared class. I use methods from the subclasses a lot. I consider this the powert of SystemUnderTest.

This small addition enables this again.