### PR TITLE
make "last change date" visible in the wiki

### DIFF
--- a/src/fitnesse/resources/templates/versionSelection.vm
+++ b/src/fitnesse/resources/templates/versionSelection.vm
@@ -1,3 +1,4 @@
+<p>Current: $lastModified</p>
 <h2>Select a version</h2>
 <form action= "" method="get" name="compareVersions">
  <fieldset>

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -3,7 +3,10 @@
 package fitnesse.responders.editing;
 
 import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -26,7 +29,9 @@ import fitnesse.wiki.SymbolicPage;
 import fitnesse.wiki.WikiImportProperty;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.WikiPageProperties;
 import fitnesse.wiki.WikiPageProperty;
+
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -121,10 +126,23 @@ public class PropertiesResponder implements SecureResponder {
 
   private void makeLastModifiedTag() {
     String username = pageData.getAttribute(LAST_MODIFYING_USER);
+    String dateString = pageData.getAttribute(PropertyLAST_MODIFIED);
+  if (dateString == null) dateString ="";
+  if (!dateString.isEmpty()){
+    try {
+      Date date = WikiPageProperties.getTimeFormat().parse(dateString);
+      dateString = " on " + new SimpleDateFormat("MMM dd, yyyy").format(date) + " at " + new SimpleDateFormat("hh:mm:ss a").format(date);
+    }
+    catch (ParseException e) {
+      dateString = " on " + dateString;
+    }
+  }
+  
     if (username == null || "".equals(username))
-      html.put("lastModified", "Last modified anonymously");
+      html.put("lastModified", "Last modified anonymously" + dateString);
     else
-      html.put("lastModified", "Last modified by " + username);
+      html.put("lastModified", "Last modified by " + username + dateString) ;
+
   }
 
   private void makeFormSections() {

--- a/src/fitnesse/responders/versions/VersionSelectionResponder.java
+++ b/src/fitnesse/responders/versions/VersionSelectionResponder.java
@@ -16,6 +16,14 @@ import fitnesse.wiki.*;
 
 import java.util.*;
 
+import fitnesse.wiki.WikiPageProperties;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import fitnesse.wiki.PageData.*;
+import static fitnesse.wiki.PageData.*;
+
+
 public class VersionSelectionResponder implements SecureResponder {
 
   @Override
@@ -33,6 +41,7 @@ public class VersionSelectionResponder implements SecureResponder {
     HtmlPage html = context.pageFactory.newPage();
     html.setTitle("Version Selection: " + resource);
     html.setPageTitle(new PageTitle("Version Selection", PathParser.parse(resource), pageData.getAttribute(PageData.PropertySUITES)));
+  html.put("lastModified", makeLastModifiedTag(pageData));
     html.put("versions", versions);
     html.setNavTemplate("viewNav");
     html.put("viewLocation", request.getResource());
@@ -41,6 +50,26 @@ public class VersionSelectionResponder implements SecureResponder {
     response.setContent(html.html());
 
     return response;
+  }
+
+  private String makeLastModifiedTag(PageData pageData) {
+    String username = pageData.getAttribute(LAST_MODIFYING_USER);
+    String dateString = pageData.getAttribute(PropertyLAST_MODIFIED);
+  if (dateString == null) dateString ="";
+  if (!dateString.isEmpty()){
+  try {
+    Date date = WikiPageProperties.getTimeFormat().parse(dateString);
+    dateString = " on " + new SimpleDateFormat("MMM dd, yyyy").format(date) + " at " + new SimpleDateFormat("hh:mm:ss a").format(date);
+  }
+  catch (ParseException e) {
+    dateString = " on " + dateString;
+  }
+  }
+  if (username == null || "".equals(username))
+  return "Last modified anonymously" + dateString;
+  else
+  return "Last modified by " + username + dateString;
+
   }
 
   public static List<VersionInfo> getVersionsList(WikiPage page) {


### PR DESCRIPTION
As a Wiki User
To understand the flow of changes
I need to see the "last changed date" of a wiki page when comparing versions or when looking at the properties of a single page

currently only the last author can be seen