### PR TITLE
Allow Slim to use a custom NameTranslator

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
@@ -47,7 +47,7 @@ The Slim test system can be configured using the following properties:
 | slim.pool.size | 10 | The size of the pool of ports to cycle through. By default the ports 8085 up to 8095 are used (''slim.port'' + ''slim.pool.size''). |
 | slim.host | localhost | The host the SLIM server will be running on. This is mostly useful if you're running a remote SLIM server. |
 | slim.flags | | Extra flags to provide to the SLIM server. Arguments supported by the slim service are: !-
--![-v] [-i interactionClass] [-s statementTimeout] [-d] [-ssl parameterClass] |
+-![-v] [-i interactionClass] [-nt nameTranslatorClass] [-s statementTimeout] [-d] [-ssl parameterClass] |
 | slim.timeout | 10 seconds | Connection timeout starting and finishing a test run. |
 | slim.debug.timeout | ''slim.timeout'' | Same as ''slim.timeout'', used when the debug property is set (falls back to ''slim.timeout''). |
 | manually.start.test.runner.on.debug | false | Do not launch a SLIM server if the test is ran in debug mode. |

--- a/src/fitnesse/slim/JavaSlimFactory.java
+++ b/src/fitnesse/slim/JavaSlimFactory.java
@@ -5,13 +5,14 @@ import fitnesse.slim.fixtureInteraction.FixtureInteraction;
 
 public class JavaSlimFactory extends SlimFactory {
 
-  private final NameTranslator identityTranslator = new NameTranslatorIdentity();
+  private final NameTranslator nameTranslator;
   private final Integer timeout;
   private final boolean verbose;
   private final FixtureInteraction interaction;
 
-  private JavaSlimFactory(FixtureInteraction interaction, Integer timeout, boolean verbose) {
+  private JavaSlimFactory(FixtureInteraction interaction, NameTranslator nameTranslator, Integer timeout, boolean verbose) {
     this.interaction = interaction;
+    this.nameTranslator = nameTranslator;
     this.timeout = timeout;
     this.verbose = verbose;
   }
@@ -26,8 +27,8 @@ public class JavaSlimFactory extends SlimFactory {
   }
 
   @Override
-  public NameTranslator getMethodNameTranslator() {
-    return getIdentityTranslator();
+  public NameTranslator getNameTranslator() {
+    return nameTranslator;
   }
 
   @Override
@@ -35,21 +36,17 @@ public class JavaSlimFactory extends SlimFactory {
     return verbose;
   }
 
-  private NameTranslator getIdentityTranslator() {
-    return identityTranslator;
-  }
-
   // Called from main
   public static SlimFactory createJavaSlimFactory(SlimService.Options options) {
-    return createJavaSlimFactory(options.interaction, options.statementTimeout, options.verbose);
+    return createJavaSlimFactory(options.interaction, options.nameTranslator, options.statementTimeout, options.verbose);
   }
 
-  public static SlimFactory createJavaSlimFactory(FixtureInteraction interaction, Integer timeout, boolean verbose) {
-    return new JavaSlimFactory(interaction, timeout, verbose);
+  public static SlimFactory createJavaSlimFactory(FixtureInteraction interaction, NameTranslator nameTranslator, Integer timeout, boolean verbose) {
+    return new JavaSlimFactory(interaction, nameTranslator, timeout, verbose);
   }
 
   // Only used in tests
   public static SlimFactory createJavaSlimFactory() {
-    return new JavaSlimFactory(new DefaultInteraction(), null, false);
+    return new JavaSlimFactory(new DefaultInteraction(), new NameTranslatorIdentity(), null, false);
   }
 }

--- a/src/fitnesse/slim/ListExecutor.java
+++ b/src/fitnesse/slim/ListExecutor.java
@@ -2,21 +2,21 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
-import fitnesse.slim.instructions.Instruction;
-import fitnesse.slim.instructions.InstructionFactory;
-import fitnesse.slim.instructions.InstructionResult;
+import static java.util.Arrays.asList;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
+import fitnesse.slim.instructions.Instruction;
+import fitnesse.slim.instructions.InstructionFactory;
+import fitnesse.slim.instructions.InstructionResult;
 
 /**
  * executes a list of SLIM statements, and returns a list of return values.
  */
 public class ListExecutor {
   private StatementExecutorInterface executor;
-  private NameTranslator methodNameTranslator;
+  private InstructionFactory instructionFactory;
   private boolean verbose;
 
   public ListExecutor(SlimFactory slimFactory) {
@@ -26,7 +26,7 @@ public class ListExecutor {
   protected ListExecutor(boolean verbose, SlimFactory slimFactory) {
     this.verbose = verbose;
     this.executor = slimFactory.getStatementExecutor();
-    this.methodNameTranslator = slimFactory.getMethodNameTranslator();
+    this.instructionFactory = new InstructionFactory(slimFactory.getNameTranslator());
   }
 
   protected void setVerbose() {
@@ -45,7 +45,7 @@ public class ListExecutor {
     }
 
     public Object executeStatement(Object statement) {
-      Instruction instruction = InstructionFactory.createInstruction(asStatementList(statement), methodNameTranslator);
+      Instruction instruction = instructionFactory.createInstruction(asStatementList(statement));
       InstructionResult result = instruction.execute(executor);
       Object resultObject;
       if (result.hasResult() || result.hasError()) {

--- a/src/fitnesse/slim/NameTranslator.java
+++ b/src/fitnesse/slim/NameTranslator.java
@@ -1,5 +1,6 @@
 package fitnesse.slim;
 
 public interface NameTranslator {
-  String translate(String name);
+  String translateClassName(String name);
+  String translateMethodName(String name);
 }

--- a/src/fitnesse/slim/NameTranslatorIdentity.java
+++ b/src/fitnesse/slim/NameTranslatorIdentity.java
@@ -3,7 +3,12 @@ package fitnesse.slim;
 public class NameTranslatorIdentity implements NameTranslator {
 
   @Override
-  public String translate(String name) {
+  public String translateClassName(String name) {
+    return name;
+  }
+
+  @Override
+  public String translateMethodName(String name) {
     return name;
   }
 

--- a/src/fitnesse/slim/SlimFactory.java
+++ b/src/fitnesse/slim/SlimFactory.java
@@ -2,7 +2,7 @@ package fitnesse.slim;
 
 public abstract class SlimFactory {
 
-  public abstract NameTranslator getMethodNameTranslator();
+  public abstract NameTranslator getNameTranslator();
 
   public abstract boolean isVerbose();
 

--- a/src/fitnesse/slim/instructions/AssignInstruction.java
+++ b/src/fitnesse/slim/instructions/AssignInstruction.java
@@ -4,8 +4,8 @@ import fitnesse.slim.SlimException;
 
 public class AssignInstruction extends Instruction {
   public static final String INSTRUCTION = "assign";
-  private String symbolName;
-  private Object value;
+  private final String symbolName;
+  private final Object value;
 
   public AssignInstruction(String id, String symbolName, Object value) {
     super(id);

--- a/src/fitnesse/slim/instructions/CallAndAssignInstruction.java
+++ b/src/fitnesse/slim/instructions/CallAndAssignInstruction.java
@@ -1,16 +1,15 @@
 package fitnesse.slim.instructions;
 
-import fitnesse.slim.NameTranslator;
-import fitnesse.slim.SlimException;
-
 import java.util.Arrays;
+
+import fitnesse.slim.SlimException;
 
 public class CallAndAssignInstruction extends Instruction {
   public static final String INSTRUCTION = "callAndAssign";
-  private String symbolName;
-  private String instanceName;
-  private String methodName;
-  private Object[] args;
+  private final String symbolName;
+  private final String instanceName;
+  private final String methodName;
+  private final Object[] args;
 
   public CallAndAssignInstruction(String id, String symbolName, String instanceName, String methodName) {
     this(id, symbolName, instanceName, methodName, new Object[]{});
@@ -21,15 +20,6 @@ public class CallAndAssignInstruction extends Instruction {
     this.symbolName = symbolName;
     this.instanceName = instanceName;
     this.methodName = methodName;
-    this.args = args;
-  }
-
-  public CallAndAssignInstruction(String id, String symbolName, String instanceName, String methodName, Object[] args,
-                                  NameTranslator methodNameTranslator) {
-    super(id);
-    this.symbolName = symbolName;
-    this.instanceName = instanceName;
-    this.methodName = methodNameTranslator.translate(methodName);
     this.args = args;
   }
 
@@ -64,7 +54,6 @@ public class CallAndAssignInstruction extends Instruction {
     if (!instanceName.equals(that.instanceName)) return false;
     if (!methodName.equals(that.methodName)) return false;
     return symbolName.equals(that.symbolName);
-
   }
 
   @Override

--- a/src/fitnesse/slim/instructions/CallInstruction.java
+++ b/src/fitnesse/slim/instructions/CallInstruction.java
@@ -1,15 +1,14 @@
 package fitnesse.slim.instructions;
 
-import fitnesse.slim.NameTranslator;
-import fitnesse.slim.SlimException;
-
 import java.util.Arrays;
+
+import fitnesse.slim.SlimException;
 
 public class CallInstruction extends Instruction {
   public static final String INSTRUCTION = "call";
-  private String instanceName;
-  private String methodName;
-  private Object[] args;
+  private final String instanceName;
+  private final String methodName;
+  private final Object[] args;
 
   public CallInstruction(String id, String instanceName, String methodName) {
     this(id, instanceName, methodName, new Object[]{});
@@ -19,14 +18,6 @@ public class CallInstruction extends Instruction {
     super(id);
     this.instanceName = instanceName;
     this.methodName = methodName;
-    this.args = args;
-  }
-
-  public CallInstruction(String id, String instanceName, String methodName, Object[] args,
-                         NameTranslator methodNameTranslator) {
-    super(id);
-    this.instanceName = instanceName;
-    this.methodName = methodNameTranslator.translate(methodName);
     this.args = args;
   }
 

--- a/src/fitnesse/slim/instructions/ImportInstruction.java
+++ b/src/fitnesse/slim/instructions/ImportInstruction.java
@@ -4,7 +4,7 @@ import fitnesse.slim.SlimException;
 
 public class ImportInstruction extends Instruction {
   public static final String INSTRUCTION = "import";
-  private String path;
+  private final String path;
 
   public ImportInstruction(String id, String path) {
     super(id);

--- a/src/fitnesse/slim/instructions/Instruction.java
+++ b/src/fitnesse/slim/instructions/Instruction.java
@@ -11,7 +11,7 @@ public abstract class Instruction {
     }
   };
 
-  private String id;
+  private final String id;
 
   public Instruction(String id) {
     this.id = id;
@@ -22,7 +22,6 @@ public abstract class Instruction {
   }
 
   public final InstructionResult execute(InstructionExecutor executor) {
-    
     InstructionResult result;
     try {
       SystemExitSecurityManager.activateIfWanted();

--- a/src/fitnesse/slim/instructions/InstructionFactory.java
+++ b/src/fitnesse/slim/instructions/InstructionFactory.java
@@ -9,68 +9,64 @@ import fitnesse.slim.SlimServer;
 import static java.lang.String.format;
 
 public class InstructionFactory {
-  private InstructionFactory() {
+  private final NameTranslator nameTranslator;
+
+  public InstructionFactory(NameTranslator nameTranslator) {
+    this.nameTranslator = nameTranslator;
   }
 
-  public static Instruction createInstruction(List<Object> words, NameTranslator methodNameTranslator) {
+  public Instruction createInstruction(List<Object> words) {
     String id = getWord(words, 0);
     String operation = getWord(words, 1);
-    Instruction instruction;
 
     if (MakeInstruction.INSTRUCTION.equalsIgnoreCase(operation)) {
-      instruction = createMakeInstruction(id, words);
+      return createMakeInstruction(id, words);
     } else if (AssignInstruction.INSTRUCTION.equalsIgnoreCase(operation)) {
-      instruction = createAssignInstruction(id, words);
+      return createAssignInstruction(id, words);
     } else if (CallAndAssignInstruction.INSTRUCTION.equalsIgnoreCase(operation)) {
-      instruction = createCallAndAssignInstruction(id, words, methodNameTranslator);
+      return createCallAndAssignInstruction(id, words);
     } else if (CallInstruction.INSTRUCTION.equalsIgnoreCase(operation)) {
-      instruction = createCallInstruction(id, words, methodNameTranslator);
+      return createCallInstruction(id, words);
     } else if (ImportInstruction.INSTRUCTION.equalsIgnoreCase(operation)) {
-      instruction = createImportInstruction(id, words);
-    } else {
-      instruction = createInvalidInstruction(id, operation);
+      return createImportInstruction(id, words);
     }
-
-    return instruction;
+    return createInvalidInstruction(id, operation);
   }
 
-  private static MakeInstruction createMakeInstruction(String id, List<Object> words) {
+  private MakeInstruction createMakeInstruction(String id, List<Object> words) {
     String instanceName = getWord(words, 2);
-    String className = getWord(words, 3);
+    String className = nameTranslator.translateClassName(getWord(words, 3));
     Object[] args = makeArgsArray(words, 4);
     return new MakeInstruction(id, instanceName, className, args);
   }
 
-  private static AssignInstruction createAssignInstruction(String id, List<Object> words) {
+  private AssignInstruction createAssignInstruction(String id, List<Object> words) {
     String symbolName = getWord(words, 2);
     String value = getWord(words, 3);
     return new AssignInstruction(id, symbolName, value);
   }
 
-  private static CallAndAssignInstruction createCallAndAssignInstruction(String id,
-                                                                         List<Object> words,
-                                                                         NameTranslator methodNameTranslator) {
+  private CallAndAssignInstruction createCallAndAssignInstruction(String id, List<Object> words) {
     String symbolName = getWord(words, 2);
     String instanceName = getWord(words, 3);
-    String methodName = getWord(words, 4);
+    String methodName = nameTranslator.translateMethodName(getWord(words, 4));
     Object[] args = makeArgsArray(words, 5);
-    return new CallAndAssignInstruction(id, symbolName, instanceName, methodName, args, methodNameTranslator);
+    return new CallAndAssignInstruction(id, symbolName, instanceName, methodName, args);
   }
 
-  private static CallInstruction createCallInstruction(String id, List<Object> words,
-                                                       NameTranslator methodNameTranslator) {
+  private CallInstruction createCallInstruction(String id, List<Object> words) {
     String instanceName = getWord(words, 2);
-    String methodName = getWord(words, 3);
+    String methodName = nameTranslator.translateMethodName(getWord(words, 3));
     Object[] args = makeArgsArray(words, 4);
-    return new CallInstruction(id, instanceName, methodName, args, methodNameTranslator);
+    return new CallInstruction(id, instanceName, methodName, args);
   }
 
-  private static ImportInstruction createImportInstruction(String id, List<Object> words) {
+  private ImportInstruction createImportInstruction(String id, List<Object> words) {
     String path = getWord(words, 2);
     return new ImportInstruction(id, path);
   }
 
-  private static InvalidInstruction createInvalidInstruction(String id, String operation) {
+  private InvalidInstruction createInvalidInstruction(String id, String operation) {
     return new InvalidInstruction(id, operation);
   }
 

--- a/src/fitnesse/slim/instructions/InstructionResult.java
+++ b/src/fitnesse/slim/instructions/InstructionResult.java
@@ -3,8 +3,8 @@ package fitnesse.slim.instructions;
 import fitnesse.slim.SlimException;
 
 public class InstructionResult {
-  private String id;
-  private Object result;
+  private final String id;
+  private final Object result;
 
   public InstructionResult(String id, Object result) {
     this.id = id;

--- a/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
@@ -1,6 +1,7 @@
 package fitnesse.testsystems.slim;
 
 import fitnesse.slim.JavaSlimFactory;
+import fitnesse.slim.NameTranslatorIdentity;
 import fitnesse.slim.SlimServer;
 import fitnesse.slim.SlimService;
 import fitnesse.slim.fixtureInteraction.DefaultInteraction;
@@ -32,7 +33,7 @@ public class InProcessSlimClientBuilder extends ClientBuilder<SlimClient> {
   }
 
   protected SlimServer createSlimServer(Integer timeout, boolean verbose) {
-    return JavaSlimFactory.createJavaSlimFactory(new DefaultInteraction(), timeout, verbose).getSlimServer();
+    return JavaSlimFactory.createJavaSlimFactory(new DefaultInteraction(), new NameTranslatorIdentity(), timeout, verbose).getSlimServer();
   }
 
   protected String[] getSlimFlags() {

--- a/test/fitnesse/slim/JavaSlimFactoryTest.java
+++ b/test/fitnesse/slim/JavaSlimFactoryTest.java
@@ -23,7 +23,7 @@ public class JavaSlimFactoryTest {
   }
 
   private SlimService.Options optionsWithStatementTimeout() {
-    return new SlimService.Options(false, 8099, new DefaultInteraction(), false, 1000, false, null);
+    return new SlimService.Options(false, 8099, new DefaultInteraction(), new NameTranslatorIdentity(), false, 1000, false, null);
   }
 
 }

--- a/test/fitnesse/slim/instructions/CallAndAssignInstructionTest.java
+++ b/test/fitnesse/slim/instructions/CallAndAssignInstructionTest.java
@@ -1,13 +1,8 @@
 package fitnesse.slim.instructions;
 
-import fitnesse.slim.NameTranslator;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.mock;
@@ -15,33 +10,25 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
+import org.junit.Test;
+
 public class CallAndAssignInstructionTest {
   private static final String RESULT = "result";
 
   private InstructionExecutor executor;
-  private NameTranslator nameTranslator;
 
   @Before
   public void setUp() throws Exception {
     executor = mock(InstructionExecutor.class);
-    nameTranslator = mock(NameTranslator.class);
 
     when(executor.callAndAssign(anyString(), anyString(), anyString(), anyVararg())).thenReturn(RESULT);
-    when(nameTranslator.translate(anyString())).thenAnswer(returnsFirstArg());
-  }
-
-  @Test
-  public void shouldTranslateMethodNameOnConstruction() {
-    new CallAndAssignInstruction("id_1", "symbol", "instance", "method", new Object[] {"arg1", "arg2"},
-        nameTranslator);
-
-    verify(nameTranslator, times(1)).translate("method");
   }
 
   @Test
   public void shouldCallExecutorOnExecution() throws Exception {
     CallAndAssignInstruction instruction = new CallAndAssignInstruction("id_1", "symbol", "instance", "method",
-        new Object[] {"arg1", "arg2"}, nameTranslator);
+        new Object[] {"arg1", "arg2"});
 
     instruction.execute(executor);
 
@@ -51,7 +38,7 @@ public class CallAndAssignInstructionTest {
   @Test
   public void shouldReturnExecutionResults() {
     CallAndAssignInstruction instruction = new CallAndAssignInstruction("id_1", "symbol", "instance", "method",
-        new Object[] {"arg1", "arg2"}, nameTranslator);
+        new Object[] {"arg1", "arg2"});
 
     InstructionResult result = instruction.execute(executor);
 

--- a/test/fitnesse/slim/instructions/CallInstructionTest.java
+++ b/test/fitnesse/slim/instructions/CallInstructionTest.java
@@ -1,41 +1,34 @@
 package fitnesse.slim.instructions;
 
-import fitnesse.slim.NameTranslator;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.*;
 
 public class CallInstructionTest {
   private static final String ID = "id_1";
   private static final String RESULT = "result";
 
   private InstructionExecutor executor;
-  private NameTranslator nameTranslator;
 
   @Before
   public void setUp() throws Exception {
     executor = mock(InstructionExecutor.class);
-    nameTranslator = mock(NameTranslator.class);
 
     when(executor.call(anyString(), anyString(), anyVararg())).thenReturn(RESULT);
-    when(nameTranslator.translate(anyString())).thenAnswer(returnsFirstArg());
-  }
-
-  @Test
-  public void shouldTranslateMethodNameOnCreation() {
-    new CallInstruction(ID, "instance", "method", new Object[]{"arg1", "arg2"},
-      nameTranslator);
-
-    verify(nameTranslator, times(1)).translate("method");
   }
 
   @Test
   public void shouldDelegateExecutionToExecutor() throws Exception {
-    CallInstruction instruction = new CallInstruction(ID, "instance", "method", new Object[]{"arg1", "arg2"},
-      nameTranslator);
+    CallInstruction instruction = new CallInstruction(ID, "instance", "method", new Object[]{"arg1", "arg2"});
     instruction.execute(executor);
 
     verify(executor, times(1)).call("instance", "method", "arg1", "arg2");
@@ -43,8 +36,7 @@ public class CallInstructionTest {
 
   @Test
   public void shouldFormatReturnValues() {
-    CallInstruction instruction = new CallInstruction(ID, "instance", "method", new Object[]{"arg1", "arg2"},
-      nameTranslator);
+    CallInstruction instruction = new CallInstruction(ID, "instance", "method", new Object[]{"arg1", "arg2"});
 
     InstructionResult result = instruction.execute(executor);
 


### PR DESCRIPTION
- NameTranslator interface now has two methods (class/method specific)
- JavaSlimFactory now needs a NameTranslator for construction.
- Added -nt parameter to SlimService, to specify a custom class name of a NameTranslator for SlimFactory. If none is given, NameTranslatorIdentity is used by default.
- Reworked the way instructions are created by InstructionFactory: The InstructionFactory now needs an instance of a NameTranslator. It translates the method/class names before creating the instructions, so the instructions themselves are now unaware of NameTranslators. The factory methods are not static anymore.
- Updated description of slim.flags on the SliM wiki page

I noticed that different default ports for Slim are specified in fitnesse.testsystems.slim.SlimClientBuilder and fitnesse.slim.SlimService.

See also: #859