### PR TITLE
Slim: run TearDown after StopText exception and SuiteTeardown after StopSuite

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteSetUpAndTearDown/TestSetUpAndTearDownAreUncollapsedWithVariable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteSetUpAndTearDown/TestSetUpAndTearDownAreUncollapsedWithVariable/content.txt
@@ -33,4 +33,4 @@ By setting the variables COLLAPSE_SETUP or COLLAPSE_TEARDOWN to false (using the
 !|Response Examiner.|
 |type|pattern|matches?|
 |contents|<div class="collapsible">.*<div>set up</div>|true|
-|contents|<div class="collapsible closed">.*<div>tear down</div>|true|
+|contents|<div class="collapsible closed teardown">.*<div>tear down</div>|true|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/StopSuite/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/StopSuite/content.txt
@@ -20,5 +20,24 @@ Raising an exception with the term "StopSuite" in it will make sure all remainin
 | table in page B never to be executed |
 
 -! |
+| given page | MySuite.TearDown | with content | !-
+| import |
+| fitnesse.slim.test |
+
+| script | echo script |
+| check | echo | tear down after ${PAGE_NAME} | tear down after ${PAGE_NAME} |
+
+-! |
+| given page | MySuite.SuiteTearDown | with content | !-
+| import |
+| fitnesse.slim.test |
+
+| script | echo script |
+| check | echo | suite tear down executed | suite tear down executed |
+
+-! |
 | test results for suite | MySuite | should contain | table in page A never to be executed <span class="ignore">Test not run</span> |
+| ensure | content contains | <span class="pass">tear down after <a href="MySuite.TestPageA">TestPageA</a></span> |
 | ensure | content contains | table in page B never to be executed <span class="ignore">Test not run</span> |
+| ensure | content contains | tear down after <a href="MySuite.TestPageB">TestPageB</a> <span class="ignore">Test not run</span> |
+| ensure | content contains | <span class="pass">suite tear down executed</span> |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/StopTest/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/StopTest/content.txt
@@ -19,5 +19,24 @@
 | check | echo | hello | hello |
 
 -! |
+| given page | MySuite.TearDown | with content | !-
+| import |
+| fitnesse.slim.test |
+
+| script | echo script |
+| check | echo | tear down after ${PAGE_NAME} | tear down after ${PAGE_NAME} |
+
+-! |
+| given page | MySuite.SuiteTearDown | with content | !-
+| import |
+| fitnesse.slim.test |
+
+| script | echo script |
+| check | echo | suite tear down executed | suite tear down executed |
+
+-! |
 | test results for suite | MySuite | should contain | table never to be executed <span class="ignore">Test not run</span> |
+| ensure | content contains | <span class="pass">tear down after <a href="MySuite.TestPageA">TestPageA</a></span> |
 | ensure | content contains | <span class="pass">echo script</span> |
+| ensure | content contains | <span class="pass">tear down after <a href="MySuite.TestPageB">TestPageB</a></span> |
+| ensure | content contains | <span class="pass">suite tear down executed</span> |

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/ExceptionHandling/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/ExceptionHandling/content.txt
@@ -4,6 +4,6 @@ The default way Slim handles exceptions is to indicate in the test table that an
 !2 Specifying a custom message
 You can specify a custom message to be written into the test output instead of a stack trace.  This is done by prefixing your message with {{{message:<<}}} and ending with {{{>>}}}  For instance if you want the message to be "Can't create object" then the text for your exception should be {{{message:<<Can't create object>>}}}
 !2 Stopping the execution of the test.
-If your exception indicates an error that cannot be recovered from, then you may want the test execution to stop at that point.   You can do this by throwing an exception with "!-StopTest-!" in the class name.  If the test is part of a suite, then this will cause the next test in the suite to be be started immediately.
+If your exception indicates an error that cannot be recovered from, then you may want the test execution to stop at that point.   You can do this by throwing an exception with "!-StopTest-!" in the class name. Teardown for the test will still be executed. If the test is part of a suite, then the next test in the suite to be be started afterwards.
 
-Be warned, that if you throw a "!-StopTest-!" exception then the tear down for your test will not run.  A fix for this is to run the tear down procedure before you throw the exception.
+By throwing an exception with "!-StopSuite-!" in the class name you can stop both current test and the suite execution. Tear down procedure for the running test and the suite will still be executed, but all the consequent tests in the suite will not run.

--- a/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
@@ -10,6 +10,7 @@ import org.htmlparser.lexer.Page;
 import org.htmlparser.util.NodeList;
 import org.htmlparser.util.ParserException;
 
+import fitnesse.wiki.PageData;
 import fitnesse.slim.SlimError;
 import fitnesse.testsystems.TestExecutionException;
 import fitnesse.testsystems.TestPage;
@@ -40,6 +41,8 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
   protected void processAllTablesOnPage(TestPage pageToTest) throws TestExecutionException {
     List<SlimTable> allTables = createSlimTables(pageToTest);
 
+    boolean isSuiteTearDownPage = PageData.SUITE_TEARDOWN_NAME.equals(pageToTest.getName());
+
     if (allTables.isEmpty()) {
       String html = createHtmlResults(START_OF_TEST, END_OF_TEST);
       testOutputChunk(html);
@@ -50,7 +53,7 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
         SlimTable nextTable = (index + 1 < allTables.size()) ? allTables.get(index + 1) : END_OF_TEST;
 
         try {
-          processTable(theTable);
+          processTable(theTable, isSuiteTearDownPage);
         } catch (SyntaxError e) {
           String tableName = theTable.getTable().getCellContents(0, 0);
           theTable.getTable().updateContent(0, 0, SlimTestResult.error(String.format("<strong> %s: Bad table! %s</strong>", tableName, e.getMessage())));

--- a/src/fitnesse/testsystems/slim/HtmlTable.java
+++ b/src/fitnesse/testsystems/slim/HtmlTable.java
@@ -43,6 +43,7 @@ public class HtmlTable implements Table {
 
   private List<Row> rows = new ArrayList<>();
   private TableTag tableNode;
+  private boolean isTearDown;
 
   public HtmlTable(TableTag tableNode) {
     this.tableNode = tableNode;
@@ -57,6 +58,14 @@ public class HtmlTable implements Table {
 
   public TableTag getTableNode() {
     return tableNode;
+  }
+
+  public boolean isTearDown() {
+    return isTearDown;
+  }
+
+  public void setTearDown(boolean teardown) {
+    isTearDown = teardown;
   }
 
   @Override

--- a/src/fitnesse/testsystems/slim/HtmlTableScanner.java
+++ b/src/fitnesse/testsystems/slim/HtmlTableScanner.java
@@ -61,7 +61,7 @@ public class HtmlTableScanner implements TableScanner<HtmlTable> {
 
         NodeList children = node.getChildren();
         if (children != null) {
-          scanForTables(children, markAsTeardown || nodeHasClass(Include.TEARDOWN, node));
+          scanForTables(children, markAsTeardown || nodeHasClass(node, Include.TEARDOWN));
         }
 
         Node endNode = endTag(node);

--- a/src/fitnesse/testsystems/slim/HtmlTableScanner.java
+++ b/src/fitnesse/testsystems/slim/HtmlTableScanner.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import fitnesse.slim.SlimError;
+import fitnesse.wikitext.parser.Include;
 import org.htmlparser.Node;
 import org.htmlparser.Parser;
 import org.htmlparser.lexer.Lexer;
@@ -43,18 +44,24 @@ public class HtmlTableScanner implements TableScanner<HtmlTable> {
   }
 
   private void scanForTables(NodeList nodes) {
+    scanForTables(nodes, false);
+  }
+
+  private void scanForTables(NodeList nodes, boolean markAsTeardown) {
     for (int i = 0; i < nodes.size(); i++) {
       Node node = nodes.elementAt(i);
       if (node instanceof TableTag) {
         TableTag tableTag = deepClone((TableTag) node);
-        tables.add(new HtmlTable(tableTag));
+        HtmlTable htmlTable = new HtmlTable(tableTag);
+        htmlTable.setTearDown(markAsTeardown);
+        tables.add(htmlTable);
         this.nodes.add(tableTag);
       } else {
         this.nodes.add(flatClone(node));
 
         NodeList children = node.getChildren();
         if (children != null) {
-          scanForTables(children);
+          scanForTables(children, markAsTeardown || nodeHasClass(Include.TEARDOWN, node));
         }
 
         Node endNode = endTag(node);

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -27,7 +27,7 @@ public abstract class SlimTestSystem implements TestSystem {
   private final String testSystemName;
 
   private SlimTestContextImpl testContext;
-  private boolean stopTestCalled;
+  boolean stopTestCalled;
   private boolean stopSuiteCalled;
   private boolean testSystemIsStopped;
 

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -113,13 +113,18 @@ public abstract class SlimTestSystem implements TestSystem {
 
   protected abstract void processAllTablesOnPage(TestPage testPage) throws TestExecutionException;
 
-  protected void processTable(SlimTable table) throws TestExecutionException {
+  protected void processTable(SlimTable table, boolean isSuiteTearDownPage) throws TestExecutionException {
     List<SlimAssertion> assertions = table.getAssertions();
-    Map<String, Object> instructionResults;
-    if (!stopTestCalled && !stopSuiteCalled) {
-      instructionResults = slimClient.invokeAndGetResponse(SlimAssertion.getInstructions(assertions));
-    } else {
+    final Map<String, Object> instructionResults;
+    if (stopTestCalled && !table.isTearDown()) {
       instructionResults = Collections.emptyMap();
+    } else {
+      boolean tearDownOfAlreadyStartedTest = stopTestCalled && table.isTearDown();
+      if (stopSuiteCalled && !isSuiteTearDownPage && !tearDownOfAlreadyStartedTest) {
+        instructionResults = Collections.emptyMap();
+      } else {
+        instructionResults = slimClient.invokeAndGetResponse(SlimAssertion.getInstructions(assertions));
+      }
     }
 
     evaluateTables(assertions, instructionResults);

--- a/src/fitnesse/testsystems/slim/Table.java
+++ b/src/fitnesse/testsystems/slim/Table.java
@@ -10,6 +10,8 @@ import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.testsystems.slim.tables.SyntaxError;
 
 public interface Table {
+  boolean isTearDown();
+
   String getCellContents(int col, int row);
 
   int getRowCount();

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -33,6 +33,7 @@ public abstract class SlimTable {
   private String tableName;
   private int instructionNumber = 0;
   private String fixtureName;
+  private boolean isTearDown;
 
   private List<SlimTable> children = new LinkedList<>();
   private SlimTable parent = null;
@@ -75,7 +76,6 @@ public abstract class SlimTable {
   public String replaceSymbolsWithFullExpansion(String s) {
     return new FullExpansionSymbolReplacer(s).replace();
   }
-
 
   protected abstract String getTableType();
 
@@ -130,6 +130,14 @@ public abstract class SlimTable {
       fixtureName = getFixtureName(tableHeader);
     }
     return Disgracer.disgraceClassName(fixtureName);
+  }
+
+  public boolean isTearDown() {
+    return isTearDown;
+  }
+
+  public void setTearDown(boolean teardown) {
+    isTearDown = teardown;
   }
 
   protected String getFixtureName(String tableHeader) {

--- a/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
@@ -77,6 +77,7 @@ public class SlimTableFactory {
     	newTable = new SlimErrorTable(table, tableId, slimTestContext);
     }
     newTable.setFixtureName(getRawFixtureName(tableType));
+    newTable.setTearDown(table.isTearDown());
     return newTable;
   }
 

--- a/src/fitnesse/util/HtmlParserTools.java
+++ b/src/fitnesse/util/HtmlParserTools.java
@@ -102,7 +102,7 @@ public final class HtmlParserTools {
     return newAttributes;
   }
 
-  public static boolean nodeHasClass(String classToCheck, Node node) {
+  public static boolean nodeHasClass(Node node, String classToCheck) {
     if (!(node instanceof TagNode)) {
       return false;
     }

--- a/src/fitnesse/util/HtmlParserTools.java
+++ b/src/fitnesse/util/HtmlParserTools.java
@@ -5,6 +5,7 @@ import java.util.Vector;
 import org.htmlparser.Attribute;
 import org.htmlparser.Node;
 import org.htmlparser.Tag;
+import org.htmlparser.nodes.TagNode;
 import org.htmlparser.util.NodeList;
 
 /**
@@ -99,6 +100,22 @@ public final class HtmlParserTools {
       newAttributes.add(new Attribute(a.getName(), a.getAssignment(), a.getValue(), a.getQuote()));
     }
     return newAttributes;
+  }
+
+  public static boolean nodeHasClass(String classToCheck, Node node) {
+    if (!(node instanceof TagNode)) {
+      return false;
+    }
+    String classAttribute = ((TagNode) node).getAttribute("class");
+    if (null == classAttribute) {
+      return false;
+    }
+    for (String className : classAttribute.split(" ")) {
+      if (classToCheck.equals(className)) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/src/fitnesse/wikitext/parser/Collapsible.java
+++ b/src/fitnesse/wikitext/parser/Collapsible.java
@@ -3,6 +3,9 @@ package fitnesse.wikitext.parser;
 import fitnesse.html.HtmlTag;
 import fitnesse.html.RawHtml;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class Collapsible extends SymbolType implements Rule, Translation {
 
     private static final String STATE = "State";
@@ -56,8 +59,17 @@ public class Collapsible extends SymbolType implements Rule, Translation {
     }
 
     public static String generateHtml(String state, String titleText, String bodyText) {
+        return generateHtml(state, titleText, bodyText, Collections.<String>emptySet());
+    }
+
+    public static String generateHtml(String state, String titleText, String bodyText, Collection<String> extraClasses) {
+        StringBuilder outerClasses = new StringBuilder("collapsible" + state);
+        for (String extraClass : extraClasses) {
+            outerClasses.append(' ').append(extraClass);
+        }
+
         HtmlTag outerBlock = new HtmlTag("div");
-        outerBlock.addAttribute("class", "collapsible" + state);
+        outerBlock.addAttribute("class", outerClasses.toString());
 
         outerBlock.add(new RawHtml("<ul>" +
         		"<li><a href='#' class='expandall'>Expand</a></li>" +

--- a/src/fitnesse/wikitext/parser/Include.java
+++ b/src/fitnesse/wikitext/parser/Include.java
@@ -3,9 +3,14 @@ package fitnesse.wikitext.parser;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
 public class Include extends SymbolType implements Rule, Translation {
     private static final String[] setUpSymbols = new String[] {"COLLAPSE_SETUP"};
     private static final String includeHelpOption = "-h";
+    public static final String TEARDOWN = "teardown";
 
     public Include() {
         super("Include");
@@ -87,7 +92,9 @@ public class Include extends SymbolType implements Rule, Translation {
             String collapseState = stateForOption(option, symbol);
             String title = "Included page: "
                     + translator.translate(symbol.childAt(1));
-            return Collapsible.generateHtml(collapseState, title, translator.translate(symbol.childAt(3)));
+            Collection<String> extraCollapsibleClass =
+                    option.equals("-teardown") ? Collections.singleton(TEARDOWN) : Collections.<String>emptySet();
+            return Collapsible.generateHtml(collapseState, title, translator.translate(symbol.childAt(3)), extraCollapsibleClass);
         }
     }
 

--- a/test/fitnesse/plugins/slimcoverage/SlimCoverageTestSystem.java
+++ b/test/fitnesse/plugins/slimcoverage/SlimCoverageTestSystem.java
@@ -63,7 +63,7 @@ public class SlimCoverageTestSystem extends HtmlSlimTestSystem {
     }
 
     @Override
-    protected void processTable(SlimTable table) throws TestExecutionException {
+    protected void processTable(SlimTable table, boolean isSuiteTearDownPage) throws TestExecutionException {
         table.getAssertions();
     }
 

--- a/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
+++ b/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
@@ -1,0 +1,304 @@
+package fitnesse.testsystems.slim;
+
+import fitnesse.slim.SlimException;
+import fitnesse.slim.SlimServer;
+import fitnesse.slim.instructions.Instruction;
+import fitnesse.slim.instructions.InstructionExecutor;
+import fitnesse.slim.instructions.InstructionResult;
+import fitnesse.testsystems.*;
+import fitnesse.testsystems.slim.results.SlimExceptionResult;
+import fitnesse.testsystems.slim.results.SlimTestResult;
+import fitnesse.testsystems.slim.tables.SlimAssertion;
+import fitnesse.testsystems.slim.tables.SlimExpectation;
+import fitnesse.testsystems.slim.tables.SlimTable;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static fitnesse.slim.SlimServer.EXCEPTION_TAG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * See also FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests, StopSuite and StopTest in particular
+ */
+public class SlimTestSystemTableProcessingTest {
+
+  private final RecordingTestSystemListener listener = new RecordingTestSystemListener();
+  private final DummySlimTestSystem slimTestSystem = new DummySlimTestSystem();
+
+  @Before
+  public void setup() {
+    slimTestSystem.addTestSystemListener(listener);
+  }
+
+  @Test
+  public void normalFlowTwoTablesSamePage() throws TestExecutionException {
+    slimTestSystem.processTable(table("Table1"), false);
+    slimTestSystem.processTable(table("Table2"), false);
+
+    assertTestRecords(pass("Table1"), pass("Table2"));
+  }
+
+  @Test
+  public void tableFollowingRandomExceptionStillExecuted() throws TestExecutionException {
+    String exceptionId = EXCEPTION_TAG + "table1 with random exception";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.processTable(table("Table2"), false);
+
+    assertTestRecords(error(exceptionId), pass("Table2"));
+  }
+
+  @Test
+  public void tableFollowingStopTestExceptionSkipped() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_TEST_TAG + "StopTestException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.processTable(table("Table2"), false);
+
+    assertTestRecords(fail(exceptionId), ignore("Table2"));
+  }
+
+  @Test
+  public void nextTestFollowingStopTestExceptionExecuted() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_TEST_TAG + "StopTestException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.newTestPage();
+    slimTestSystem.processTable(table("NextTest"), false);
+
+    assertTestRecords(fail(exceptionId), pass("NextTest"));
+  }
+
+  @Test
+  public void tearDownFollowingStopTestExceptionStillExecuted() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_TEST_TAG + "StopTestException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.processTable(tearDownTable("TearDown"), false);
+
+    assertTestRecords(fail(exceptionId), pass("TearDown"));
+  }
+
+  @Test
+  public void suiteTearDownFollowingStopTestExceptionStillExecuted() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_TEST_TAG + "StopTestException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.newTestPage();
+    slimTestSystem.processTable(table("SuiteTearDown"), true);
+    assertTestRecords(fail(exceptionId), pass("SuiteTearDown"));
+  }
+
+  @Test
+  public void nextPageAndItsTeardownShouldBeSkipped() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_SUITE_TAG + "StopSuiteException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.newTestPage();
+    slimTestSystem.processTable(table("NextPage"), false);
+    slimTestSystem.processTable(tearDownTable("NextPageTearDown"), false);
+
+    assertTestRecords(error(exceptionId), ignore("NextPage"), ignore("NextPageTearDown"));
+  }
+
+  @Test
+  public void suiteTearDownAlsoOnSuiteStopExceptionExecuted() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_SUITE_TAG + "StopSuiteException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.newTestPage();
+    slimTestSystem.processTable(table("SuiteTearDown"), true);
+
+    assertTestRecords(error(exceptionId), pass("SuiteTearDown"));
+  }
+
+  @Test
+  public void tearDownThisPageStopSuiteExceptionShouldStillBeExecuted() throws TestExecutionException {
+    String exceptionId = SlimServer.EXCEPTION_STOP_SUITE_TAG + "StopSuiteException";
+    slimTestSystem.processTable(table(exceptionId), false);
+    slimTestSystem.processTable(tearDownTable("ThisPageTeardown"), false);
+
+    assertTestRecords(error(exceptionId), pass("ThisPageTeardown"));
+  }
+
+  private static DummySlimTable table(String exceptionId) {
+    return new DummySlimTable(exceptionId);
+  }
+
+  private static SlimTable tearDownTable(String key) {
+    DummySlimTable result = table(key);
+    result.setTearDown(true);
+    return result;
+  }
+
+  public void assertTestRecords(String... testRecords) {
+    assertEquals(Arrays.asList(testRecords), listener.getRecordedHistory());
+  }
+
+  public static String pass(String key) {
+    return formatTestRecord(ExecutionResult.PASS, key);
+  }
+
+  public static String ignore(String key) {
+    return formatTestRecord(ExecutionResult.IGNORE, key);
+  }
+
+  public static String error(String key) {
+    return formatTestRecord(ExecutionResult.ERROR, key);
+  }
+
+  public static String fail(String key) {
+    return formatTestRecord(ExecutionResult.FAIL, key);
+  }
+
+  private static String formatTestRecord(ExecutionResult executionResult, String key) {
+    return String.format("%s(\"%s\")", executionResult, key);
+  }
+
+  private static class RecordingTestSystemListener implements TestSystemListener {
+
+    private final List<String> recordedHistory = new ArrayList<>();
+
+    @Override
+    public void testExceptionOccurred(Assertion assertion, ExceptionResult exceptionResult) {
+      assertNotEquals("Exceptions are not expected to indicate success", exceptionResult.getExecutionResult(), ExecutionResult.PASS);
+      record(assertion, exceptionResult.getExecutionResult());
+    }
+
+    private void record(Assertion assertion, ExecutionResult executionResult) {
+      recordedHistory.add(formatTestRecord(executionResult, assertion.getInstruction().getId()));
+    }
+
+    public List<String> getRecordedHistory() {
+      return recordedHistory;
+    }
+
+    @Override
+    public void testSystemStarted(TestSystem testSystem) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testOutputChunk(String output) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testStarted(TestPage testPage) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testComplete(TestPage testPage, TestSummary testSummary) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testSystemStopped(TestSystem testSystem, Throwable cause) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testAssertionVerified(Assertion assertion, TestResult testResult) {
+      ExecutionResult executionResult = testResult.getExecutionResult();
+      record(assertion, executionResult);
+    }
+  }
+
+  private static class DummySlimTable extends SlimTable {
+
+    private final List<SlimAssertion> assertions;
+
+    public DummySlimTable(String assertionId) {
+      super(null, null, null);
+      this.assertions = Collections.singletonList(
+          new SlimAssertion(new DummyInstruction(assertionId),
+              new IgnoreOnNullPassOtherwiseSlimExpectation())
+      );
+    }
+
+    @Override
+    protected String getTableType() {
+      return "test";
+    }
+
+    @Override
+    public List<SlimAssertion> getAssertions() throws TestExecutionException {
+      return assertions;
+    }
+  }
+
+  private static class DummyInstruction extends Instruction {
+    public DummyInstruction(String assertion) {
+      super(assertion);
+    }
+
+    @Override
+    protected InstructionResult executeInternal(InstructionExecutor executor) throws SlimException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class DummySlimTestSystem extends SlimTestSystem {
+
+    public final InstructionIdMirroringSlimClient slimClientMock;
+
+    public DummySlimTestSystem() {
+      this(new InstructionIdMirroringSlimClient());
+    }
+
+    public DummySlimTestSystem(InstructionIdMirroringSlimClient slimClientMock) {
+      super(null, slimClientMock);
+      this.slimClientMock = slimClientMock;
+    }
+
+    @Override
+    protected void processAllTablesOnPage(TestPage testPage) throws TestExecutionException {
+      throw new UnsupportedOperationException();
+    }
+
+    public void newTestPage() {
+      stopTestCalled = false;
+    }
+  }
+
+  private static class InstructionIdMirroringSlimClient implements SlimClient {
+    @Override
+    public void start() throws IOException, SlimVersionMismatch {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> invokeAndGetResponse(List<Instruction> statements) throws SlimCommunicationException {
+      Map<String, Object> response = new HashMap<>();
+      for (Instruction statement : statements) {
+        response.put(statement.getId(), statement.getId());
+      }
+      return response;
+    }
+
+    @Override
+    public void connect() throws IOException, SlimVersionMismatch {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bye() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void kill() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class IgnoreOnNullPassOtherwiseSlimExpectation implements SlimExpectation {
+    @Override
+    public TestResult evaluateExpectation(Object returnValues) {
+      return new SlimTestResult(null == returnValues ? ExecutionResult.IGNORE : ExecutionResult.PASS);
+    }
+
+    @Override
+    public SlimExceptionResult evaluateException(SlimExceptionResult exceptionResult) {
+      return exceptionResult;
+    }
+  }
+}

--- a/test/fitnesse/util/HtmlParserToolsTest.java
+++ b/test/fitnesse/util/HtmlParserToolsTest.java
@@ -2,10 +2,8 @@ package fitnesse.util;
 
 import static fitnesse.util.HtmlParserTools.deepClone;
 import static fitnesse.util.HtmlParserTools.flatClone;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertEquals;
+import static fitnesse.util.HtmlParserTools.nodeHasClass;
+import static org.junit.Assert.*;
 
 import org.htmlparser.Node;
 import org.htmlparser.Parser;
@@ -21,8 +19,7 @@ public class HtmlParserToolsTest {
   @Test
   public void shoudlMakeExactCopy() throws ParserException, CloneNotSupportedException {
     String html = "<div class='foo'>funky <em>content</em></div>";
-    Parser parser = new Parser(new Lexer(new Page(html)));
-    NodeList tree = parser.parse(null);
+    NodeList tree = parseToTree(html);
 
     NodeList cloneTree = deepClone(tree);
 
@@ -34,9 +31,7 @@ public class HtmlParserToolsTest {
 
   @Test
   public void shouldAlsoCloneAttributes() throws ParserException, CloneNotSupportedException {
-    String html = "<div class='foo'>funky <em>content</em></div>";
-    Parser parser = new Parser(new Lexer(new Page(html)));
-    NodeList tree = parser.parse(null);
+    NodeList tree = parseToTree("<div class='foo'>funky <em>content</em></div>");
 
     NodeList cloneTree = deepClone(tree);
 
@@ -49,13 +44,44 @@ public class HtmlParserToolsTest {
 
   @Test
   public void flatCloneShouldJustGiveACopyOfANode() throws ParserException {
-    String html = "<div class='foo'>funky <em>content</em></div>";
-    Parser parser = new Parser(new Lexer(new Page(html)));
-    NodeList tree = parser.parse(null);
+    NodeList tree = parseToTree("<div class='foo'>funky <em>content</em></div>");
 
     Node copy = flatClone(tree.elementAt(0));
 
     assertNull(copy.getParent());
     assertEquals(0, copy.getChildren().size());
+  }
+
+  @Test
+  public void hasClassShouldSayNoOnNoClasses() throws ParserException {
+    NodeList tree = parseToTree("<div>content</div>");
+
+    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+  }
+
+  @Test
+  public void hasClassShouldSayNoOnOtherClasses() throws ParserException {
+    NodeList tree = parseToTree("<div class='fooe foor'>content</div>");
+
+    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+  }
+
+  @Test
+  public void hasClassShouldSayYesWhenFound() throws ParserException {
+    NodeList tree = parseToTree("<div class='fooe foo foor'>content</div>");
+
+    assertTrue(nodeHasClass("foo", tree.elementAt(0)));
+  }
+
+  @Test
+  public void hasClassShouldSayNoForNonTagNode() throws ParserException {
+    NodeList tree = parseToTree("text node");
+
+    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+  }
+
+  private static NodeList parseToTree(String html) throws ParserException {
+    Parser parser = new Parser(new Lexer(new Page(html)));
+    return parser.parse(null);
   }
 }

--- a/test/fitnesse/util/HtmlParserToolsTest.java
+++ b/test/fitnesse/util/HtmlParserToolsTest.java
@@ -56,28 +56,28 @@ public class HtmlParserToolsTest {
   public void hasClassShouldSayNoOnNoClasses() throws ParserException {
     NodeList tree = parseToTree("<div>content</div>");
 
-    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+    assertFalse(nodeHasClass(tree.elementAt(0), "foo"));
   }
 
   @Test
   public void hasClassShouldSayNoOnOtherClasses() throws ParserException {
     NodeList tree = parseToTree("<div class='fooe foor'>content</div>");
 
-    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+    assertFalse(nodeHasClass(tree.elementAt(0), "foo"));
   }
 
   @Test
   public void hasClassShouldSayYesWhenFound() throws ParserException {
     NodeList tree = parseToTree("<div class='fooe foo foor'>content</div>");
 
-    assertTrue(nodeHasClass("foo", tree.elementAt(0)));
+    assertTrue(nodeHasClass(tree.elementAt(0), "foo"));
   }
 
   @Test
   public void hasClassShouldSayNoForNonTagNode() throws ParserException {
     NodeList tree = parseToTree("text node");
 
-    assertFalse(nodeHasClass("foo", tree.elementAt(0)));
+    assertFalse(nodeHasClass(tree.elementAt(0), "foo"));
   }
 
   private static NodeList parseToTree(String html) throws ParserException {

--- a/test/fitnesse/wikitext/parser/IncludeTest.java
+++ b/test/fitnesse/wikitext/parser/IncludeTest.java
@@ -119,10 +119,10 @@ public class IncludeTest {
   }
 
   @Test
-  public void teardownsAreHidden() throws Exception {
+  public void teardownsAreHiddenAndMarked() throws Exception {
     String result = ParserTestHelper.translateTo(makePageThatIncludesTeardown());
 
-    assertContains(result, "class=\"collapsible closed\"");
+    assertContains(result, "class=\"collapsible closed teardown\"");
     assertContains(result, "<a href=\"PageTwo.TearDown\">");
   }
 


### PR DESCRIPTION
closes #684 for slim testing system. 

Assumes fit system doesn't need this change as stop test/suite exceptions are slim-specific. 

For TearDown pages we marked them as such on inclusion during the wiki markup parsing. This flag is applied to the tables built from such page and carried all the way to the execution point at `fitnesse.testsystems.slim.SlimTestSystem#processTable`. 

SuiteTearDown is executed as a separate page by slim, so we can recognize it by the name, following the practices of `fitnesse.testrunner.WikiTestPage#isSuiteSetUpOrTearDownPage` and alike.
