### PR TITLE
Added Slim Hybrid Decision Table

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/ImplementDynamicDecisionTableWithHybridTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/ImplementDynamicDecisionTableWithHybridTable/content.txt
@@ -1,0 +1,34 @@
+|import            |
+|fitnesse.slim.test|
+
+!3 The Dynamic Decision Table is just a special case of the Hybrid Decision table.
+With the following rules for getter and setter the behavior of Dynamic Decision Tables is achieved.
+!define SLIM_DT_GETTER (!-
+{
+"FormatVersion":"1.0",
+"MethodExtractorRules":[
+  {
+    "Scope":".+",
+    "TargetName":"get",
+    "Parameters":"$0"
+  }
+ ]
+}
+-!)
+!define SLIM_DT_SETTER (!-
+{
+"FormatVersion":"1.0",
+"MethodExtractorRules":[
+  {
+    "Scope":".+",
+    "TargetName":"set",
+    "Parameters":"$0"
+  }
+ ]
+}
+-!)
+|dt: add up change                                                                                                          |
+|# description                           |1c         |5c|10c|25c|50c|$1|total cents?|$ total?                               |
+|some simple addition                    |2          |2 |4  |0  |0  |0 |52          |0.52                                   |
+|save the total cents in a symbol        |56         |0 |0  |0  |1  |20|$totalCents=|21.06                                  |
+|now use the total cents that were stored|$totalCents|0 |0  |0  |0  |10|3106        |~=31.1|An example for Value Comparisons|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/ImplementDynamicDecisionTableWithHybridTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/ImplementDynamicDecisionTableWithHybridTable/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/MethodExtractorRuleTest/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/MethodExtractorRuleTest/content.txt
@@ -1,0 +1,103 @@
+!*> Setup
+
+|import                          |
+|fitnesse.testsystems.slim.tables|
+
+!|scenario            |Test Json Method Extractor Configuration                  _ _ _ _|configuration, example column name, generated method name?,parameter list?|
+|start                |Method Extractor                                                 |@configuration                                                            |
+|$RR=                 |findRule                                                         |@exampleColumnName                                                        |
+|start                |$RR                                                                                                                                         |
+|$generatedMethodName=|getMethod Name                                                                                                                              |
+|$generatedMethodName=|get Disgraced Method Name                                                                                                                   |
+|$parameterList=      |getParameters                                                                                                                               |
+
+!|scenario            |Test Object Method Extractor Configuration                  _ _ _|example column name, generated method name?,parameter list?|
+|start                |$TestMethodExtractorConfiguration                                                                                            |
+|$RR=                 |findRule                                                         |@exampleColumnName                                         |
+|start                |$RR                                                                                                                          |
+|$generatedMethodName=|getMethod Name                                                                                                               |
+|$generatedMethodName=|get Disgraced Method Name                                                                                                    |
+|$parameterList=      |getParameters                                                                                                                |
+
+
+*!
+
+
+!3 Build a JSON configuration string
+
+!4 Hint: use this table to construct your Json expression.
+ 
+!|script                           |Method Extractor                                                        |
+|#                                 |Scope Pattern                               |Target Name |Parameter List|
+|add;                              |Cell\s+(\w+):(\d+)\s*                       |getRowColumn|$2,$1         |
+|# used a named group in the pattern                                                                        |
+|add;                              |Named\s+Cell\s+(?<column>\w+):(?<row>\d+)\s*|getRowColumn|$row,$column  |
+|# used a fixed value as parameter                                                                          |
+|add;                              |Header\s+Column\s+(\w+)\s*                  |getRowColumn|0,$1          |
+|# Default (match all pattern) catches every column name                                                    |
+|add;                              |.+                                          |set         |$0            |
+|# The first matching rule is used. The below will never be used as it comes after the default rule         |
+|add;                              |Last.*                                      |Unreachable |              |
+|show collapsed                    |to Json                                                                 |
+|$TestMethodExtractorConfiguration=|get fixture                                                             |
+
+!3 Test the above defined configuration
+
+!4 Hint: use this table to test your own definitions.
+
+|Test Object Method Extractor Configuration                 |
+|example column name|generated method name?|parameter list? |
+|hallo              |set                   |[hallo]         |
+|Cell A:5           |getRowColumn          |[5, A]          |
+|Named Cell BX:451  |getRowColumn          |[451, BX]       |
+|Header Column F    |getRowColumn          |[0, F]          |
+|Cell 7             |set                   |[Cell 7]        |
+|Last and Least     |set                   |[Last and Least]|
+
+
+!3 Test a JSON configuration string
+
+
+
+|Test Json Method Extractor Configuration|having|configuration|!-
+{
+"FormatVersion":"1.0",
+"MethodExtractorRules":[
+  {
+    "Scope":"char at (\\d)",
+    "TargetName":"char at",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":"index of '(\\w)'",
+    "TargetName":"index of",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":"Element\\s(\\d)",
+    "TargetName":"get",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":"property\\s+(\\w*)\\s*",
+    "TargetName":"get property",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":"has Value\\s+'(\\w*)'\\s*",
+    "TargetName":"contains Value",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":".+",
+    "TargetName":"set $0",
+    "Parameters":""
+  }
+ ]
+}
+-!|
+|example column name|generated method name?|parameter list?|
+|hallo              |setHallo              |[]             |
+|property abc       |getProperty           |[abc]          |
+|Element 5          |get                   |[5]            |
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/MethodExtractorRuleTest/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/MethodExtractorRuleTest/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/SetUp/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/SetUp/content.txt
@@ -1,0 +1,7 @@
+!|Import          |
+|fitnesse.fixtures|
+
+
+|Library     |
+|echo fixture|
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/SetUp/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/SetUp/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/TearDown/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/TearDown/content.txt
@@ -1,0 +1,3 @@
+Reset variables to get normal behaviour back.
+!define SLIM_DT_GETTER ()
+!define SLIM_DT_SETTER ()

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/TearDown/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/TearDown/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Help>Reset DT Getter and Setter variables</Help>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Static/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/content.txt
@@ -1,0 +1,109 @@
+
+The Hybrid Decision Table is a combination of the Decision Table  and the Dynamic Decision Table. 
+A decision table requires for each table column the definition of a method. 
+This is impractical when you deal with structured data that has a varying size like: hash maps, XML, properties, database tables, etc.
+The number of methods you need to write could be infinite.
+
+A dynamic decision table has just one method which is called for all columns and your fixture has to do the dispatching. 
+This solves the above problem but dispatching should be done by the test system and not by your fixture.
+
+Sometimes you want both features in one table and that is when you use the Hybrid Decision table.
+
+The Hybrid Decision Table allows the methods called for each column to be 
+redefined and method parameters can be extracted from the column names.
+
+
+
+Example
+
+!*>  Setup
+
+|import            |
+|fitnesse.slim.test|
+|java.util         |
+
+!5 define some string variables (just to show that this is supported)
+|script: Test Query|5                                  |
+|$S1=              |echo|abcdefghijklmnopqrstuvwxyz    |
+|$S2=              |echo|123456789                     |
+|$S3=              |echo|"The fox jumps over the wall."|
+
+!define SLIM_DT_GETTER (!-
+{
+"FormatVersion":"1.0",
+"MethodExtractorRules":[
+  {
+    "Scope":"property\\s+(\\w*)\\s*",
+    "TargetName":"get property",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":"has Value\\s+'(\\w*)'\\s*",
+    "TargetName":"contains Value",
+    "Parameters":"$1"
+  }
+ ]
+}
+-!)
+!define SLIM_DT_SETTER (!-
+{
+"FormatVersion":"1.0",
+"MethodExtractorRules":[
+  {
+    "Scope":"property\\s+(\\w*)\\s*",
+    "TargetName":"set property",
+    "Parameters":"$1"
+  },
+  {
+    "Scope":".+",
+    "TargetName":"$0",
+    "Parameters":""
+  }
+ ]
+}
+-!)
+
+*!
+
+!3 Based on your test cases you might expect or need to add a varying number of properties to a collection.
+!4 Test Case with 2 properties
+|Properties                                                                                                                                                                 |
+|#|property a|property b                    |size?|key set?|property a?|property b?|to string?                                                      |has Value '123456789' ?|
+| |$S1       |123456789                     |2    |[b, a]  |$S1        |123456789  |{b=123456789, a=abcdefghijklmnopqrstuvwxyz}                     |true                   |
+| |$S2       |"The fox jumps over the wall."|2    |[b, a]  |123456789  |$S3        |{b="The fox jumps over the wall.", a=123456789}                 |true                   |
+| |$S3       |abcdefghijklmnopqrstuvwxyz    |2    |[b, a]  |$S3        |$S1        |{b=abcdefghijklmnopqrstuvwxyz, a="The fox jumps over the wall."}|false                  |
+
+!4 Test Case with 3 properties added and 2 expected
+|Properties                                                                                                                                                                                                 |
+|#|property NEW|property a|property b|size?|key set?|property NEW?|property b?|to string?                                                                 |has Value '123456789' ?|has Value '!-FitNesse-!'?|
+| |Hello       |$S1       |$S2       |3    |        |Hello        |123456789  |                                                                           |true                   |false                    |
+| |!-FitNesse-!|$S2       |$S3       |3    |        |             |$S3        |                                                                           |true                   |true                     |
+| |World       |$S3       |$S1       |3    |        |World        |$S1        |{b=abcdefghijklmnopqrstuvwxyz, a="The fox jumps over the wall.", NEW=World}|false                  |false                    |
+
+
+!4 Look in the collapsed setup how the mapping between column names and method names is done.
+The magic is done with two variables:
+SLIM_DT_SETTER  -  for input columns
+SLIM_DT_GETTER  - for output columns
+
+For each variable you can define a list of ''Method Extractor Rules'' in JSON format. A Method Extractor Rule has 3 properties:
+1. Scope - a regular expression which identifies all columns for which this extractor should be applied.
+2. Target Name - a replacement string for the "Column Name" regular expression. This will be passed to the Disgracer to generate the final method name.
+3. Parameters - a colon separated list of parameters passed to the method called. 
+
+The list of rules is preceded with a version number ''Format Version''. This must currently be always "1.0". 
+Future versions might define additional features and will require a different version number. 
+
+If no Method Extractor Rule matches the current column name than the default rules of the Decision Table are used ("set " + column name).
+
+
+!3 The Hybrid Decision Table is no new table type but it modifies the behavior of the decision table with the help of the above variables.
+This has the advantage that you don't need to specify the table type in your test cases
+and leaves the decision to the implementer of the test cases if he wants to use a hybrid, dynamic or normal decision table.
+
+
+!4 IMPORTANT: to avoid side effects always add a >TearDown page to reset the mappings to the defaults.  
+
+
+Further Reading:
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/content.txt
@@ -1,4 +1,3 @@
-
 The Hybrid Decision Table is a combination of the Decision Table  and the Dynamic Decision Table. 
 A decision table requires for each table column the definition of a method. 
 This is impractical when you deal with structured data that has a varying size like: hash maps, XML, properties, database tables, etc.
@@ -96,13 +95,19 @@ Future versions might define additional features and will require a different ve
 
 If no Method Extractor Rule matches the current column name than the default rules of the Decision Table are used ("set " + column name).
 
-
-!3 The Hybrid Decision Table is no new table type but it modifies the behavior of the decision table with the help of the above variables.
+The Hybrid Decision Table is no new table type but it modifies the behavior of the decision table with the help of the above variables.
 This has the advantage that you don't need to specify the table type in your test cases
 and leaves the decision to the implementer of the test cases if he wants to use a hybrid, dynamic or normal decision table.
 
 
 !4 IMPORTANT: to avoid side effects always add a >TearDown page to reset the mappings to the defaults.  
+
+
+!2 Warning: The Hybrid Decision Table is still experimental
+The way how the method names are configured (via variables) might change.
+Be prepared to refactor your tests if you use this feature.
+Your ideas for a final solution are welcome please give feedback on the [[!-FitNesse-! mail group][https://groups.yahoo.com/neo/groups/fitnesse/info]]
+
 
 
 Further Reading:

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HybridDecisionTable/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
@@ -18,6 +18,7 @@ The first cell of a slim table tells you what kind of table it is. Here are the 
 
 | [[Decision Table][>DecisionTable]] | Supplies the inputs and outputs for decisions. This is similar to the Fit Column Fixture |
 | [[Dynamic Decision Table][>DynamicDecisionTable]] | Has the same syntax as a >DecisionTable, but passes the column headers as parameters to the fixture. |
+| [[Hybrid Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.HybridDecisionTable]]| Combines the advantages of a Decision and a Dynamic Decision Table.|
 | [[Query Table][>QueryTable]] | Supplies the expected results of a query. This is similar to the Fit Row Fixture |
 | [[Subset Query Table][>SubsetQueryTable]] | Supplies a subset of the expected results of a query. |
 | [[Ordered query Table][>OrderedQueryTable]] | Supplies the expected results of a query. The rows are expected to be in order. This is similar to the Fit Row Fixture |

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -40,15 +40,15 @@ public class DecisionTable extends SlimTable {
     if (scenario != null) {
       return new ScenarioCaller().call(scenario);
     } else {
-    	scenarioName =getFixtureName();
-    	scenario = getTestContext().getScenario(scenarioName);
-        if (scenario != null) {
-            return new ScenarioCallerWithConstuctorParameters().call(scenario);
-        }else{
-        	setterMethodExtractor = prepareMethodExtractorIfNull(setterMethodExtractor,"SLIM_DT_SETTER");
-        	getterMethodExtractor = prepareMethodExtractorIfNull(getterMethodExtractor,"SLIM_DT_GETTER");
-        	return new FixtureCaller().call(getFixtureName());
-        }
+      scenarioName =getFixtureName();
+      scenario = getTestContext().getScenario(scenarioName);
+      if (scenario != null) {
+        return new ScenarioCallerWithConstuctorParameters().call(scenario);
+      } else {
+       	setterMethodExtractor = prepareMethodExtractorIfNull(setterMethodExtractor,"SLIM_DT_SETTER");
+       	getterMethodExtractor = prepareMethodExtractorIfNull(getterMethodExtractor,"SLIM_DT_GETTER");
+       	return new FixtureCaller().call(getFixtureName());
+      }
     }
   }
 
@@ -156,8 +156,7 @@ public class DecisionTable extends SlimTable {
   }
 
   private class FixtureCaller extends DecisionTableCaller {
-
-	  public FixtureCaller() {
+    public FixtureCaller() {
       super(table);
     }
 
@@ -172,7 +171,6 @@ public class DecisionTable extends SlimTable {
       return assertions;
     }
 
-    
     private List<SlimAssertion> invokeRows() throws SyntaxError {
       List<SlimAssertion> assertions = new ArrayList<SlimAssertion>();
       assertions.add(callUnreportedFunction("beginTable", 0));
@@ -212,11 +210,11 @@ public class DecisionTable extends SlimTable {
       SlimAssertion assertion;
 
       Object[] args = new Object[] {};
- 	  MethodExtractorResult extractedGetter =  getterMethodExtractor.findRule(functionName);
-	  if(extractedGetter != null){
-	  	functionName = extractedGetter.methodName;
-    	args = extractedGetter.mergeParameters(args);
-	  }
+      MethodExtractorResult extractedGetter =  getterMethodExtractor.findRule(functionName);
+      if(extractedGetter != null){
+        functionName = extractedGetter.methodName;
+        args = extractedGetter.mergeParameters(args);
+      }
 
       if (assignedSymbol != null) {
         assertion = makeAssertion(callAndAssign(assignedSymbol, getTableName(), functionName, args),
@@ -233,17 +231,16 @@ public class DecisionTable extends SlimTable {
       for (String var : varStore.getLeftToRightAndResetColumnNumberIterator()) {
         int col = varStore.getColumnNumber(var);
         String valueToSet = table.getCellContents(col, row);
+
         Object[] args = new Object[] {valueToSet};
-        
    	    MethodExtractorResult extractedSetter =  setterMethodExtractor.findRule(var);
-	  	if(extractedSetter != null){
-	  	  var = extractedSetter.methodName;
-	  	  args = extractedSetter.mergeParameters(args);
-	  	}else{
-	  		// Default for Setter
-	  		var = "set " + var;
-	  	}
-	  	
+   	    if(extractedSetter != null){
+          var = extractedSetter.methodName;
+          args = extractedSetter.mergeParameters(args);
+          }else{
+            // Default for Setter
+            var = "set " + var;
+        }
 
         Instruction setInstruction = callFunction(getTableName(), var, args);
         assertions.add(makeAssertion(setInstruction,
@@ -251,6 +248,5 @@ public class DecisionTable extends SlimTable {
       }
       return assertions;
     }
-
   }
 }

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -15,10 +15,14 @@ import fitnesse.testsystems.slim.Table;
 
 public class DecisionTable extends SlimTable {
   private static final String instancePrefix = "decisionTable";
+  protected MethodExtractor setterMethodExtractor;
+  protected MethodExtractor getterMethodExtractor;
 
+  
   public DecisionTable(Table table, String id, SlimTestContext context) {
     super(table, id, context);
   }
+
 
   @Override
   protected String getTableType() {
@@ -38,11 +42,13 @@ public class DecisionTable extends SlimTable {
     } else {
     	scenarioName =getFixtureName();
     	scenario = getTestContext().getScenario(scenarioName);
-      if (scenario != null) {
-        return new ScenarioCallerWithConstuctorParameters().call(scenario);
-      } else {
-        return new FixtureCaller().call(getFixtureName());
-      }
+        if (scenario != null) {
+            return new ScenarioCallerWithConstuctorParameters().call(scenario);
+        }else{
+        	setterMethodExtractor = prepareMethodExtractorIfNull(setterMethodExtractor,"SLIM_DT_SETTER");
+        	getterMethodExtractor = prepareMethodExtractorIfNull(getterMethodExtractor,"SLIM_DT_GETTER");
+        	return new FixtureCaller().call(getFixtureName());
+        }
     }
   }
 
@@ -62,6 +68,24 @@ public class DecisionTable extends SlimTable {
     return callAndAssign(symbolName, getTableName(), functionName);
   }
 
+  private MethodExtractor prepareMethodExtractorIfNull(MethodExtractor current, String sourceVariableName) throws SyntaxError{
+  	
+  	if (current == null){
+  		String setterString = this.getTestContext().getPageToTest().getVariable(sourceVariableName);
+  		try{
+  		    if (setterString != null && !setterString.isEmpty() ) current = new MethodExtractor(setterString);
+  		    else{
+  		        current = new MethodExtractor();
+  		    }
+  			
+  		}catch (Exception cause ){
+  			SyntaxError sE =  new SyntaxError(sourceVariableName+ " variable could not be parsed:\n"+setterString+"\nCause:"+cause.getMessage());
+  			sE.initCause(cause);
+  			throw sE;
+  		}
+  	}
+  	return current;
+  }
 
   private class ScenarioCaller extends DecisionTableCaller {
     public ScenarioCaller() {
@@ -120,12 +144,6 @@ public class DecisionTable extends SlimTable {
         String valueToSet = table.getCellContents(col, row);
         scenarioArguments.put(disgracedVar, valueToSet);
       }
-//      for (String var : funcStore.getLeftToRightAndResetColumnNumberIterator()) {
-//          String disgracedVar = Disgracer.disgraceMethodName(var);
-//          int col = funcStore.getColumnNumber(var);
-//          String valueToSet = table.getCellContents(col, row);
-//          scenarioArguments.put(disgracedVar, valueToSet);
-//      }
       return scenarioArguments;
     }
   }
@@ -138,7 +156,8 @@ public class DecisionTable extends SlimTable {
   }
 
   private class FixtureCaller extends DecisionTableCaller {
-    public FixtureCaller() {
+
+	  public FixtureCaller() {
       super(table);
     }
 
@@ -153,6 +172,7 @@ public class DecisionTable extends SlimTable {
       return assertions;
     }
 
+    
     private List<SlimAssertion> invokeRows() throws SyntaxError {
       List<SlimAssertion> assertions = new ArrayList<SlimAssertion>();
       assertions.add(callUnreportedFunction("beginTable", 0));
@@ -190,11 +210,19 @@ public class DecisionTable extends SlimTable {
       int col = funcStore.getColumnNumber(functionName);
       String assignedSymbol = ifSymbolAssignment(col, row);
       SlimAssertion assertion;
+
+      Object[] args = new Object[] {};
+ 	  MethodExtractorResult extractedGetter =  getterMethodExtractor.findRule(functionName);
+	  if(extractedGetter != null){
+	  	functionName = extractedGetter.methodName;
+    	args = extractedGetter.mergeParameters(args);
+	  }
+
       if (assignedSymbol != null) {
-        assertion = makeAssertion(callAndAssign(assignedSymbol, functionName),
+        assertion = makeAssertion(callAndAssign(assignedSymbol, getTableName(), functionName, args),
                 new SymbolAssignmentExpectation(assignedSymbol, col, row));
       } else {
-        assertion = makeAssertion(callFunction(getTableName(), functionName),
+        assertion = makeAssertion(callFunction(getTableName(), functionName, args),
                 new ReturnedValueExpectation(col, row));
       }
       return assertion;
@@ -205,11 +233,24 @@ public class DecisionTable extends SlimTable {
       for (String var : varStore.getLeftToRightAndResetColumnNumberIterator()) {
         int col = varStore.getColumnNumber(var);
         String valueToSet = table.getCellContents(col, row);
-        Instruction setInstruction = new CallInstruction(makeInstructionTag(), getTableName(), Disgracer.disgraceMethodName("set " + var), new Object[] {valueToSet});
+        Object[] args = new Object[] {valueToSet};
+        
+   	    MethodExtractorResult extractedSetter =  setterMethodExtractor.findRule(var);
+	  	if(extractedSetter != null){
+	  	  var = extractedSetter.methodName;
+	  	  args = extractedSetter.mergeParameters(args);
+	  	}else{
+	  		// Default for Setter
+	  		var = "set " + var;
+	  	}
+	  	
+
+        Instruction setInstruction = callFunction(getTableName(), var, args);
         assertions.add(makeAssertion(setInstruction,
                 new VoidReturnExpectation(col, row)));
       }
       return assertions;
     }
+
   }
 }

--- a/src/fitnesse/testsystems/slim/tables/DynamicDecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DynamicDecisionTable.java
@@ -1,105 +1,22 @@
 package fitnesse.testsystems.slim.tables;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import fitnesse.slim.instructions.CallInstruction;
-import fitnesse.slim.instructions.Instruction;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.Table;
 
-public class DynamicDecisionTable extends SlimTable {
+public class DynamicDecisionTable extends DecisionTable {
   private static final String TABLE_TYPE = "dynamicDecisionTable";
 
   public DynamicDecisionTable(Table table, String id, SlimTestContext testContext) {
     super(table, id, testContext);
+    this.setterMethodExtractor = new MethodExtractor();
+    this.setterMethodExtractor.add(new MethodExtractorRule(".+", "set", "$0"));
+    this.getterMethodExtractor = new MethodExtractor();
+    this.getterMethodExtractor.add(new MethodExtractorRule(".+", "get", "$0"));
   }
 
   @Override
   protected String getTableType() {
     return TABLE_TYPE;
-  }
-
-  @Override
-  public List<SlimAssertion> getAssertions() throws SyntaxError {
-    if (table.getRowCount() == 2)
-      throw new SyntaxError("DynamicDecisionTables should have at least three rows.");
-    return new FixtureCaller().call(getFixtureName());
-  }
-
-  private class FixtureCaller extends DecisionTableCaller {
-    public FixtureCaller() {
-      super(table);
-    }
-
-    public List<SlimAssertion> call(String fixtureName) throws SyntaxError {
-      final List<SlimAssertion> assertions = new ArrayList<>();
-      assertions.add(constructFixture(fixtureName));
-      assertions.add(makeAssertion(
-              callFunction(getTableName(), "table", tableAsList()),
-              new SilentReturnExpectation(0, 0)));
-      if (table.getRowCount() > 2)
-        assertions.addAll(invokeRows());
-      return assertions;
-    }
-
-    private List<SlimAssertion> invokeRows() throws SyntaxError {
-      List<SlimAssertion> assertions = new ArrayList<>();
-      assertions.add(callUnreportedFunction("beginTable", 0));
-      gatherFunctionsAndVariablesFromColumnHeader();
-      for (int row = 2; row < table.getRowCount(); row++)
-        assertions.addAll(invokeRow(row));
-      assertions.add(callUnreportedFunction("endTable", 0));
-      return assertions;
-    }
-
-    private List<SlimAssertion> invokeRow(int row) throws SyntaxError {
-      List<SlimAssertion> assertions = new ArrayList<>();
-      checkRow(row);
-      assertions.add(callUnreportedFunction("reset", row));
-      assertions.addAll(callSetForVariables(row));
-      assertions.add(callUnreportedFunction("execute", row));
-      assertions.addAll(callGetForFunctions(row));
-      return assertions;
-    }
-
-    private SlimAssertion callUnreportedFunction(String functionName, int row) {
-      return makeAssertion(callFunction(getTableName(), functionName),
-              new SilentReturnExpectation(0, row));
-    }
-
-    private List<SlimAssertion> callGetForFunctions(int row) {
-      List<SlimAssertion> instructions = new ArrayList<>();
-      for (String functionName : funcStore.getLeftToRightAndResetColumnNumberIterator()) {
-        instructions.add(callGetForFunctionInRow(functionName, row));
-      }
-      return instructions;
-    }
-
-    private SlimAssertion callGetForFunctionInRow(String functionName, int row) {
-      int col = funcStore.getColumnNumber(functionName);
-      String assignedSymbol = ifSymbolAssignment(col, row);
-      SlimAssertion assertion;
-      if (assignedSymbol != null) {
-        assertion = makeAssertion(callAndAssign(assignedSymbol, getTableName(), "get", functionName),
-                new SymbolAssignmentExpectation(assignedSymbol, col, row));
-      } else {
-        assertion = makeAssertion(callFunction(getTableName(), "get", functionName),
-                new ReturnedValueExpectation(col, row));
-      }
-      return assertion;
-    }
-
-    private List<SlimAssertion> callSetForVariables(int row) {
-      List<SlimAssertion> assertions = new ArrayList<>();
-      for (String var : varStore.getLeftToRightAndResetColumnNumberIterator()) {
-        int col = varStore.getColumnNumber(var);
-        String valueToSet = table.getCellContents(col, row);
-        Instruction setInstruction = new CallInstruction(makeInstructionTag(), getTableName(), "set", new Object[] {var, valueToSet});
-        assertions.add(makeAssertion(setInstruction, new VoidReturnExpectation(col, row)));
-      }
-      return assertions;
-    }
   }
 
 }

--- a/src/fitnesse/testsystems/slim/tables/MethodExtractor.java
+++ b/src/fitnesse/testsystems/slim/tables/MethodExtractor.java
@@ -34,12 +34,6 @@ public class MethodExtractor{
 		}
 	}
 
-	public MethodExtractor(
-			ArrayList<MethodExtractorRule> configurations) {
-		super();
-		this.configurations = configurations;
-	}
-	
 	public boolean add(String scope, String targetName, String parameters){
 		return add(new MethodExtractorRule(scope, targetName, parameters));
 	}

--- a/src/fitnesse/testsystems/slim/tables/MethodExtractor.java
+++ b/src/fitnesse/testsystems/slim/tables/MethodExtractor.java
@@ -1,0 +1,82 @@
+package fitnesse.testsystems.slim.tables;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class MethodExtractor{
+	private final String version = "1.0";
+	
+	private final ArrayList<MethodExtractorRule> configurations;
+
+	public MethodExtractor() {
+		super();
+		this.configurations = new ArrayList<MethodExtractorRule>();
+	}
+	
+	public MethodExtractor(String configString) {
+		super();
+		this.configurations = new ArrayList<MethodExtractorRule>();
+		
+			JSONObject jo = new JSONObject(configString);
+		
+		String fV= jo.getString("FormatVersion");
+		if (!version.equals(fV)) throw new IllegalArgumentException("JSON Mesage has version '" + fV + "'. This class expects version '"+ version +"'." );
+		JSONArray configList = jo.getJSONArray("MethodExtractorRules");
+		for (int i=0;i< configList.length(); i++){
+			JSONObject config = configList.getJSONObject(i);
+			String scopePattern = config.getString("Scope");
+			String methodName = config.getString("TargetName");
+			String parameterNames = config.getString("Parameters");
+			add(new MethodExtractorRule(scopePattern, methodName, parameterNames));
+		}
+	}
+
+	public MethodExtractor(
+			ArrayList<MethodExtractorRule> configurations) {
+		super();
+		this.configurations = configurations;
+	}
+	
+	public boolean add(String scope, String targetName, String parameters){
+		return add(new MethodExtractorRule(scope, targetName, parameters));
+	}
+	
+	public boolean add(MethodExtractorRule config){
+		return configurations.add(config);
+	}
+	
+
+	public MethodExtractorResult findRule(String methodName){
+		for(int i=0; i< configurations.size(); i++){
+			  Matcher m = configurations.get(i).matcher(methodName);
+			  if(m.matches()){
+				  // The order of the next two lines is important. Don't change it
+				  ArrayList<String>  parameterObjects = configurations.get(i).getParameterList(m);
+				  methodName = configurations.get(i).getMethodName(m);
+				  return new MethodExtractorResult(methodName, parameterObjects);	
+			  }
+		}
+		return null;
+	}
+	public String toString(){
+		StringBuilder sb = new StringBuilder("ME:[");
+		for(int i=0; i< configurations.size(); i++){
+			sb.append( configurations.get(i).toString());
+		}
+		sb.append("]");
+		return sb.toString();
+	}
+
+	public String toJson(){
+		StringBuilder sb = new StringBuilder("{\n\"FormatVersion\":\""+version+"\",\n\"MethodExtractorRules\":[\n");
+		for(int i=0; i< configurations.size(); i++){
+			if(i>0)sb.append(", ");
+			sb.append( configurations.get(i).toJson());
+		}
+		sb.append("]\n}\n");
+		return sb.toString();
+	}
+}

--- a/src/fitnesse/testsystems/slim/tables/MethodExtractorResult.java
+++ b/src/fitnesse/testsystems/slim/tables/MethodExtractorResult.java
@@ -1,0 +1,35 @@
+package fitnesse.testsystems.slim.tables;
+
+import java.util.ArrayList;
+
+public final class MethodExtractorResult{
+		public final String methodName;
+		public final ArrayList<String> parameterNames;
+
+		public MethodExtractorResult(String methodName,
+				ArrayList<String> parameterNames) {
+			this.methodName = methodName;
+			this.parameterNames = parameterNames;
+		}
+		public String toString(){
+			return methodName + ":" + parameterNames.toString();
+		}
+		public String getDisgracedMethodName(){
+			return Disgracer.disgraceMethodName(methodName);
+		}
+		public String getMethodName(){
+			return methodName;
+		}
+		public String getParameters(){
+			return parameterNames.toString();
+		}
+		
+		public Object[] mergeParameters(Object[] args) {
+			Object[] newArgs = new Object[parameterNames.size()+args.length];
+		  	  for (int i=0; i< parameterNames.size();i++) newArgs[i] = parameterNames.get(i);
+		  	  for (int i=0; i< args.length;i++) newArgs[i+ parameterNames.size()] = args[i];
+		  	  args = newArgs;
+			return args;
+		}
+
+}

--- a/src/fitnesse/testsystems/slim/tables/MethodExtractorRule.java
+++ b/src/fitnesse/testsystems/slim/tables/MethodExtractorRule.java
@@ -1,0 +1,92 @@
+package fitnesse.testsystems.slim.tables;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONWriter;
+
+public class MethodExtractorRule {
+	private final String scopePattern;
+	private final String methodNamePattern;
+	private final String parameterListString;
+	private final String[] parameterList;
+	
+	private final Pattern scope;
+	
+	public MethodExtractorRule(String scopePattern,
+			String methodNamePattern, String parameterList) {
+		super();
+		this.scopePattern = scopePattern;
+		this.methodNamePattern = methodNamePattern;
+		this.parameterListString = parameterList;
+		
+		this.parameterList = getParameterList().split(",");
+		this.scope = Pattern.compile(this.scopePattern);
+		
+	}
+	public String getScopePattern() {
+		return scopePattern;
+	}
+	public String getMethodNamePattern() {
+		return methodNamePattern;
+	}
+	public String getParameterList() {
+		return parameterListString;
+	}
+	
+	// For Testing Only
+	//public  MethodExtractor createDisgracerConfiguration(String jsonString){
+	//	if (jsonString == null) return new MethodExtractor();
+	//	else return new MethodExtractor(jsonString);
+	//}
+	
+	public Matcher matcher(String methodName){
+		return scope.matcher(methodName);
+	}
+
+	public ArrayList<String> getParameterList(Matcher m){
+		  ArrayList<String>  parameterObjects = new ArrayList<String>();
+		  for (int i=0; i< parameterList.length; i++){
+			  if (!parameterList[i].isEmpty()){
+				  String parameter =parameterList[i]; 
+				  if(parameter.startsWith("$")){
+					  String groupName = parameter.substring(1);
+					  try{
+						  int groupID = Integer.parseInt(groupName);
+						  parameterObjects.add( m.group(groupID));
+					  }catch (NumberFormatException e){
+						  // if it is not a number than it must be a named group
+						  parameterObjects.add(m.group(groupName));
+					  }
+				  }
+				  else{
+					  parameterObjects.add(parameter);
+				  }
+			  }
+		  }
+		  return parameterObjects;
+		
+	}
+	public String getMethodName(Matcher m) {
+		
+		return m.replaceAll(getMethodNamePattern());
+	}
+	
+	public String toString(){
+		return "Scope:"+ scopePattern + ";TargetName:"+methodNamePattern+";Parameters:"+parameterListString;
+	}
+	
+	public StringBuilder toJson(){
+		StringBuilder sb = new StringBuilder("{\n\"Scope\":\"");
+		sb.append(getScopePattern().replaceAll("\\\\", "\\\\\\\\"));
+		sb.append("\",\n\"TargetName\":\"");
+		sb.append(getMethodNamePattern().replaceAll("\\\\", "\\\\\\\\"));
+		sb.append("\",\n\"Parameters\":\"");
+		sb.append(getParameterList().replaceAll("\\\\", "\\\\\\\\"));
+		sb.append("\"\n}\n");
+		return sb;
+		
+	}
+
+}

--- a/src/fitnesse/testsystems/slim/tables/MethodExtractorRule.java
+++ b/src/fitnesse/testsystems/slim/tables/MethodExtractorRule.java
@@ -35,12 +35,6 @@ public class MethodExtractorRule {
 		return parameterListString;
 	}
 	
-	// For Testing Only
-	//public  MethodExtractor createDisgracerConfiguration(String jsonString){
-	//	if (jsonString == null) return new MethodExtractor();
-	//	else return new MethodExtractor(jsonString);
-	//}
-	
 	public Matcher matcher(String methodName){
 		return scope.matcher(methodName);
 	}

--- a/test/fitnesse/testsystems/slim/tables/MethodExtractorRuleTest.java
+++ b/test/fitnesse/testsystems/slim/tables/MethodExtractorRuleTest.java
@@ -1,0 +1,64 @@
+package fitnesse.testsystems.slim.tables;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MethodExtractorRuleTest {
+
+	
+	@Test
+	public void JasonConfigurationParser() {
+		MethodExtractor cf = new MethodExtractor();
+		cf.add(new MethodExtractorRule("abc", "set price", "$2,$1"));
+		cf.add(new MethodExtractorRule("(...)/(...)\\s+fixing", "set price", "$2,$1"));
+		cf.add(new MethodExtractorRule("Cell (\\d+):(\\d+)", "goto", "$1,$2"));
+		cf.add(new MethodExtractorRule("Country\\s+(\\w+)\\s+City\\s+(\\w+)", "geo $1", "$2"));
+		cf.add(new MethodExtractorRule("age\\s+(?<person>\\w+)", "setAge $1", "$person"));
+		cf.add(new MethodExtractorRule(".+", "set $0", ""));
+		String cfString=cf.toJson();
+		System.out.println(cfString);
+		MethodExtractor cf2 = new MethodExtractor(cfString);
+		assertEquals("JSON Objects must match",cfString, cf2.toJson());
+
+		assertEquals("set method Name:[]",cf2.findRule("method Name").toString());
+		assertEquals("set price:[USD, EUR]",cf2.findRule("EUR/USD fixing").toString());
+		assertEquals("goto:[4, 8]",cf2.findRule("Cell 4:8").toString());
+		assertEquals("goto:[9, 2]",cf2.findRule("Cell 9:2").toString());
+		assertEquals("geo US:[LA]",cf2.findRule("Country US City LA").toString());
+		assertEquals("geo NL:[Amsterdam]",cf2.findRule("Country        NL     City 		Amsterdam").toString());
+		assertEquals("setAge Lucy:[Lucy]",cf2.findRule("age Lucy").toString());
+		
+	}
+		@Test
+	  public void DynamicDecisionTableSetter() {
+		MethodExtractor cf = new MethodExtractor();
+		cf.add(new MethodExtractorRule(".+", "set", "$0"));
+		assertEquals("set:[method Name]",cf.findRule("method Name").toString());
+	}			
+	@Test
+	public void DecisionTableSetter() {
+		MethodExtractor cf = new MethodExtractor();
+		cf.add(new MethodExtractorRule(".+", "set $0", ""));
+		assertEquals("set method Name:[]",cf.findRule("method Name").toString());
+	}
+	
+	@Test
+	public void HybridTableSetter() {
+		MethodExtractor cf = new MethodExtractor();
+		cf.add(new MethodExtractorRule("(...)/(...)\\s+fixing", "set price", "$2,$1"));
+		cf.add(new MethodExtractorRule("Cell (\\d+):(\\d+)", "goto", "$1,$2"));
+		cf.add(new MethodExtractorRule("Country\\s+(\\w+)\\s+City\\s+(\\w+)", "geo $1", "$2"));
+		cf.add(new MethodExtractorRule("age\\s+(?<person>\\w+)", "setAge $1", "$person"));
+		cf.add(new MethodExtractorRule("man\\s+(?<person>\\w+)", "setAge $1", "MR,$person"));
+		cf.add(new MethodExtractorRule(".+", "set $0", ""));
+		assertEquals("set method Name:[]",cf.findRule("method Name").toString());
+		assertEquals("set price:[USD, EUR]",cf.findRule("EUR/USD fixing").toString());
+		assertEquals("goto:[4, 8]",cf.findRule("Cell 4:8").toString());
+		assertEquals("goto:[9, 2]",cf.findRule("Cell 9:2").toString());
+		assertEquals("geo US:[LA]",cf.findRule("Country US City LA").toString());
+		assertEquals("geo NL:[Amsterdam]",cf.findRule("Country        NL     City 		Amsterdam").toString());
+		assertEquals("setAge Lucy:[MR, Lucy]",cf.findRule("man Lucy").toString());
+		
+	  }
+}


### PR DESCRIPTION
The Hybrid Decision Table is a combination of the Decision Table and the Dynamic Decision Table.
A decision table requires for each table column the definition of a method.
This is impractical when you deal with structured data that has a varying size like: hash maps, XML, properties, database tables, etc.
The number of methods you need to write could be infinite.

A dynamic decision table has just one method which is called for all columns and your fixture has to do the dispatching.
This solves the above problem but dispatching should be done by the test system and not by your fixture.

Sometimes you want both features in one table and that is when you use the Hybrid Decision table.

The Hybrid Decision Table allows the methods called for each column to be
redefined and method parameters can be extracted from the column names.

This PR also cleans up the code as the Dynamic Decision Table is now just a special cases of the Decision Table 