### PR TITLE
JUnit run notifier will fire test finished as well after test failure…

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -51,13 +51,20 @@ public class JUnitRunNotifierResultsListener
     increaseCompletedTests();
     if (firstFailure != null) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), firstFailure));
+      fireTestFinishedFor(test);
     } else if (testSummary.getExceptions() > 0) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), new Exception("Exception occurred on page " + test.getFullPath())));
+      fireTestFinishedFor(test);
     } else if (testSummary.getWrong() > 0) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("Test failures occurred on page " + test.getFullPath())));
+      fireTestFinishedFor(test);
     } else {
-      notifier.fireTestFinished(descriptionFor(test));
+      fireTestFinishedFor(test);
     }
+  }
+
+  private void fireTestFinishedFor(TestPage test) {
+    notifier.fireTestFinished(descriptionFor(test));
   }
 
   @Override

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -51,16 +51,12 @@ public class JUnitRunNotifierResultsListener
     increaseCompletedTests();
     if (firstFailure != null) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), firstFailure));
-      fireTestFinishedFor(test);
     } else if (testSummary.getExceptions() > 0) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), new Exception("Exception occurred on page " + test.getFullPath())));
-      fireTestFinishedFor(test);
     } else if (testSummary.getWrong() > 0) {
       notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("Test failures occurred on page " + test.getFullPath())));
-      fireTestFinishedFor(test);
-    } else {
-      fireTestFinishedFor(test);
     }
+    fireTestFinishedFor(test);
   }
 
   private void fireTestFinishedFor(TestPage test) {

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -7,6 +7,7 @@ import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.wiki.PageCrawlerImpl;
 import fitnesse.wiki.WikiPage;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.mockito.ArgumentCaptor;
@@ -14,23 +15,83 @@ import org.mockito.ArgumentCaptor;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class JUnitRunNotifierResultsListenerTest {
+  private RunNotifier notifier = mock(RunNotifier.class);
+  private JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
+  private ArgumentCaptor<Failure> arguments = ArgumentCaptor.forClass(Failure.class);
+
+  @Test
+  public void shouldFinishSuccessfully() {
+    TestResult testResult = SlimTestResult.ok("-");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFinished(any(Description.class));
+  }
+
+  @Test
+  public void shouldStillFinishOnFailures() {
+    TestResult testResult = SlimTestResult.fail("-", "-");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(any(Failure.class));
+    verify(notifier).fireTestFinished(any(Description.class));
+  }
+
+  @Test
+  public void shouldStillFinishWhenResultsOkButSummaryReportsFailures() {
+    TestResult testResult = SlimTestResult.ok("-");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("W"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    verify(notifier).fireTestFinished(any(Description.class));
+
+    Failure failure = arguments.getValue();
+    assertThat(failure.getMessage(), is("Test failures occurred on page WikiPage"));
+  }
+
+  @Test
+  public void shouldStillFinishOnErrors() {
+    TestResult testResult = SlimTestResult.error("-", "-");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(any(Failure.class));
+    verify(notifier).fireTestFinished(any(Description.class));
+  }
+
+  @Test
+  public void shouldStillFinishWhenResultsOkButSummaryReportsExceptions() {
+    TestResult testResult = SlimTestResult.ok("-");
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("E"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    verify(notifier).fireTestFinished(any(Description.class));
+
+    Failure failure = arguments.getValue();
+    assertThat(failure.getMessage(), is("Exception occurred on page WikiPage"));
+  }
 
   @Test
   public void shouldProvideFirstFailure() {
-    RunNotifier notifier = mock(RunNotifier.class);
-    JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
-
     TestResult testResult = SlimTestResult.fail("Actual", "Expected");
 
     listener.testAssertionVerified(null, testResult);
-    listener.testComplete(mockWikiTestPage(), new TestSummary(0, 1, 0, 0));
+    listener.testComplete(mockWikiTestPage(), summary("-"));
 
-    ArgumentCaptor<Failure> argument = ArgumentCaptor.forClass(Failure.class);
-    verify(notifier).fireTestFailure(argument.capture());
-    Failure failure = argument.getValue();
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
 
     assertThat(failure.getException(), instanceOf(AssertionError.class));
     assertThat(failure.getMessage(), is("[Actual] expected [Expected]"));
@@ -38,27 +99,42 @@ public class JUnitRunNotifierResultsListenerTest {
 
   @Test
   public void shouldProvideFirstException() {
-    RunNotifier notifier = mock(RunNotifier.class);
-    JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
-
     TestResult testResult = SlimTestResult.error("Message", "Actual");
 
     listener.testAssertionVerified(null, testResult);
-    listener.testComplete(mockWikiTestPage(), new TestSummary(0, 0, 0, 1));
+    listener.testComplete(mockWikiTestPage(), summary("-"));
 
-    ArgumentCaptor<Failure> argument = ArgumentCaptor.forClass(Failure.class);
-    verify(notifier).fireTestFailure(argument.capture());
-    Failure failure = argument.getValue();
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
 
     assertThat(failure.getException(), instanceOf(Exception.class));
     assertThat(failure.getMessage(), is("[Actual] Message"));
   }
 
   private WikiTestPage mockWikiTestPage() {
-    WikiPage mock = mock(WikiPage.class);
-    when(mock.isRoot()).thenReturn(true);
-    when(mock.getName()).thenReturn("WikiPage");
-    when(mock.getPageCrawler()).thenReturn(new PageCrawlerImpl(mock));
-    return new WikiTestPage(mock);
+    WikiPage root = mock(WikiPage.class);
+    when(root.isRoot()).thenReturn(true);
+
+    WikiPage test = mock(WikiPage.class);
+    when(test.isRoot()).thenReturn(false);
+    when(test.getParent()).thenReturn(root);
+    when(test.getName()).thenReturn("WikiPage");
+    when(test.getPageCrawler()).thenReturn(new PageCrawlerImpl(test));
+    return new WikiTestPage(test);
+  }
+
+  private TestSummary summary(String report) {
+    int rights = 0;
+    int wrongs = 0;
+    int ignores = 0;
+    int exceptions = 0;
+
+    for (char c : report.toUpperCase().toCharArray())
+      if(c == 'R') rights++;
+      else if(c == 'W') wrongs++;
+      else if(c == 'I') ignores++;
+      else if(c == 'E') exceptions++;
+
+    return new TestSummary(rights, wrongs, ignores, exceptions);
   }
 }


### PR DESCRIPTION
I created a patch for issue #908 to help out.

In summary the FitNesseRunner doesn't work properly with the Gradle build tool. Reason for this is they expect an invocation of fireTestFinished for every fireTestStarted even if you already invoked fireTestFailure.
They do this as suggested by the Javadoc of RunNotifier.fireTestFinished (http://junit.sourceforge.net/javadoc/org/junit/runner/notification/RunNotifier.html#fireTestFinished%28org.junit.runner.Description%29)

The effect is that any failures or errors observed in a fitnesse run are ignored by Gradle's test result listener.

I added tests to JUnitRunNotifierResultsListenerTest to cover this behavior.

Finally, I'd like to bring your attention to the fact I modified the 2 existing tests slightly to illustrate the summaries passed into testComplete don't matter. They only matter when the test result succeeds and the summary still insists there were failures or errors of some kind.
I don't know if this use case makes sense so I made sure to cover both approaches when adding my own tests.