### PR TITLE
Fix failing junit test under Windows

### DIFF
--- a/test/fitnesse/wiki/fs/WikiFilePageTest.java
+++ b/test/fitnesse/wiki/fs/WikiFilePageTest.java
@@ -36,7 +36,8 @@ public class WikiFilePageTest {
     final List<WikiPage> children = root.getChildren();
 
     assertThat(children, hasSize(1));
-    assertThat(((WikiFilePage) children.get(0)).getFileSystemPath().getPath(), is("root/testPage"));
+    assertThat(((WikiFilePage) children.get(0)).getFileSystemPath().getPath(),
+        is("root" + File.separator + "testPage"));
     assertThat(children.get(0).getName(), is("testPage"));
   }
 
@@ -50,7 +51,8 @@ public class WikiFilePageTest {
     final List<WikiPage> children = root.getChildren();
 
     assertThat(children, hasSize(1));
-    assertThat(((WikiFilePage) children.get(0)).getFileSystemPath().getPath(), is("root/testPage"));
+    assertThat(((WikiFilePage) children.get(0)).getFileSystemPath().getPath(),
+        is("root" + File.separator + "testPage"));
     assertThat(children.get(0).getName(), is("testPage"));
   }
 


### PR DESCRIPTION
junit test "WikiFilePageTest.java" failed under Windows.
The below make it work and I assume it will still work under Linux and Mac 
 