### PR TITLE
Add ability to specify the locale used to format evaluated expressions

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestEvaluator/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestEvaluator/content.txt
@@ -6,286 +6,323 @@ An expression may be a combination of constants, variables, and opertors.  All i
 !3 Format
 A format is a specifier that describes the rendering of the numeric result.  The format specifier is described by the Java 5 String class's .format() method:
 {{{       %[flags][width][.precision]conversion}}} *!note N.B., The ''[argument_index$]'' specifier is not permitted.
+
+Additionally, a formatting locale can be defined by setting the variable ''FORMAT_LOCALE'' to override the default JVM locale.
 !3 Links
  * [[format string][http://java.sun.com/j2se/1.5.0/docs/api/java/util/Formatter.html#syntax]]
- * [[String.format()][http://java.sun.com/j2se/1.5.0/docs/api/java/lang/String.html#format(java.lang.String,%20java.lang.Object...)]]
+ * [[String.format()][http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/String.html#format(java.util.Locale,%20java.lang.String,%20java.lang.Object...)]]
  * [[String class][http://java.sun.com/j2se/1.5.0/docs/api/java/lang/String.html]]
 !3 Examples
 {{{    $!--!{= 12 + 23 =} renders (sand brackets) as [35]
     $!--!{=%5.4f:1.414=} : [1.4140]
     $!--!{=%05X:14+14=}  : [0001C]
     $!--!{= %-10s : 123 =}   : [123       ]}}}
+
+And when specifying a formatting locale:
+{{{    !define FORMAT_LOCALE {fr}
+    $!--!{=%5.4f:1.414=} : [1,4140]}}}
 !3 Operators supported
-|Comment| !note Spaces between items are optional |
-|'''Operator'''|'''Argument'''|'''Description'''|
-|!c ''arg''   | ''constant or variable'' | Examples: 3, 12.4, 4E+8, $!--!{VALUE}, $!--!{some.var} |
-|!c ''expr''  |!c ''expression''           | Any valid combination of arguments and optional operations and parentheses|
-|!c '''+'''   |!c ''expr'' + ''expr''      | Addition |
-|!c '''-'''   |!c -''expr''                | Unary negation |
-|!c '''-'''   |!c ''expr'' - ''expr''      | Subtraction |
-|!c '''!-*-!'''|!c ''expr'' !-*-! ''expr''  | Multiplication |
-|!c '''/'''   |!c ''expr'' / ''expr''      | Division |
-|!c '''^'''   |!c ''expr'' ^ ''expr''      | Exponentiation |
-|!c '''sin''' |!c sin ''expr''             | Radian Sine of ''expr'' |
-|!c '''cos''' |!c cos ''expr''             | Radian Cosine of ''expr'' |
-|!c '''tan '''|!c cos ''expr''             | Radian Tangent of ''expr'' |
-|!c '''( )'''  |!c ( ''expr'' )             | Parenthetical grouping of an expression |
+|Comment       |!note Spaces between items are optional                                                              |
+|'''Operator'''|'''Argument'''            |'''Description'''                                                         |
+|!c ''arg''    |''constant or variable''  |Examples: 3, 12.4, 4E+8, $!--!{VALUE}, $!--!{some.var}                    |
+|!c ''expr''   |!c ''expression''         |Any valid combination of arguments and optional operations and parentheses|
+|!c '''+'''    |!c ''expr'' + ''expr''    |Addition                                                                  |
+|!c '''-'''    |!c -''expr''              |Unary negation                                                            |
+|!c '''-'''    |!c ''expr'' - ''expr''    |Subtraction                                                               |
+|!c '''!-*-!'''|!c ''expr'' !-*-! ''expr''|Multiplication                                                            |
+|!c '''/'''    |!c ''expr'' / ''expr''    |Division                                                                  |
+|!c '''^'''    |!c ''expr'' ^ ''expr''    |Exponentiation                                                            |
+|!c '''sin'''  |!c sin ''expr''           |Radian Sine of ''expr''                                                   |
+|!c '''cos'''  |!c cos ''expr''           |Radian Cosine of ''expr''                                                 |
+|!c '''tan ''' |!c cos ''expr''           |Radian Tangent of ''expr''                                                |
+|!c '''( )'''  |!c ( ''expr'' )           |Parenthetical grouping of an expression                                   |
 #-----------------------------------------------------------------
 -----
 !3 Test Blank Expressions
 ''' Build blank expression page '''
-!|script|
-| start | Page Builder|
-| line |~1a:&dollar;{==}~|
-| line |~1b:&dollar;{= =}~|
-| line |~1c:&dollar;{=  =}~|
-| page | ExpressionPage  |
+!|script                  |
+|start|Page Builder       |
+|line |~1a:&dollar;{==}~  |
+|line |~1b:&dollar;{= =}~ |
+|line |~1c:&dollar;{=  =}~|
+|page |ExpressionPage     |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
-!|Response Examiner|
-| type     | pattern |matches?|
-| contents | ~1a:~   |true    |
-| contents | ~1b:~   |true    |
-| contents | ~1c:~   |true    |
+!|Response Examiner       |
+|type    |pattern|matches?|
+|contents|~1a:~  |true    |
+|contents|~1b:~  |true    |
+|contents|~1c:~  |true    |
 
 #-----------------------------------------------------------------
 -----
 !3 Test Single Argument Expressions
 ''' Build expression page '''
-!|script|
-| start | Page Builder|
-| line |!- ~2a:${=3=}~   -!|
-| line |!- ~2b:${= 4.2 =}~  -!|
-| line |!- ~2c:${= 2E+1 =}~ -!|
-| line |!- ~2d:${=  2.3E+42  =}~ -!|
-| line |!- ~2e:${=  4.2E + 24  =}~ -!|
-| page | ExpressionPage  |
+!|script                            |
+|start|Page Builder                 |
+|line |!- ~2a:${=3=}~   -!          |
+|line |!- ~2b:${= 4.2 =}~  -!       |
+|line |!- ~2c:${= 2E+1 =}~ -!       |
+|line |!- ~2d:${=  2.3E+42  =}~ -!  |
+|line |!- ~2e:${=  4.2E + 24  =}~ -!|
+|page |ExpressionPage               |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
-!|Response Examiner|
-| type     | pattern     |matches?|
-| contents | ~2a:3~      |true    |
-| contents | ~2b:4.2~    |true    |
-| contents | ~2c:20~     |true    |
-| contents | ~2d:2.3E+42~|true    |
-| contents | ~2e:4.2E+24~|true    |
+!|Response Examiner            |
+|type    |pattern     |matches?|
+|contents|~2a:3~      |true    |
+|contents|~2b:4.2~    |true    |
+|contents|~2c:20~     |true    |
+|contents|~2d:2.3E+42~|true    |
+|contents|~2e:4.2E+24~|true    |
 
 #-----------------------------------------------------------------
 -----
 !3 Test spaces around experssions
 ''' Build expression page '''
-!|script|
-| start | Page Builder|
-| line |!- ~3a:${=1+1=}~ -!|
-| line |!- ~3b:${=2 + 2=}~ -!|
-| line |!- ~3c:${= 3 + 3=}~ -!|
-| line |!- ~3d:${=4 + 4 =}~ -!|
-| line |!- ~3e:${=5 +5 =}~ -!|
-| page | ExpressionPage  |
+!|script                     |
+|start|Page Builder          |
+|line |!- ~3a:${=1+1=}~ -!   |
+|line |!- ~3b:${=2 + 2=}~ -! |
+|line |!- ~3c:${= 3 + 3=}~ -!|
+|line |!- ~3d:${=4 + 4 =}~ -!|
+|line |!- ~3e:${=5 +5 =}~ -! |
+|page |ExpressionPage        |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
-!|Response Examiner|
-| type     | pattern |matches?|
-| contents | ~3a:2~  |true    |
-| contents | ~3b:4~  |true    |
-| contents | ~3c:6~  |true    |
-| contents | ~3d:8~  |true    |
-| contents | ~3e:10~ |true    |
+!|Response Examiner       |
+|type    |pattern|matches?|
+|contents|~3a:2~ |true    |
+|contents|~3b:4~ |true    |
+|contents|~3c:6~ |true    |
+|contents|~3d:8~ |true    |
+|contents|~3e:10~|true    |
 
 #-----------------------------------------------------------------
 -----
 !3 Test each operator
 ''' Build expression page '''
-!|script|
-| start | Page Builder|
-| line |!- ~4plus:${= 1 + 2 =}~     -!|
-| line |!- ~4minus:${= 2 - 3 =}~    -!|
-| line |!- ~4unary:${= -12 =}~      -!|
-| line |!- ~4mult:${= 3 * 4 =}~     -!|
-| line |!- ~4div:${= 4 / 5 =}~      -!|
-| line |!- ~4exp:${=%2d: 5 ^ 6 =}~  -!|
-| line |!- ~4sin1:${=%5.4f: sin0.39269875   =}~ -!|
-| line |!- ~4sin2:${=%5.4f: sin 0.39269875  =}~ -!|
-| line |!- ~4sin3:${=%5.4f: sin(0.39269875) =}~ -!|
-| line |!- ~4sin4:${=%5.4f: sin(3.14159/8)  =}~ -!|
-| line |!- ~4sin5:${=%5.4f: sin (3.14159/8) =}~ -!|
-| line |!- ~4cos:${=%5.4f: cos(3.14159 / 8) =}~ -!|
-| line |!- ~4tan:${=%5.4f: tan(3.14159 / 8) =}~ -!|
-| page | ExpressionPage  |
+!|script                                         |
+|start|Page Builder                              |
+|line |!- ~4plus:${= 1 + 2 =}~     -!            |
+|line |!- ~4minus:${= 2 - 3 =}~    -!            |
+|line |!- ~4unary:${= -12 =}~      -!            |
+|line |!- ~4mult:${= 3 * 4 =}~     -!            |
+|line |!- ~4div:${= 4 / 5 =}~      -!            |
+|line |!- ~4exp:${=%2d: 5 ^ 6 =}~  -!            |
+|line |!- ~4sin1:${=%5.4f: sin0.39269875   =}~ -!|
+|line |!- ~4sin2:${=%5.4f: sin 0.39269875  =}~ -!|
+|line |!- ~4sin3:${=%5.4f: sin(0.39269875) =}~ -!|
+|line |!- ~4sin4:${=%5.4f: sin(3.14159/8)  =}~ -!|
+|line |!- ~4sin5:${=%5.4f: sin (3.14159/8) =}~ -!|
+|line |!- ~4cos:${=%5.4f: cos(3.14159 / 8) =}~ -!|
+|line |!- ~4tan:${=%5.4f: tan(3.14159 / 8) =}~ -!|
+|page |ExpressionPage                            |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
-!|Response Examiner|
-| type     | pattern        |matches?|
-| contents | ~4plus:3~      |true    |
-| contents | ~4minus:-1~    |true    |
-| contents | ~4unary:-12~   |true    |
-| contents | ~4mult:12~     |true    |
-| contents | ~4div:0.8~     |true    |
-| contents | ~4exp:15625~   |true    |
-| contents | ~4sin1:0.3827~ |true    |
-| contents | ~4sin2:0.3827~ |true    |
-| contents | ~4sin3:0.3827~ |true    |
-| contents | ~4sin4:0.3827~ |true    |
-| contents | ~4sin5:0.3827~ |true    |
-| contents | ~4cos:0.9239~  |true    |
-| contents | ~4tan:0.4142~  |true    |
+!|Response Examiner              |
+|type    |pattern       |matches?|
+|contents|~4plus:3~     |true    |
+|contents|~4minus:-1~   |true    |
+|contents|~4unary:-12~  |true    |
+|contents|~4mult:12~    |true    |
+|contents|~4div:0.8~    |true    |
+|contents|~4exp:15625~  |true    |
+|contents|~4sin1:0.3827~|true    |
+|contents|~4sin2:0.3827~|true    |
+|contents|~4sin3:0.3827~|true    |
+|contents|~4sin4:0.3827~|true    |
+|contents|~4sin5:0.3827~|true    |
+|contents|~4cos:0.9239~ |true    |
+|contents|~4tan:0.4142~ |true    |
 
 #-----------------------------------------------------------------
 -----
 !3 Test parentheses
 ''' Build expression page '''
-!|script|
-| start | Page Builder|
-| line |!- ~5a:${= 2 * 3 + 4 / 2 - 3             =}~ -!|
-| line |!- ~5b:${= 2 * ( 3 + 4 ) / 2 - 3         =}~ -!|
-| line |!- ~5c:${= 2 * ( 3 + 4 ) / ( 2 - 3 )     =}~ -!|
-| line |!- ~5d:${= 2 * ( 3 + ( 4 / ( 2 - 3 ) ) ) =}~ -!|
-| page | ExpressionPage  |
+!|script                                              |
+|start|Page Builder                                   |
+|line |!- ~5a:${= 2 * 3 + 4 / 2 - 3             =}~ -!|
+|line |!- ~5b:${= 2 * ( 3 + 4 ) / 2 - 3         =}~ -!|
+|line |!- ~5c:${= 2 * ( 3 + 4 ) / ( 2 - 3 )     =}~ -!|
+|line |!- ~5d:${= 2 * ( 3 + ( 4 / ( 2 - 3 ) ) ) =}~ -!|
+|page |ExpressionPage                                 |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
-!|Response Examiner|
-| type     | pattern  |matches?|
-| contents | ~5a:5~   |true    |
-| contents | ~5b:4~   |true    |
-| contents | ~5c:-14~ |true    |
-| contents | ~5d:-2~  |true    |
+!|Response Examiner        |
+|type    |pattern |matches?|
+|contents|~5a:5~  |true    |
+|contents|~5b:4~  |true    |
+|contents|~5c:-14~|true    |
+|contents|~5d:-2~ |true    |
 
 #-----------------------------------------------------------------
 -----
 !3 Test formatting
 ''' Build expression page '''
-!|script|
-| start | Page Builder|
-| line |!- ~6a:${=%d:2                =}~ -!|
-| line |!- ~6b:${= %d : 3.2           =}~ -!|
-| line |!- ~6c:${=%02d: 2 + 1        =}~  -!|
-| line |!- ~6d:${= %4.4f: 2.2 / 3.4 =}~   -!|
-| line |!- ~6e:${=%03o: 16 =}~            -!|
-| line |!- ~6f:${= %03o : 18 =}~          -!|
-| line |!- ~6g:${=%03x: 26 =}~            -!|
-| line |!- ~6h:${=%03X: 27 =}~            -!|
-| line |!- ~6i:${= %-12s : 123 =}~        -!|
-| line |!- ~6j:${=%TY: 73422123127 =}~    -!|
-| line |!- ~6k:${=%b: 27 =}~              -!|
-| line |!- ~6l:${=%b: 0 =}~               -!|
-| line |!- ~6m:${=%B: 27 =}~              -!|
-| line |!- ~6n:${=%B: 0 =}~               -!|
-| line |!- ~6o:${= % d : 3.2          =}~ -!|
-| page | ExpressionPage  |
+!|script                                   |
+|start|Page Builder                        |
+|line |!- ~6a:${=%d:2                =}~ -!|
+|line |!- ~6b:${= %d : 3.2           =}~ -!|
+|line |!- ~6c:${=%02d: 2 + 1        =}~  -!|
+|line |!- ~6d:${= %4.4f: 2.2 / 3.4 =}~   -!|
+|line |!- ~6e:${=%03o: 16 =}~            -!|
+|line |!- ~6f:${= %03o : 18 =}~          -!|
+|line |!- ~6g:${=%03x: 26 =}~            -!|
+|line |!- ~6h:${=%03X: 27 =}~            -!|
+|line |!- ~6i:${= %-12s : 123 =}~        -!|
+|line |!- ~6j:${=%TY: 73422123127 =}~    -!|
+|line |!- ~6k:${=%b: 27 =}~              -!|
+|line |!- ~6l:${=%b: 0 =}~               -!|
+|line |!- ~6m:${=%B: 27 =}~              -!|
+|line |!- ~6n:${=%B: 0 =}~               -!|
+|line |!- ~6o:${= % d : 3.2          =}~ -!|
+|page |ExpressionPage                      |
 
 ''' Render it '''
-!|Response Requester|
-| uri            | valid? |
-| ExpressionPage | true   |
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
 
 !**> Contents
 !|Response Examiner|
-|type    | string? |
-|contents|         |
+|type     |string? |
+|contents |        |
 
-!|Response Examiner|
-|type    | wrapped html? |
-|contents|               |
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
 
 ***!
 
 ''' Verify results '''
+!|Response Examiner                                                              |
+|type    |pattern                                                       |matches?|
+|contents|~6a:2~                                                        |true    |
+|contents|~6b:3~                                                        |true    |
+|contents|~6c:03~                                                       |true    |
+|contents|~6d:0.6471~                                                   |true    |
+|contents|~6e:020~                                                      |true    |
+|contents|~6f:022~                                                      |true    |
+|contents|~6g:01a~                                                      |true    |
+|contents|~6h:01B~                                                      |true    |
+|contents|~6i:123&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;~|true    |
+|contents|~6j:1972~                                                     |true    |
+|contents|~6k:true~                                                     |true    |
+|contents|~6l:false~                                                    |true    |
+|contents|~6m:true~                                                     |true    |
+|contents|~6n:false~                                                    |true    |
+|contents|~6o: 3~                                                       |true    |
+
+#-----------------------------------------------------------------
+-----
+!3 Test formatting with specific locale
+''' Build expression page '''
+!|script                                   |
+|start|Page Builder                        |
+|line |!-!define FORMAT_LOCALE {fr}-!      |
+|line |!- ~7a:${= %4.4f: 2.2 / 3.4 =}~   -!|
+|page |ExpressionPage                      |
+
+''' Render it '''
+!|Response Requester  |
+|uri           |valid?|
+|ExpressionPage|true  |
+
+!**> Contents
 !|Response Examiner|
-| type     | pattern     |matches?|
-| contents | ~6a:2~      |true    |
-| contents | ~6b:3~      |true    |
-| contents | ~6c:03~     |true    |
-| contents | ~6d:0.6471~ |true    |
-| contents | ~6e:020~    |true    |
-| contents | ~6f:022~    |true    |
-| contents | ~6g:01a~    |true    |
-| contents | ~6h:01B~    |true    |
-| contents | ~6i:123&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;~|true|
-| contents | ~6j:1972~   |true    |
-| contents | ~6k:true~   |true    |
-| contents | ~6l:false~  |true    |
-| contents | ~6m:true~   |true    |
-| contents | ~6n:false~  |true    |
-| contents | ~6o: 3~      |true    |
+|type     |string? |
+|contents |        |
+
+!|Response Examiner    |
+|type    |wrapped html?|
+|contents|             |
+
+***!
+
+''' Verify results '''
+!|Response Examiner           |
+|type    |pattern    |matches?|
+|contents|~7a:0,6471~|true    |
 
 #---[EOT]---

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestEvaluator/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestEvaluator/properties.xml
@@ -1,11 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Files/>
-	<LastModified>20081213004646</LastModified>
-	<RecentChanges/>
-	<Suites/>
-	<Test/>
-	<WhereUsed/>
-	<saveId>1229150806385</saveId>
-	<ticketId>3090056070224906711</ticketId>
+<Files/>
+<RecentChanges/>
+<Test/>
+<WhereUsed/>
+<saveId>1229150806385</saveId>
+<ticketId>3090056070224906711</ticketId>
 </properties>

--- a/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupExpressions/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupExpressions/content.txt
@@ -30,17 +30,23 @@ The result is 10?: ${= ${X} + ${Y} + ${Z} + 4 =} yes!
 Where format is a single numeric or boolean format specifier defined by the Java Formatter class conversions.
 
 '''Examples'''
-|''' Mark Up '''|''' Result '''|
-|!-${=1+2+3=}-! | ${=1+2+3=} |
-|!-${=12E+2 + 34=}-! | ${=12E+2 + 34=} |
-|!-${=%03d:1+2+3=}-! | ${=%03d:1+2+3=} |
-|!-${=%02X:10+1=}-! | ${=%02X:8+1=} |
-|!-${= %02x : 10 + 1 =}-! | ${= %02x : 8 + 1 =} |
-|!-${= %03.2f : 10.12345678 =}-! | ${= %03.2f : 10.12345678 =} |
-|!-${=%b: 1 =}-! | ${=%b:1=} |
-|!-${=%b: 0 =}-! | ${=%b:0=} |
-|!-${=%B: 6 =}-! | ${=%B:6=} |
-|!-${=%B: -2 =}-! | ${=%B:-2=} |
+|''' Mark Up '''                |''' Result '''             |
+|!-${=1+2+3=}-!                 |${=1+2+3=}                 |
+|!-${=12E+2 + 34=}-!            |${=12E+2 + 34=}            |
+|!-${=%03d:1+2+3=}-!            |${=%03d:1+2+3=}            |
+|!-${=%02X:10+1=}-!             |${=%02X:8+1=}              |
+|!-${= %02x : 10 + 1 =}-!       |${= %02x : 8 + 1 =}        |
+|!-${= %03.2f : 10.12345678 =}-!|${= %03.2f : 10.12345678 =}|
+|!-${=%b: 1 =}-!                |${=%b:1=}                  |
+|!-${=%b: 0 =}-!                |${=%b:0=}                  |
+|!-${=%B: 6 =}-!                |${=%B:6=}                  |
+|!-${=%B: -2 =}-!               |${=%B:-2=}                 |
+
+!3 Formatting Locale
+The formatting locale can be overriden by setting the ''FORMAT_LOCALE'' variable.
+
+'''Example'''
+{{{!-!define FORMAT_LOCALE {fr}-!}}}
 
 !see <FitNesse.SuiteAcceptanceTests.SuiteWidgetTests.TestEvaluator
 

--- a/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupExpressions/properties.xml
+++ b/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupExpressions/properties.xml
@@ -1,14 +1,13 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<LastModified>20090327101940</LastModified>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
-	<saveId>1238167180400</saveId>
-	<ticketId>7251473079430893688</ticketId>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+<saveId>1238167180400</saveId>
+<ticketId>7251473079430893688</ticketId>
 </properties>

--- a/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/content.txt
@@ -296,6 +296,7 @@ ${OPT}${BAR} ''optional table row'' ${BAR}${OPT} ''optional 2nd column'' ${BAR}$
 | ${CODE} RSS_PREFIX ${CODEend} | !c | !c | '' Link prefix for [[RSS Feeds][AdministeringFitNesse.RestfulServices.RssFeed]] '' |
 | ${CODE} INCLUDE_SCENARIO_LIBRARIES ${CODEend} | !c false* | !c true${BAR}false | ''Test pages should include [[!-ScenarioLibrary-!][WritingAcceptanceTests.SpecialPages]] pages''!-
 -! * defaults to true if the SLiM test system is defined. |
+| ${CODE} FORMAT_LOCALE ${CODEend} | !c nil | !c IETF language tag | '' IETF language tag for the locale used for formatting evaluated expressions '' |
 | ${CODE} ''PAGE_NAME'' ${CODEend} | !c | !c Read Only | '' Name of current page'' |
 | ${CODE} ''PAGE_PATH '' ${CODEend} | !c | !c Read Only | '' Fully qualified name of parent. '' |
 | ${CODE} ''RUNNING_PAGE_NAME'' ${CODEend} | !c | !c Read Only | '' Name of current top level running page'' |

--- a/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/properties.xml
+++ b/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/properties.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit/>
-	<Files/>
-	<Normal/>
-	<Properties/>
-	<RecentChanges/>
-	<Refactor/>
-	<Versions/>
-	<WhereUsed/>
-	<saveId>1237228032275</saveId>
-	<ticketId>-5542215261053372341</ticketId>
+<Edit/>
+<Files/>
+<Normal/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Versions/>
+<WhereUsed/>
+<saveId>1237228032275</saveId>
+<ticketId>-5542215261053372341</ticketId>
 </properties>

--- a/src/fitnesse/wikitext/parser/Evaluator.java
+++ b/src/fitnesse/wikitext/parser/Evaluator.java
@@ -20,7 +20,11 @@ public class Evaluator extends SymbolType implements Rule, Translation {
     @Override
     public String toTarget(Translator translator, Symbol symbol) {
         String body = translator.translate(symbol.childAt(0));
-        Maybe<String> result = new FormattedExpression(body).evaluate();
+        Maybe<String> formatLocale = Maybe.noString;
+        if(translator instanceof HtmlTranslator){
+          formatLocale = ((HtmlTranslator) translator).getParsingPage().findVariable("FORMAT_LOCALE");
+        }
+        Maybe<String> result = new FormattedExpression(body, formatLocale).evaluate();
         if (result.isNothing()) return translator.formatMessage(result.because());
         return result.getValue();
     }


### PR DESCRIPTION
This patch allows the user to specify which locale to use when formatting the result of a ${= =} expression.
The locale can be specified by setting the FORMAT_LOCALE variable, i. e. !define FORMAT_LOCALE {fr} will make the formatting use the French locale regardless of the JVM default locale.
If the FORMAT_LOCALE variable is not defined, the default JVM locale is used.