### PR TITLE
Add SLIM Baseline decision table to make tests easier to read

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ComparatorsAreSupported/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ComparatorsAreSupported/content.txt
@@ -1,0 +1,16 @@
+|baseline: eg.Division                                           |
+|numerator|denominator|quotient?|# Explication                   |
+|10       |2          |5.0      |S1 Base scenario                |
+|20       |4          |         |S2 Same result as base - correct|
+|         |5          |2.0      |S4 Same numerator as base       |
+|16       |           |8.0      |S5 Same denominator as base     |
+|22       |7          |~=3.14   |S6 Special comparator           |
+|11       |2          |4<_<6    |S8 Special comparator           |
+|         |           |         |S9 Correct but useless duplicate|
+
+
+|baseline: eg.Division                                           |
+|numerator|denominator|quotient?|# Explication                   |
+|10       |2          |4<_<6    |S1 Base scenario                |
+|20       |4          |         |S2 Same result as base - correct|
+|11       |2          |         |S8 Special comparator           |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ComparatorsAreSupported/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ComparatorsAreSupported/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/HowtoIgnoreResultValues/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/HowtoIgnoreResultValues/content.txt
@@ -1,0 +1,8 @@
+Given you want to '''ignore''' the results of an output column (like ''quotient'')
+Then already in the base scenario the column must be empty.
+
+|baseline: eg.Division                                    |
+|numerator|denominator|quotient?|# Explication            |
+|10       |2          |         |S1 Base scenario - ignore|
+|20       |4          |5.0      |S2  correct result       |
+|20       |6          |         |Ignore                   |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/HowtoIgnoreResultValues/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/HowtoIgnoreResultValues/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Test/>
+<Versions/>
+<WhereUsed/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/TearDown/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/TearDown/content.txt
@@ -1,0 +1,3 @@
+!define SLIM_DT_BASELINE ()
+
+!include  .FitNesse.SuiteAcceptanceTests.TearDown 

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/TearDown/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/TearDown/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/content.txt
@@ -1,0 +1,30 @@
+GIVEN you want that all decision tables behave like the baseline table 
+AND you don't want to add "baeline:" in each table
+THEN define the variable SLIM_DT_BASELINE somewhere on our root page
+
+!define SLIM_DT_BASELINE (true)
+
+
+
+!*>  Dependencies
+
+|import            |
+|fitnesse.slim.test|
+
+*!
+
+
+
+
+Given I have at least one milk remaining
+Then I should NOT go to the store
+
+|should I buy milk                                              |
+|cash in wallet|credit card|pints of milk remaining|go to store?|
+|0             |no         |1                      |no          |
+|              |           |2                      |            |
+|              |           |7                      |            |
+|10            |           |                       |            |
+|              |yes        |                       |            |
+|10            |yes        |                       |            |
+|1             |           |1                      |            |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/MakingTheBaselineTableTheDefaultDecisionTable/properties.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Help/>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Suites/>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ScenariosAreSupported/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ScenariosAreSupported/content.txt
@@ -1,0 +1,30 @@
+!3 !help
+
+|scenario      |my division|numerator||denominator||my result?|
+|setNumerator  |@numerator                                    |
+|setDenominator|@denominator                                  |
+|$myResult=    |quotient                                      |
+
+
+Get the Division implementation from the eg package
+|Library    |
+|eg.Division|
+
+
+
+|baseline: my division                                            |
+|numerator|denominator|my result?|# Explication                   |
+|10       |2          |5.0       |S1 Base scenario                |
+|20       |4          |          |S2 Same result as base - correct|
+|         |5          |2.0       |S4 Same numerator as base       |
+|16       |           |8.0       |S5 Same denominator as base     |
+|22       |7          |~=3.14    |S6 Special comparator           |
+|11       |2          |4<_<6     |S8 Special comparator           |
+|         |           |          |S9 Correct but useless duplicate|
+
+
+|baseline: my division                                            |
+|numerator|denominator|my result?|# Explication                   |
+|10       |2          |4<_<6     |S1 Base scenario                |
+|20       |4          |          |S2 Same result as base - correct|
+|11       |2          |          |S8 Special comparator           |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ScenariosAreSupported/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/ScenariosAreSupported/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Help>baseline tables can also be implemented with a scenario</Help>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/TestPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/TestPage/content.txt
@@ -1,0 +1,23 @@
+|baseline: eg.Division                                           |
+|numerator|denominator|quotient?|# Explication                   |
+|10       |2          |5.0      |S1 Base scenario                |
+|20       |4          |         |S2 Same result as base - correct|
+|20       |6          |         |W3 Same result as base - wrong  |
+|         |5          |2.0      |S4 Same numerator as base       |
+|16       |           |8.0      |S5 Same denominator as base  |  |
+|22       |7          |~=3.14   |S6 Special comparator           |
+|9        |3          |7.0      |W7 Wrong result                 |
+|11       |2          |4<_<6    |S8 Special comparator           |
+|         |           |         |S9 Correct but duplicate        |
+
+Given you want to ignore outputs like ''quotient''
+Then the base scenario must ignore them already
+
+!define SLIM_DT_BASELINE (true)
+
+|eg.Division                                                    |
+|numerator|denominator|quotient?|# Explication                  |
+|10       |2          |         |S1 Base scenario - ignore      |
+|20       |4          |5.0      |S2  correct result             |
+|20       |6          |         |W3 Same result as base - ignore|
+|         |2          |5.0      |W3 Same result as base - ignore|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/TestPage/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/TestPage/properties.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Help>same content as parent page, for manual execution required</Help>
+<Prune/>
+<Test/>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/content.txt
@@ -1,0 +1,48 @@
+See also: >TestPage.
+
+!define TestPageName {Testpage}
+
+!| script                                                      |
+|given test page         |${TestPageName}                      |
+|and Test System setup is|!define TEST_SYSTEM {slim}${SUT_PATH}|
+|and Setup content is                                          |!-
+|import                                                        |
+|fitnesse.slim.test                                            |
+
+-!|
+|and Test content is|!-
+#
+|baseline: eg.Division                                           |
+|numerator|denominator|quotient?|# Explication                   |
+|10       |2          |5.0      |S1 Base scenario                |
+|20       |4          |         |S2 Same result as base - correct|
+|20       |6          |         |W3 Same result as base - wrong  |
+|         |5          |2.0      |S4 Same numerator as base       |
+|16       |           |8.0      |S5 Same denominator as base  |  |
+|22       |7          |~=3.14   |S6 Special comparator           |
+|9        |3          |7        |W7 Wrong result                 |
+|11       |2          |4<_<6    |S8 Special comparator           |
+|         |           |         |S9 Correct but duplicate        |
+
+Given you want to ignore outputs like ''quotient''
+Then the base scenario must ignore them already
+
+!define SLIM_DT_BASELINE (true)
+
+|eg.Division                                                    |
+|numerator|denominator|quotient?|# Explication                  |
+|10       |2.5        |         |S1 Base scenario - ignore      |
+|20       |4          |5.0      |S2  correct result             |
+|20       |20         |         |W3 Same result as base - ignore|
+#
+-!|
+|when page                          |${TestPageName}|is tested and HTML is extracted                           |
+|then                               |8              |assertions pass,|2|fail,|2|are ignored|0|exceptions thrown|
+|and cell                           |3.333[^<]*     |has result      |diff                                     |
+|and cell                           |expected \[5   |has result      |fail                                     |
+|and cell                           |3.0            |has result      |diff                                     |
+|and cell                           |4.0            |has result      |ignore                                   |
+|and cell                           |1.0            |has result      |ignore                                   |
+|show Symbol                        |$HTML_Input                                                               |
+|show Symbol                        |$HTML_Result                                                              |
+|get collapsed executon log for page|${TestPageName}                                                           |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/TestFailuresAreMarked/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/content.txt
@@ -1,0 +1,79 @@
+!2 The aim of the baseline decision table is to make tests easier to read.
+
+!3 Background
+The idea of a [[decision table][.FitNesse.UserGuide.WritingAcceptanceTests.SliM.DecisionTable]] is to demonstrate how different combinations of input parameters generate different results.
+To make the impact of each parameter to the output results transparent it is good practice to modify just one parameter from row to row.
+For big tables with many input parameters it is often not immediately visible to the reader which parameter changes from row to row.
+
+!3 Syntax
+As a user of the '''baseline decision table''' you specify in the first row below the header in each column the values for all input and output parameters. 
+This defines your ''base scenario'' and so far this is 100% identical to a normal decision table.
+In all following lines you just specify the values which differ from the ''base scenario'' all other columns are left empty.
+
+This makes your table more readable. It is also easier to maintain in case a value must be changed.
+Don't repeat yourself is a good rule even when you write test cases. :)
+
+!3 Fixture Code
+When the baseline decision table is tested all empty columns are filled by the Slim test system with the corresponding values from the ''base scenario''. 
+In all other aspects the bahviour is identical to the decision table. 
+Your fixture code is identical to a [[decision table][.FitNesse.UserGuide.WritingAcceptanceTests.SliM.DecisionTable]]. The fixture will not be able to identif any difference between a baseline decision table and a normal [[decision table][.FitNesse.UserGuide.WritingAcceptanceTests.SliM.DecisionTable]].  
+
+!3 Example
+Let's look at an example which you know already from the [[Decision Table][.FitNesse.UserGuide.WritingAcceptanceTests.SliM.DecisionTable]]
+
+!*>  Dependencies
+
+|import            |
+|fitnesse.slim.test|
+
+*!
+
+Given I have at least one milk remaining
+Then I should NOT go to the store
+
+|baseline: should I buy milk                                    |
+|cash in wallet|credit card|pints of milk remaining|go to store?|
+|0             |no         |1                      |no          |
+|              |           |2                      |            |
+|              |           |7                      |            |
+|10            |           |                       |            |
+|              |yes        |                       |            |
+|10            |yes        |                       |            |
+|1             |           |1                      |            |
+
+
+Given I have no milk remaining
+And a credit card 
+Then I should go to the store
+
+|baseline: should I buy milk                                    |
+|cash in wallet|credit card|pints of milk remaining|go to store?|
+|0             |yes        |0                      |yes         |
+|1             |           |                       |            |
+|2             |           |                       |            |
+
+
+Given I have no milk remaining
+And at least three $ 
+Then I should go to the store
+
+|baseline: should I buy milk                                    |
+|cash in wallet|credit card|pints of milk remaining|go to store?|
+|3             |no         |0                      |yes         |
+|10            |           |                       |            |
+|7             |           |                       |            |
+|              |yes        |                       |            |
+
+Given I have no milk remaining
+And no credit card
+And less then three $ 
+Then I should NOT go to the store
+
+|baseline: should I buy milk                                    |
+|cash in wallet|credit card|pints of milk remaining|go to store?|
+|0             |no         |0                      |no          |
+|1             |           |                       |            |
+|2             |           |                       |            |
+
+
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/BaseLineDecisionTable/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
@@ -17,8 +17,9 @@ If you want a test page to be run under SLIM, you simply set the TEST_SYSTEM var
 The first cell of a slim table tells you what kind of table it is. Here are the table types so far:
 
 | [[Decision Table][>DecisionTable]] | Supplies the inputs and outputs for decisions. This is similar to the Fit Column Fixture |
-| [[Dynamic Decision Table][>DynamicDecisionTable]] | Has the same syntax as a >DecisionTable, but passes the column headers as parameters to the fixture. |
-| [[Hybrid Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.HybridDecisionTable]]| Combines the advantages of a Decision and a Dynamic Decision Table.|
+| [[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]|Almost identical to a >DecisionTable but more readable for very big tables with many columns as only the changed values from one line to the baseline must be specified. The fixture implementation is identical to >DecisionTable.|
+| [[Dynamic Decision Table][>DynamicDecisionTable]]                                               |Has the same syntax as a >DecisionTable, but differs in the fixture implementation. It passes the column headers as parameters to the fixture.                                                                                     |
+| [[Hybrid Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.HybridDecisionTable]]    |Combines the advantages in the fixture implementation of a Decision and a Dynamic Decision Table. Also supported by a [[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]             |
 | [[Query Table][>QueryTable]] | Supplies the expected results of a query. This is similar to the Fit Row Fixture |
 | [[Subset Query Table][>SubsetQueryTable]] | Supplies a subset of the expected results of a query. |
 | [[Ordered query Table][>OrderedQueryTable]] | Supplies the expected results of a query. The rows are expected to be in order. This is similar to the Fit Row Fixture |

--- a/src/fitnesse/testsystems/slim/tables/BaselineDecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/BaselineDecisionTable.java
@@ -1,0 +1,12 @@
+package fitnesse.testsystems.slim.tables;
+
+import fitnesse.testsystems.slim.SlimTestContext;
+import fitnesse.testsystems.slim.Table;
+
+public class BaselineDecisionTable extends DecisionTable {
+
+	public BaselineDecisionTable(Table table, String id, SlimTestContext context) {
+		super(table, id, context);
+		setBaselineDecisionTable(true);
+	}
+}

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -16,7 +16,8 @@ public class DecisionTable extends SlimTable {
   private static final String instancePrefix = "decisionTable";
   protected MethodExtractor setterMethodExtractor;
   protected MethodExtractor getterMethodExtractor;
-
+  protected boolean baselineDecisionTable = false;
+  
 
   public DecisionTable(Table table, String id, SlimTestContext context) {
     super(table, id, context);
@@ -39,14 +40,14 @@ public class DecisionTable extends SlimTable {
     if (scenario != null) {
       return new ScenarioCaller().call(scenario);
     } else {
-      scenarioName =getFixtureName();
-      scenario = getTestContext().getScenario(scenarioName);
+      String fixtureName =getFixtureName();
+      scenario = getTestContext().getScenario(fixtureName);
       if (scenario != null) {
         return new ScenarioCallerWithConstuctorParameters().call(scenario);
       } else {
        	setterMethodExtractor = prepareMethodExtractorIfNull(setterMethodExtractor,"SLIM_DT_SETTER");
        	getterMethodExtractor = prepareMethodExtractorIfNull(getterMethodExtractor,"SLIM_DT_GETTER");
-       	return new FixtureCaller().call(getFixtureName());
+       	return new FixtureCaller().call(fixtureName);
       }
     }
   }
@@ -88,7 +89,7 @@ public class DecisionTable extends SlimTable {
 
   private class ScenarioCaller extends DecisionTableCaller {
     public ScenarioCaller() {
-      super(table);
+      super(table, isBaselineDecisionTable());
     }
 
     public ArrayList<SlimAssertion> call(ScenarioTable scenario) throws TestExecutionException {
@@ -123,7 +124,7 @@ public class DecisionTable extends SlimTable {
         	assertion= makeAssertion(callAndAssign(assignedSymbol, "scriptTable" + "Actor", "cloneSymbol", "$"+name),
         			new ReturnedSymbolExpectation(col, row, name, assignedSymbol));
         } else {
-          assertion = makeAssertion(Instruction.NOOP_INSTRUCTION, new ReturnedSymbolExpectation(col, row, name));
+          assertion = makeAssertion(Instruction.NOOP_INSTRUCTION, new ReturnedSymbolExpectation(getDTCellContents(col, row), col, row, name));
         }
         return assertion;
       }
@@ -140,7 +141,7 @@ public class DecisionTable extends SlimTable {
       for (String var : varStore.getLeftToRightAndResetColumnNumberIterator()) {
         String disgracedVar = Disgracer.disgraceMethodName(var);
         int col = varStore.getColumnNumber(var);
-        String valueToSet = table.getCellContents(col, row);
+        String valueToSet = getDTCellContents(col, row);
         scenarioArguments.put(disgracedVar, valueToSet);
       }
       return scenarioArguments;
@@ -156,7 +157,7 @@ public class DecisionTable extends SlimTable {
 
   private class FixtureCaller extends DecisionTableCaller {
     public FixtureCaller() {
-      super(table);
+      super(table,isBaselineDecisionTable() );
     }
 
     public List<SlimAssertion> call(String fixtureName) throws SyntaxError {
@@ -219,8 +220,8 @@ public class DecisionTable extends SlimTable {
         assertion = makeAssertion(callAndAssign(assignedSymbol, getTableName(), functionName, args),
                 new SymbolAssignmentExpectation(assignedSymbol, col, row));
       } else {
-        assertion = makeAssertion(callFunction(getTableName(), functionName, args),
-                new ReturnedValueExpectation(col, row));
+         assertion = makeAssertion(callFunction(getTableName(), functionName, args),
+                new ReturnedValueExpectation(col, row, getDTCellContents(col, row)));
       }
       return assertion;
     }
@@ -229,7 +230,7 @@ public class DecisionTable extends SlimTable {
       List<SlimAssertion> assertions = new ArrayList<>();
       for (String var : varStore.getLeftToRightAndResetColumnNumberIterator()) {
         int col = varStore.getColumnNumber(var);
-        String valueToSet = table.getCellContents(col, row);
+        String valueToSet = getDTCellContents(col, row);
 
         Object[] args = new Object[] {valueToSet};
    	    MethodExtractorResult extractedSetter =  setterMethodExtractor.findRule(var);
@@ -248,4 +249,17 @@ public class DecisionTable extends SlimTable {
       return assertions;
     }
   }
+
+  boolean isBaselineDecisionTable() {
+    String useFirstDataRowForEmpty = null;
+    useFirstDataRowForEmpty = this.getTestContext().getPageToTest().getVariable("SLIM_DT_BASELINE");
+    return ((useFirstDataRowForEmpty != null && !useFirstDataRowForEmpty.isEmpty())
+		  || baselineDecisionTable);
+  }
+
+
+  void setBaselineDecisionTable(boolean baselineDecisionTable) {
+    this.baselineDecisionTable = baselineDecisionTable;
+  }
+
 }

--- a/src/fitnesse/testsystems/slim/tables/DecisionTableCaller.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTableCaller.java
@@ -49,9 +49,17 @@ public class DecisionTableCaller {
   protected ColumnHeaderStore funcStore = new ColumnHeaderStore();
   protected int columnHeaders;
   private final Table table;
+  private final boolean emptyCellsUseValueFromFirstDataRow;
+  private int firstDataRow = 2;
 
   public DecisionTableCaller(Table table) {
     this.table = table;
+    this.emptyCellsUseValueFromFirstDataRow =false;
+  }
+
+  public DecisionTableCaller(Table table, boolean emptyCellsUseValueFromFirstDataRow) {
+	this.table = table;
+	this.emptyCellsUseValueFromFirstDataRow = emptyCellsUseValueFromFirstDataRow;
   }
 
   protected void gatherConstructorParameters() {
@@ -79,6 +87,17 @@ public class DecisionTableCaller {
         varStore.add(cell, col);
       }
     }
+  }
+
+  protected String getDTCellContents(int col, int row){
+    String value = table.getCellContents(col, row);
+    if (shoudUseBaseLineValue(value))
+      value = table.getCellContents(col, firstDataRow );
+    return value;
+  }
+
+  private boolean shoudUseBaseLineValue(String valueToSet) {
+    return emptyCellsUseValueFromFirstDataRow && valueToSet != null &&  valueToSet.isEmpty();
   }
 
   protected void checkRow(int row) throws SyntaxError {

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -395,6 +395,10 @@ public abstract class SlimTable {
       super(col, row, table.getCellContents(col, row));
     }
 
+    public ReturnedValueExpectation(int col, int row, String expected) {
+        super(col, row, expected);
+	}
+
     @Override
     protected SlimTestResult createEvaluationMessage(String actual, String expected) {
       SlimTestResult testResult;
@@ -422,11 +426,16 @@ public abstract class SlimTable {
   }
 
   class ReturnedSymbolExpectation extends ReturnedValueExpectation {
-	  private String symbolName;
-	  private String assignToName = null;
-	  public ReturnedSymbolExpectation(int col, int row, String symbolName) {
+    private String symbolName;
+    private String assignToName = null;
+    public ReturnedSymbolExpectation(int col, int row, String symbolName) {
       super(col, row);
-		  this.symbolName = symbolName;
+      this.symbolName = symbolName;
+    }
+
+    public ReturnedSymbolExpectation(String expected, int col, int row, String symbolName) {
+      super(col, row, expected);
+      this.symbolName = symbolName;
     }
 
     public ReturnedSymbolExpectation(int col, int row, String symbolName, String assignToName) {

--- a/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
@@ -35,6 +35,7 @@ public class SlimTableFactory {
     addTableType("scenario", ScenarioTable.class);
     addTableType("import", ImportTable.class);
     addTableType("library", LibraryTable.class);
+    addTableType("baseline", BaselineDecisionTable.class);
   }
 
   protected SlimTableFactory(Map<String, Class<? extends SlimTable>> tableTypes, Map<String, String> tableTypeArrays, Map<String, String> aliasArrays) {


### PR DESCRIPTION
The aim of the baseline decision table is to make tests easier to read.

Background
The idea of a decision table is to demonstrate how different combinations of input parameters generate different results.
To make the impact of each parameter to the output results transparent it is good practice to modify just one parameter from row to row.
For big tables with many input parameters it is often not immediately visible to the reader which parameter changes from row to row.

Syntax
As a user of the baseline decision table you specify in the first row below the header in each column the values for all input and output parameters.
This defines your base scenario and so far this is 100% identical to a normal decision table.
In all following lines you just specify the values which differ from the base scenario all other columns are left empty.

This makes your table more readable. It is also easier to maintain in case a value must be changed.
Don't repeat yourself is a good rule even when you write test cases. :)

Fixture Code
When the baseline decision table is tested all empty columns are filled by the Slim test system with the corresponding values from the base scenario.
In all other aspects the bahviour is identical to the decision table.
Your fixture code is identical to a decision table. The fixture will not be able to identif any difference between a baseline decision table and a normal decision table.

Example
Let's look at an example which you know already from the Decision Table

Given I have at least one milk remaining
Then I should NOT go to the store

|baseline: should I buy milk                                    |

| cash in wallet | credit card | pints of milk remaining | go to store? |
| --- | --- | --- | --- |
| 0 | no | 1 | no |
|  |  | 2 |  |
|  |  | 7 |  |
| 10 |  |  |  |
|  | yes |  |  |
| 10 | yes |  |  |
| 1 |  | 1 |  |

for more details see: FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable
