### PR TITLE
Expose wiki page to jUnit listeners

### DIFF
--- a/src/fitnesse/junit/DescriptionFactory.java
+++ b/src/fitnesse/junit/DescriptionFactory.java
@@ -1,5 +1,7 @@
 package fitnesse.junit;
 
+import java.lang.annotation.Annotation;
+
 import fitnesse.testsystems.TestPage;
 import fitnesse.wiki.WikiPage;
 import org.junit.runner.Description;
@@ -26,7 +28,8 @@ public class DescriptionFactory {
    */
   public Description createDescription(Class<?> clazz, WikiPage page) {
     String name = page.getPageCrawler().getFullPath().toString();
-    return createDescription(clazz, name);
+    FitNessePageAnnotation wikiPageAnnotation = new FitNessePageAnnotation(page);
+    return createDescription(clazz, name, wikiPageAnnotation);
   }
 
   /**
@@ -38,10 +41,11 @@ public class DescriptionFactory {
    */
   public Description createDescription(Class<?> clazz, TestPage page) {
     String name = page.getFullPath();
-    return createDescription(clazz, name);
+    FitNessePageAnnotation wikiPageAnnotation = new FitNessePageAnnotation(page);
+    return createDescription(clazz, name, wikiPageAnnotation);
   }
 
-  private Description createDescription(Class<?> clazz, String name) {
-    return Description.createTestDescription(clazz, name);
+  private Description createDescription(Class<?> clazz, String name, Annotation... annotations) {
+    return Description.createTestDescription(clazz, name, annotations);
   }
 }

--- a/src/fitnesse/junit/DescriptionFactory.java
+++ b/src/fitnesse/junit/DescriptionFactory.java
@@ -1,0 +1,47 @@
+package fitnesse.junit;
+
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.WikiPage;
+import org.junit.runner.Description;
+
+/**
+ * Factory to create jUnit test Descriptions.
+ */
+public class DescriptionFactory {
+  /**
+   * Creates Description for suite.
+   * @param clazz class defining suite.
+   * @return description.
+   */
+  public Description createSuiteDescription(Class<?> clazz) {
+    return Description.createSuiteDescription(clazz);
+  }
+
+  /**
+   * Creates description for a wiki page being run from a jUnit class.
+   *
+   * @param clazz class triggering page.
+   * @param page  page to be executed.
+   * @return description.
+   */
+  public Description createDescription(Class<?> clazz, WikiPage page) {
+    String name = page.getPageCrawler().getFullPath().toString();
+    return createDescription(clazz, name);
+  }
+
+  /**
+   * Creates description for a wiki page being run from a jUnit class.
+   *
+   * @param clazz class triggering page.
+   * @param page  page to be executed.
+   * @return description.
+   */
+  public Description createDescription(Class<?> clazz, TestPage page) {
+    String name = page.getFullPath();
+    return createDescription(clazz, name);
+  }
+
+  private Description createDescription(Class<?> clazz, String name) {
+    return Description.createTestDescription(clazz, name);
+  }
+}

--- a/src/fitnesse/junit/DescriptionHelper.java
+++ b/src/fitnesse/junit/DescriptionHelper.java
@@ -1,0 +1,76 @@
+package fitnesse.junit;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import org.apache.commons.lang.StringUtils;
+import org.junit.runner.Description;
+
+/**
+ * Helper to deal with jUnit descriptions.
+ */
+public class DescriptionHelper {
+  // private constructor to  prevent instances from being made
+  private DescriptionHelper() {
+  }
+
+  /**
+   * @param description description of current test.
+   * @return current wiki page (null if no wiki page was found in description)
+   */
+  public static WikiPage getWikiPage(Description description) {
+    WikiPage result = null;
+    FitNessePageAnnotation pageAnn = description.getAnnotation(FitNessePageAnnotation.class);
+    if (pageAnn != null) {
+      result = pageAnn.getWikiPage();
+    }
+    return result;
+  }
+
+  /**
+   * @param description description of current test.
+   * @return current test page (null if no test page was found in description)
+   */
+  public static TestPage getTestPage(Description description) {
+    TestPage result = null;
+    FitNessePageAnnotation pageAnn = description.getAnnotation(FitNessePageAnnotation.class);
+    if (pageAnn != null) {
+      result = pageAnn.getTestPage();
+    }
+    return result;
+  }
+
+  /**
+   * @param description description of current test.
+   * @return tags for current wiki page (empty list if none)
+   */
+  public static List<String> getPageTags(Description description) {
+    List<String> result = Collections.emptyList();
+    WikiPage wikiPage = getWikiPage(description);
+    if (wikiPage != null) {
+      result = getPageTags(wikiPage);
+    }
+    return result;
+  }
+
+  /**
+   * @param page page to get tags for
+   * @return tags of the wiki page.
+   */
+  public static List<String> getPageTags(WikiPage page) {
+    List<String> result = Collections.emptyList();
+
+    PageData data = page.getData();
+    if (data != null) {
+      String suitesValue = StringUtils.stripToNull(data.getProperties().get(PageData.PropertySUITES));
+      if (suitesValue != null) {
+        result = Arrays.asList(suitesValue.split("\\s*,\\s*"));
+      }
+    }
+    return result;
+  }
+}

--- a/src/fitnesse/junit/FitNessePageAnnotation.java
+++ b/src/fitnesse/junit/FitNessePageAnnotation.java
@@ -1,0 +1,58 @@
+package fitnesse.junit;
+
+import java.lang.annotation.Annotation;
+
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.WikiPage;
+
+/**
+ * Annotation used to pass FitNesse page information to test listeners.
+ */
+public class FitNessePageAnnotation implements Annotation {
+  private final TestPage testPage;
+  private final WikiPage wikiPage;
+
+  /**
+   * Creates new.
+   *
+   * @param wikiPage page describing test.
+   */
+  public FitNessePageAnnotation(WikiPage wikiPage) {
+    this.testPage = null;
+    this.wikiPage = wikiPage;
+  }
+
+  /**
+   * Creates new.
+   *
+   * @param testPage page describing test.
+   */
+  public FitNessePageAnnotation(TestPage testPage) {
+    this.testPage = testPage;
+    if (testPage instanceof WikiTestPage) {
+      wikiPage = ((WikiTestPage) testPage).getSourcePage();
+    } else {
+      this.wikiPage = null;
+    }
+  }
+
+  /**
+   * @return wiki page for current test.
+   */
+  public WikiPage getWikiPage() {
+    return wikiPage;
+  }
+
+  /**
+   * @return current test page.
+   */
+  public TestPage getTestPage() {
+    return testPage;
+  }
+
+  @Override
+  public Class<? extends FitNessePageAnnotation> annotationType() {
+    return FitNessePageAnnotation.class;
+  }
+}

--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -161,11 +161,13 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   private String excludeSuiteFilter;
   private boolean debugMode;
   private boolean preventSystemExit;
-   private FitNesseContext context;
+  private FitNesseContext context;
+  private DescriptionFactory descriptionFactory;
   private List<WikiPage> children;
 
   public FitNesseRunner(Class<?> suiteClass) throws InitializationError {
     super(suiteClass);
+    descriptionFactory = new DescriptionFactory();
   }
 
   @Override
@@ -359,7 +361,7 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
 
   @Override
   protected Description describeChild(WikiPage child) {
-    return Description.createTestDescription(suiteClass, child.getPageCrawler().getFullPath().toString());
+    return getDescriptionFactory().createDescription(suiteClass, child);
   }
 
   @Override
@@ -390,18 +392,20 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
 
   protected void runPages(List<WikiPage>pages, final RunNotifier notifier) {
     MultipleTestsRunner testRunner = createTestRunner(pages);
-    addTestSystemListeners(notifier, testRunner, suiteClass);
+    addTestSystemListeners(notifier, testRunner, suiteClass, getDescriptionFactory());
     addExecutionLogListener(notifier, testRunner, suiteClass);
     System.setProperty(SystemExitSecurityManager.PREVENT_SYSTEM_EXIT, String.valueOf(preventSystemExit));
     try {
       executeTests(testRunner);
     } catch (AssertionError | Exception e) {
-      notifier.fireTestFailure(new Failure(Description.createSuiteDescription(suiteClass), e));
+      Description description = getDescriptionFactory().createSuiteDescription(suiteClass);
+      notifier.fireTestFailure(new Failure(description, e));
     }
   }
 
-  protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
-    testRunner.addTestSystemListener(new JUnitRunNotifierResultsListener(notifier, suiteClass));
+  protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass,
+                                        DescriptionFactory descriptionFactory) {
+    testRunner.addTestSystemListener(new JUnitRunNotifierResultsListener(notifier, suiteClass, descriptionFactory));
   }
 
   protected void addExecutionLogListener(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
@@ -482,5 +486,13 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
     List<WikiPage> list = new ArrayList<>(1);
     list.add(page);
     return list;
+  }
+
+  public DescriptionFactory getDescriptionFactory() {
+    return descriptionFactory;
+  }
+
+  public void setDescriptionFactory(DescriptionFactory descriptionFactory) {
+    this.descriptionFactory = descriptionFactory;
   }
 }

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -50,18 +50,15 @@ public class JUnitRunNotifierResultsListener
   @Override
   public void testComplete(TestPage test, TestSummary testSummary) {
     increaseCompletedTests();
+    Description description = descriptionFor(test);
     if (firstFailure != null) {
-      notifier.fireTestFailure(new Failure(descriptionFor(test), firstFailure));
+      notifier.fireTestFailure(new Failure(description, firstFailure));
     } else if (testSummary.getExceptions() > 0) {
-      notifier.fireTestFailure(new Failure(descriptionFor(test), new Exception("Exception occurred on page " + test.getFullPath())));
+      notifier.fireTestFailure(new Failure(description, new Exception("Exception occurred on page " + test.getFullPath())));
     } else if (testSummary.getWrong() > 0) {
-      notifier.fireTestFailure(new Failure(descriptionFor(test), new AssertionError("Test failures occurred on page " + test.getFullPath())));
+      notifier.fireTestFailure(new Failure(description, new AssertionError("Test failures occurred on page " + test.getFullPath())));
     }
-    fireTestFinishedFor(test);
-  }
-
-  private void fireTestFinishedFor(TestPage test) {
-    notifier.fireTestFinished(descriptionFor(test));
+    notifier.fireTestFinished(description);
   }
 
   @Override

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -20,13 +20,15 @@ public class JUnitRunNotifierResultsListener
 
   private final Class<?> mainClass;
   private final RunNotifier notifier;
+  private final DescriptionFactory descriptionFactory;
   private int totalNumberOfTests;
   private int completedTests;
   private Throwable firstFailure;
 
-  public JUnitRunNotifierResultsListener(RunNotifier notifier, Class<?> mainClass) {
+  public JUnitRunNotifierResultsListener(RunNotifier notifier, Class<?> mainClass, DescriptionFactory descriptionFactory) {
     this.notifier = notifier;
     this.mainClass = mainClass;
+    this.descriptionFactory = descriptionFactory;
   }
 
   @Override
@@ -97,19 +99,23 @@ public class JUnitRunNotifierResultsListener
               "Not all tests executed. Completed %s of %s tests.",
               completedTests, totalNumberOfTests);
       Exception e = new Exception(msg);
-      notifier.fireTestFailure(new Failure(Description.createSuiteDescription(mainClass), e));
+      notifier.fireTestFailure(new Failure(suiteDescription(), e));
     }
   }
 
   protected void notifyOfTestSystemException(String testSystemName, Throwable cause) {
     if (cause != null) {
       Exception e = new Exception("Exception while executing tests using: " + testSystemName, cause);
-      notifier.fireTestFailure(new Failure(Description.createSuiteDescription(mainClass), e));
+      notifier.fireTestFailure(new Failure(suiteDescription(), e));
     }
   }
 
-  private Description descriptionFor(TestPage test) {
-    return Description.createTestDescription(mainClass, test.getFullPath());
+  private Description suiteDescription() {
+    return getDescriptionFactory().createSuiteDescription(getMainClass());
+  }
+
+  protected Description descriptionFor(TestPage test) {
+    return getDescriptionFactory().createDescription(getMainClass(), test);
   }
 
   String createMessage(TestResult testResult) {
@@ -142,6 +148,10 @@ public class JUnitRunNotifierResultsListener
 
   public RunNotifier getNotifier() {
     return notifier;
+  }
+
+  public DescriptionFactory getDescriptionFactory() {
+    return descriptionFactory;
   }
 
   public int getTotalNumberOfTests() {

--- a/test/fitnesse/junit/DescriptionFactoryTest.java
+++ b/test/fitnesse/junit/DescriptionFactoryTest.java
@@ -1,0 +1,41 @@
+package fitnesse.junit;
+
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.WikiPage;
+import org.junit.Test;
+import org.junit.runner.Description;
+
+import static org.junit.Assert.*;
+
+public class DescriptionFactoryTest {
+  private DescriptionFactory descriptionFactory = new DescriptionFactory();
+
+  @Test
+  public void testCreateWithWikiTestPage() {
+    WikiTestPage page = mockWikiTestPage();
+    Description desc = descriptionFactory.createDescription(getClass(), page);
+
+    assertNotNull(desc);
+    assertEquals("WikiPage(fitnesse.junit.DescriptionFactoryTest)", desc.getDisplayName());
+
+    TestPage pageFound = DescriptionHelper.getTestPage(desc);
+    assertSame(page, pageFound);
+
+    WikiPage wikiPageFound = DescriptionHelper.getWikiPage(desc);
+    assertSame(page.getSourcePage(), wikiPageFound);
+  }
+
+  @Test
+  public void testCreateWithWikiPage() {
+    WikiPage page = mockWikiTestPage().getSourcePage();
+    Description desc = descriptionFactory.createDescription(getClass(), page);
+
+    assertNotNull(desc);
+    assertEquals("WikiPage(fitnesse.junit.DescriptionFactoryTest)", desc.getDisplayName());
+  }
+
+  private WikiTestPage mockWikiTestPage() {
+    return JUnitRunNotifierResultsListenerTest.mockWikiTestPage();
+  }
+}

--- a/test/fitnesse/junit/DescriptionHelperTest.java
+++ b/test/fitnesse/junit/DescriptionHelperTest.java
@@ -1,0 +1,52 @@
+package fitnesse.junit;
+
+import java.util.Arrays;
+
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import org.junit.Test;
+import org.junit.runner.Description;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class DescriptionHelperTest {
+  private DescriptionFactory descriptionFactory = new DescriptionFactory();
+
+  @Test
+  public void testNormalDescription() {
+    Description description = Description.EMPTY;
+    WikiPage pageFound = DescriptionHelper.getWikiPage(description);
+
+    assertNull(pageFound);
+  }
+
+  @Test
+  public void testGetWikiPageNoPageData() {
+    WikiPage page = mockWikiTestPage().getSourcePage();
+    Description desc = descriptionFactory.createDescription(getClass(), page);
+
+    WikiPage pageFound = DescriptionHelper.getWikiPage(desc);
+    assertSame(page, pageFound);
+
+    assertEquals(0, DescriptionHelper.getPageTags(pageFound).size());
+  }
+
+  @Test
+  public void testGetWikiPageWithTags() {
+    WikiPage page = mockWikiTestPage().getSourcePage();
+    page.getData().getProperties().set(PageData.PropertySUITES, " First , Second, Third,Fourth,Fifth ");
+    Description desc = descriptionFactory.createDescription(getClass(), page);
+
+    WikiPage pageFound = DescriptionHelper.getWikiPage(desc);
+    assertSame(page, pageFound);
+
+    assertEquals(Arrays.asList("First", "Second", "Third", "Fourth", "Fifth"),
+                  DescriptionHelper.getPageTags(pageFound));
+  }
+
+  private WikiTestPage mockWikiTestPage() {
+    return JUnitRunNotifierResultsListenerTest.mockWikiTestPage();
+  }
+}

--- a/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
+++ b/test/fitnesse/junit/FitNesseRunnerExtensionTest.java
@@ -8,19 +8,30 @@ import org.junit.runner.RunWith;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(FitNesseRunnerExtensionTest.SuiteExtension.class)
 @FitNesseRunner.FitnesseDir(".")
 @FitNesseRunner.OutputDir("./build/fitnesse-results")
 public class FitNesseRunnerExtensionTest {
 
   public static class SuiteExtension extends FitNesseRunner {
+    private DescriptionFactory myDescriptionFactory = new DescriptionFactory();
+
     public SuiteExtension(Class<?> suiteClass) throws InitializationError {
       super(suiteClass);
+      assertNotNull("No default description factory", getDescriptionFactory());
+      setDescriptionFactory(myDescriptionFactory);
     }
 
     @Override
-    protected void addTestSystemListeners(RunNotifier notifier, MultipleTestsRunner testRunner, Class<?> suiteClass) {
-      testRunner.addTestSystemListener(new ListenerExtension(notifier, suiteClass));
+    protected void addTestSystemListeners(RunNotifier notifier,
+                                          MultipleTestsRunner testRunner,
+                                          Class<?> suiteClass,
+                                          DescriptionFactory descriptionFactory) {
+      assertEquals("Wrong description factory provided to listener", myDescriptionFactory, descriptionFactory);
+      testRunner.addTestSystemListener(new ListenerExtension(notifier, suiteClass, descriptionFactory));
     }
 
     @Override
@@ -37,8 +48,8 @@ public class FitNesseRunnerExtensionTest {
   }
 
   public static class ListenerExtension extends JUnitRunNotifierResultsListener {
-    public ListenerExtension(RunNotifier notifier, Class<?> mainClass) {
-      super(notifier, mainClass);
+    public ListenerExtension(RunNotifier notifier, Class<?> mainClass, DescriptionFactory descriptionFactory) {
+      super(notifier, mainClass, descriptionFactory);
     }
 
     @Override

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -6,7 +6,9 @@ import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.wiki.PageCrawlerImpl;
+import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -120,7 +122,7 @@ public class JUnitRunNotifierResultsListenerTest {
     assertThat(failure.getMessage(), is("[Actual] Message"));
   }
 
-  private WikiTestPage mockWikiTestPage() {
+  static WikiTestPage mockWikiTestPage() {
     WikiPage root = mock(WikiPage.class);
     when(root.isRoot()).thenReturn(true);
 
@@ -128,6 +130,7 @@ public class JUnitRunNotifierResultsListenerTest {
     when(test.isRoot()).thenReturn(false);
     when(test.getParent()).thenReturn(root);
     when(test.getName()).thenReturn("WikiPage");
+    when(test.getData()).thenReturn(new PageData("content", new WikiPageProperties()));
     when(test.getPageCrawler()).thenReturn(new PageCrawlerImpl(test));
     return new WikiTestPage(test);
   }

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -1,11 +1,13 @@
 package fitnesse.junit;
 
 import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.wiki.PageCrawlerImpl;
 import fitnesse.wiki.WikiPage;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
@@ -19,8 +21,16 @@ import static org.mockito.Mockito.*;
 
 public class JUnitRunNotifierResultsListenerTest {
   private RunNotifier notifier = mock(RunNotifier.class);
-  private JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass());
+  private DescriptionFactory descriptionFactory = mock(DescriptionFactory.class);
+  private Description description;
+  private JUnitRunNotifierResultsListener listener = new JUnitRunNotifierResultsListener(notifier, getClass(), descriptionFactory);
   private ArgumentCaptor<Failure> arguments = ArgumentCaptor.forClass(Failure.class);
+
+  @Before
+  public void setUp() {
+    description = Description.createTestDescription("myTest","bla");
+    when(descriptionFactory.createDescription(eq(getClass()), any(TestPage.class))).thenReturn(description);
+  }
 
   @Test
   public void shouldFinishSuccessfully() {
@@ -29,7 +39,7 @@ public class JUnitRunNotifierResultsListenerTest {
     listener.testAssertionVerified(null, testResult);
     listener.testComplete(mockWikiTestPage(), summary("-"));
 
-    verify(notifier).fireTestFinished(any(Description.class));
+    verify(notifier).fireTestFinished(description);
   }
 
   @Test
@@ -40,7 +50,7 @@ public class JUnitRunNotifierResultsListenerTest {
     listener.testComplete(mockWikiTestPage(), summary("-"));
 
     verify(notifier).fireTestFailure(any(Failure.class));
-    verify(notifier).fireTestFinished(any(Description.class));
+    verify(notifier).fireTestFinished(description);
   }
 
   @Test
@@ -51,7 +61,7 @@ public class JUnitRunNotifierResultsListenerTest {
     listener.testComplete(mockWikiTestPage(), summary("W"));
 
     verify(notifier).fireTestFailure(arguments.capture());
-    verify(notifier).fireTestFinished(any(Description.class));
+    verify(notifier).fireTestFinished(description);
 
     Failure failure = arguments.getValue();
     assertThat(failure.getMessage(), is("Test failures occurred on page WikiPage"));
@@ -65,7 +75,7 @@ public class JUnitRunNotifierResultsListenerTest {
     listener.testComplete(mockWikiTestPage(), summary("-"));
 
     verify(notifier).fireTestFailure(any(Failure.class));
-    verify(notifier).fireTestFinished(any(Description.class));
+    verify(notifier).fireTestFinished(description);
   }
 
   @Test
@@ -76,7 +86,7 @@ public class JUnitRunNotifierResultsListenerTest {
     listener.testComplete(mockWikiTestPage(), summary("E"));
 
     verify(notifier).fireTestFailure(arguments.capture());
-    verify(notifier).fireTestFinished(any(Description.class));
+    verify(notifier).fireTestFinished(description);
 
     Failure failure = arguments.getValue();
     assertThat(failure.getMessage(), is("Exception occurred on page WikiPage"));


### PR DESCRIPTION
When FitNesseRunner executes a suite it would sometimes be convenient for jUnit listeners connected to the run to be able get access to the page context (for instance to access the tags associated with a test). 
Test listeners don't need to know anything about this information, but if they want to access it they can.
An example of when this is nice when creating a specialized listener to connect FitNesse test runs to a dashboard like [Allure](http://allure.qatools.ru). 

jUnit provides a mechanism to attach additional information to a test's context via annotations contained in the test Description.
In this pull request I ensure that the page context available when creating the jUnit Description is stored in an annotation inside the generated Description.

I recently got [a pull request](https://github.com/fhoeben/hsac-fitnesse-fixtures/pull/70) to change the workings of my customized FitNesseRunner to support connections to Allure. The only need for a code change was the need to have page information available for jUnit listeners. With this pull request any runner can make use of this information, without further custom coding.