### PR TITLE
Fixed one typo in each of README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The [GitHub issues](https://github.com/unclebob/fitnesse/issues) section is only
 3.  Please don't rush.  You are never in a hurry with FitNesse.  There are no deadlines.  Keep this code as clean
     as you can.  Maintain the highest pride in your workmanship.  Don't make messes.  See the "Clean Code" book for more.
 
-4.  Whenever you make a change, submit is as a pull request on https://github.com/unclebob/fitnesse. Pull requests will get a milestone "Next release" associated to them when they are merged. This milestone is used to compose the release notes.
+4.  Whenever you make a change, submit it as a pull request on https://github.com/unclebob/fitnesse. Pull requests will get a milestone "Next release" associated to them when they are merged. This milestone is used to compose the release notes.
 
 5.  If you have any questions, ask [Uncle Bob](https://github.com/unclebob).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ ./gradlew test
 To run the acceptance tests:
 
 ```
-$ ./gradlew acceptanceTests
+$ ./gradlew acceptanceTest
 ```
 
 Direct any questions to the [FitNesse Yahoo group](https://groups.yahoo.com/neo/groups/fitnesse/info).


### PR DESCRIPTION
Two typos have been fixed.

I also noticed that CONTRIBUTING.md still talks about ant targets, that may need an update.

Moreover, the section "Configure SLIM" on the wiki page describing SliM (i.e. http://fitnesse.org/FitNesse.UserGuide.WritingAcceptanceTests.SliM or the file FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt) does not match completely with what can be found in `fitnesse.slim.SlimService`:
- According to the wiki page, the default value for `slim.port` is 8085, while in the SlimService class it defaults to 8099.
- On the wiki page, the command line argument pattern for the slim service misses the `port` option. In the class source the port parameter is present. Also, as a default value is specified, shouldn't the port parameter simply be made optional?

I'd be happy to correct this as well.