### PR TITLE
Ignore symbol assignment in QueryTable.scoreMatch(...).

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/QueryTableSuite/SetContextValue/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/QueryTableSuite/SetContextValue/content.txt
@@ -1,9 +1,14 @@
 |import|
 |fitnesse.slim.test|
 
-!| Query:SplitFixture | Bob,100 |
+!| Query:SplitFixture | Bob,100;John,200 |
 |1|2|
 |Bob|$Y=|
+|$Z=|200|
 
 |script|test slim|$Y|
 |check|return Constructor Arg|100|
+
+|script|test slim|0|
+|set string|$Z|
+|check|get string arg|John|

--- a/src/fitnesse/testsystems/slim/tables/QueryTable.java
+++ b/src/fitnesse/testsystems/slim/tables/QueryTable.java
@@ -12,6 +12,8 @@ import fitnesse.testsystems.slim.results.SlimExceptionResult;
 import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.util.StringUtils;
 
+import static fitnesse.slim.SlimSymbol.isSymbolAssignment;
+
 public class QueryTable extends SlimTable {
   private static final String COMMENT_COLUMN_MARKER = "#";
   protected List<String> fieldNames = new ArrayList<>();
@@ -304,6 +306,11 @@ public class QueryTable extends SlimTable {
           if (!fieldName.startsWith(COMMENT_COLUMN_MARKER)) {
             String actualValue = row.get(fieldName);
             String expectedValue = table.getCellContents(fieldIndex, tableRow);
+
+            if(isSymbolAssignment(expectedValue) != null) {
+              continue;
+            }
+
             if (matches(actualValue, expectedValue)) {
               score++;
             } else if (!StringUtils.isBlank(expectedValue)) {

--- a/test/fitnesse/testsystems/slim/tables/QueryTableTestBase.java
+++ b/test/fitnesse/testsystems/slim/tables/QueryTableTestBase.java
@@ -309,7 +309,17 @@ public abstract class QueryTableTestBase {
     assertEquals("2", result.getVariablesToStore().get("A"));
   }
 
-  
+  @Test
+  public void tableWithSetSymbolInFirstColumnReturnVariableInResult() throws Exception {
+    makeQueryTableAndBuildInstructions(queryTableHeader + "|$A=|2|\n");
+    QueryTable.QueryTableExpectation expectation = qt.new QueryTableExpectation();
+    TestResult result = expectation.evaluateExpectation(asList(asList(asList("n", "1"), asList("2n", "2"))));
+
+    assertNotNull(result.getVariablesToStore());
+    assertEquals("1", result.getVariablesToStore().get("A"));
+  }
+
+
   @Test
   public void commentColumn() throws Exception {
 	queryTableHeader =


### PR DESCRIPTION
Without ignore

table:

!| Query:SplitFixture | Bob,100;John,200 |
|1|2|
|Bob|$Y=|
|$Z=|200|

return
![withoutignoreresult](https://cloud.githubusercontent.com/assets/4983958/15254833/0a8408b6-1939-11e6-8f58-15295dffa2ae.png)
