### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Issues and pull requests are administered at [GitHub](https://github.com/unclebo
 
 ### Building
 
-[Apache Ant](http://ant.apache.org/) and a proper internet connection is sufficient to build FitNesse. The build process will bootstrap itself by downloading Ivy (dependency management) and from there will download the modules required to build and test FitNesse.
+A proper internet connection is sufficient to build FitNesse. The build process will bootstrap itself by downloading [Gradle](http://gradle.org) and from there will download the dependencies required to build and test FitNesse.
 
 To build and run all tests, run the command
 


### PR DESCRIPTION
Now that ant+ivy is replaced by gradle, update description to reflect this.

Could potentially be reprashed some more I guess, but at least updated to match the recent changes.