### PR TITLE
Make autocomplete in plain text editor configureable

### DIFF
--- a/FitNesseRoot/WikiAutoComplete/content.txt
+++ b/FitNesseRoot/WikiAutoComplete/content.txt
@@ -1,0 +1,21 @@
+!define
+!today
+!help
+!path
+!fixture
+!lastmodified
+!img -l
+!contents
+!contents -R2 -g -p -f -h
+!include
+!include -setup
+!include -seamless
+!include -teardown
+!define TEST_SYSTEM (SLIM)
+!define TEST_SYSTEM (FIT)
+!define MANUALLY_START_TEST_RUNNER_ON_DEBUG (true)
+!define MANUALLY_START_TEST_RUNNER_ON_DEBUG (false)
+!define COMMAND_PATTERN (java -cp %p %m)
+!define TEST_RUNNER ()
+!anchor
+!style_()

--- a/FitNesseRoot/WikiAutoComplete/properties.xml
+++ b/FitNesseRoot/WikiAutoComplete/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit/>
+<Files/>
+<Help>This file contains text samples which will be used to auto complete words in the wiki plain editor once you press [ctrl][space]. Each line contains one textblock.</Help>
+<Properties/>
+<RecentChanges/>
+<Refactor/>
+<Search/>
+<Suites>beta, codemirror, wiki</Suites>
+<Versions/>
+<WhereUsed/>
+</properties>


### PR DESCRIPTION
- Add any words for auto complete to the following page: .WikiAutoComplete
  Start Typing and press [CTRL][SPACE] to get proposals:
  ![autocomplete2](https://cloud.githubusercontent.com/assets/5906592/18150736/7e20053e-6fe9-11e6-9890-84fe60ef0359.JPG)
- Also all child page names are loaded and can be accessed by typing '>'
  followed by [CTRL][SPACE]
  ![autocomplete](https://cloud.githubusercontent.com/assets/5906592/18150667/fe45c2cc-6fe8-11e6-9d54-bc2cda150e85.JPG)

Possible next step would be to identify all scenario names which are defined. The ?packet responder is a good starting point for this.
Or to identify all java classes and methods which are in the imports defined. 

I am currently blocked with other things. 
Maybe somebody feels inspired and can pick this up ... 
