### PR TITLE
Fix assignation of output parameters of scenarios with graceful names in decision tables

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioWithOutputParametersInDecisionTables/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioWithOutputParametersInDecisionTables/content.txt
@@ -1,43 +1,43 @@
 Output parameters in scenarios are flagged with a question mark in the header row, like in decision tables.
 For each output parameter a symbol with the same name must be assigned a value in the scenario.
 
-See below a sample of a division scenario with output parameter "result" 
+See below a sample of a division scenario with output parameter "my result" 
 
-|scenario | my division |numerator|  | denominator|  | result?|
-|setNumerator| @numerator|
-|setDenominator| @denominator|
-|$result= | quotient|
+|scenario      |my division|numerator||denominator||my result?|
+|setNumerator  |@numerator                                    |
+|setDenominator|@denominator                                  |
+|$myResult=    |quotient                                      |
 
 
 Get the Division implementation from the eg package
-|Library|
+|Library    |
 |eg.Division|
 
 
 
-| my division |
-| numerator | denominator | result? |
-| 10 | 2 | $x= |
-| $x | 1 | 5.0 |
+|my division                     |
+|numerator|denominator|my result?|
+|10       |2          |$x=       |
+|$x       |1          |5.0       |
 
 
 !3 A result calculated in one row and assigned to a symbol can be used in the next row
 and the order of the columns doesn't matters
 
-| my division |
-| result? | numerator | denominator |
-| $x= | 1000 | 2 | 
-| $x= | $x | 2 | 
-| $x= | $x | 2 | 
-| $x= | $x | 2 | 
-| $x= | $x | 2 | 
-| $x= | $x | 2 | 
-|7.8125   | $x | 2 |
+|my division                     |
+|my result?|numerator|denominator|
+|$x=       |1000     |2          |
+|$x=       |$x       |2          |
+|$x=       |$x       |2          |
+|$x=       |$x       |2          |
+|$x=       |$x       |2          |
+|$x=       |$x       |2          |
+|7.8125    |$x       |2          |
 
 !3 A result can be used in multiple columns in the decion table to do different checks
-| my division |
-| numerator | denominator | result? | result?|
-| 10 | 2 | 5.0 | < 7.0|
-| 12.6 | 3 | 4.2 | > 3.0|
+|my division                                |
+|numerator|denominator|my result?|my result?|
+|10       |2          |5.0       |< 7.0     |
+|12.6     |3          |4.2       |> 3.0     |
 
 

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioWithOutputParametersInDecisionTables/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioWithOutputParametersInDecisionTables/properties.xml
@@ -1,13 +1,12 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<LastModifyingUser>six42</LastModifyingUser>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Test>true</Test>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
 </properties>

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -96,7 +96,7 @@ public class DecisionTable extends SlimTable {
         String assignedSymbol = ifSymbolAssignment(col, row);
         SlimAssertion assertion;
         if (assignedSymbol != null) {
-        	assertion= makeAssertion(callAndAssign(assignedSymbol, "scriptTable" + "Actor", "cloneSymbol", "$"+functionName),
+        	assertion= makeAssertion(callAndAssign(assignedSymbol, "scriptTable" + "Actor", "cloneSymbol", "$"+name),
         			new ReturnedSymbolExpectation(col, row, name, assignedSymbol));
         } else {
           assertion = makeAssertion(Instruction.NOOP_INSTRUCTION, new ReturnedSymbolExpectation(col, row, name));


### PR DESCRIPTION
The name of the output parameter of a scenario should be disgraced when assigning the parameter in a decision table.