### PR TITLE
Add base folder for plugin documentation

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/WritingPlugins/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/WritingPlugins/content.txt
@@ -35,3 +35,10 @@ The methods ''getAuthenticator()'' should return one instance. If multiple plugi
 The same rules are applicable for ''getContentFilter()''.
 
 The ''registerXxx'' methods are invoked with the appropriate provider or registry. It is the responsibility of the plugin to register it's plugins with those providers.
+
+!2 Documentation
+Every plugin should provide documentation which should be placed in the .PlugIns folder. 
+Each plugin should add exactly one overview page directly into .PlugIns and further pages as childs to the overview page.
+ * The name of the overview page should match the plugins name.
+ * The overview page should have a lengthy help text which explains what the plugin is used for
+ * The overview page should have a tag which is identical to the current version of the plugin.

--- a/FitNesseRoot/FitNesse/UserGuide/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/content.txt
@@ -13,6 +13,7 @@
  * [[Working with the FitNesse wiki][>FitNesseWiki]]
  * [[Writing Acceptance Tests][>WritingAcceptanceTests]] (jump directly to [[Fit][>WritingAcceptanceTests.FitFramework]] or [[Slim][>WritingAcceptanceTests.SliM]])
  * [[Administering FitNesse][>AdministeringFitNesse]]
+ * [[Extend Fitnesse with Plugins][.PlugIns]]
  * [[Quick Reference Guide][>QuickReferenceGuide]]
  * [[Full Reference Guide][<FitNesse.FullReferenceGuide]] (takes some time to load)
 

--- a/FitNesseRoot/FitNesse/UserGuide/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/content.txt
@@ -13,7 +13,7 @@
  * [[Working with the FitNesse wiki][>FitNesseWiki]]
  * [[Writing Acceptance Tests][>WritingAcceptanceTests]] (jump directly to [[Fit][>WritingAcceptanceTests.FitFramework]] or [[Slim][>WritingAcceptanceTests.SliM]])
  * [[Administering FitNesse][>AdministeringFitNesse]]
- * [[Extend Fitnesse with Plugins][.PlugIns]]
+ * [[Plugins][.PlugIns]]
  * [[Quick Reference Guide][>QuickReferenceGuide]]
  * [[Full Reference Guide][<FitNesse.FullReferenceGuide]] (takes some time to load)
 

--- a/FitNesseRoot/PageFooter/content.txt
+++ b/FitNesseRoot/PageFooter/content.txt
@@ -1,1 +1,1 @@
-[[Front Page][.FrontPage]] | [[User Guide][.FitNesse.UserGuide]] | [[root][root]] (for global !-!path's-!, ''etc.'') | Press '?' for keyboard shortcuts  | [[Extend Fitnesse with Plugins][.PlugIns]] | [[Contact][http://fitnesse.org/StayInformed]] | [[(edit)][.PageFooter?edit]]
+[[Front Page][.FrontPage]] | [[User Guide][.FitNesse.UserGuide]] | [[root][root]] (for global !-!path's-!, ''etc.'') | Press '?' for keyboard shortcuts  | [[Plugins][.PlugIns]] | [[Contact][http://fitnesse.org/StayInformed]] | [[(edit)][.PageFooter?edit]]

--- a/FitNesseRoot/PageFooter/content.txt
+++ b/FitNesseRoot/PageFooter/content.txt
@@ -1,1 +1,1 @@
-[[Front Page][.FrontPage]] | [[User Guide][.FitNesse.UserGuide]] | [[root][root]] (for global !-!path's-!, ''etc.'') | Press '?' for keyboard shortcuts [[(edit)][.PageFooter?edit]]
+[[Front Page][.FrontPage]] | [[User Guide][.FitNesse.UserGuide]] | [[root][root]] (for global !-!path's-!, ''etc.'') | Press '?' for keyboard shortcuts  | [[Extend Fitnesse with Plugins][.PlugIns]] | [[Contact][http://fitnesse.org/StayInformed]] | [[(edit)][.PageFooter?edit]]

--- a/FitNesseRoot/PlugIns/content.txt
+++ b/FitNesseRoot/PlugIns/content.txt
@@ -6,7 +6,7 @@
  * Fixture frameworks you can use 
  * and more ...
 
-See http://fitnesse.org/PlugIns for a list of all available extensions.
+See [[All Available Plugins][http://fitnesse.org/PlugIns?getPage&FitnesseVersion=${FITNESSE_VERSION}]] for a list of all available extensions.
 
 Read [[Writing Plugins][FitNesse.UserGuide.AdministeringFitNesse.WritingPlugins]] to understand how to install them or write your ownn.
 

--- a/FitNesseRoot/PlugIns/content.txt
+++ b/FitNesseRoot/PlugIns/content.txt
@@ -1,5 +1,5 @@
-!1 Get more out of Fitnesse
-!3 Add Plugins to your installation and extend Fitnesse with additional great features.
+!1 Get more out of !-FitNesse-!
+!3 Add Plugins to your installation and extend !-FitNesse-! with additional great features.
  * Suport for other programming languages
  * Additional table types to express your tests and requirements in other ways
  * Additional Wiki Markup commands 

--- a/FitNesseRoot/PlugIns/content.txt
+++ b/FitNesseRoot/PlugIns/content.txt
@@ -1,0 +1,16 @@
+!1 Get more out of Fitnesse
+!3 Add Plugins to your installation and extend Fitnesse with additional great features.
+ * Suport for other programming languages
+ * Additional table types to express your tests and requirements in other ways
+ * Additional Wiki Markup commands 
+ * Fixture frameworks you can use 
+ * and more ...
+
+See http://fitnesse.org/PlugIns for a list of all available extensions.
+
+Read [[Writing Plugins][FitNesse.UserGuide.AdministeringFitNesse.WritingPlugins]] to understand how to install them or write your ownn.
+
+
+Below is the list of all installed plugins in this system:
+
+!contents -R1 -g -p -f -h

--- a/FitNesseRoot/PlugIns/properties.xml
+++ b/FitNesseRoot/PlugIns/properties.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>


### PR DESCRIPTION
This PR has additional documentation:

1) Add base folder for plugin documentation as discussed in #685
 
 2) Add information about plugins and contacts to the standard page footer
On fitnesse.org the information about plugins is eye catching. Once FitNesse is installed on your own system no eye catching link is provided.
By adding a link to the footer this should advertise the plugins and hopefully more people will provide plugins.
For new users of FitNesse it is also important that they don't feel left alone and have an easy way to get help. The contact link in the footer should do the job. 