### PR TITLE
Issue 859 gracefull names

### DIFF
--- a/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
@@ -65,8 +65,8 @@ public class DefaultInteraction implements FixtureInteraction {
     throw new SlimError(String.format("message:<<%s %s>>", SlimServer.NO_CLASS, className));
   }
 
-  private String swapCaseOfFirstLetter(String className) {
-    return StringUtils.swapCase(className.substring(0, 1)) + className.substring((1));
+  private String swapCaseOfFirstLetter(String classOrMethodName) {
+    return StringUtils.swapCase(classOrMethodName.substring(0, 1)) + classOrMethodName.substring((1));
   }
 
   protected Class<?> getClass(String className) {
@@ -110,13 +110,19 @@ public class DefaultInteraction implements FixtureInteraction {
 
     int nArgs = args.length;
     for (Method method : methods) {
-      boolean hasMatchingName = method.getName().equals(methodName);
-      boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
-      if (hasMatchingName && hasMatchingArguments) {
+      boolean isMatchingMethod = findMatchingMethod(methodName, nArgs, method);
+      isMatchingMethod = isMatchingMethod || findMatchingMethod(swapCaseOfFirstLetter(methodName), nArgs, method);
+      if (isMatchingMethod) {
         return method;
       }
     }
     return null;
+  }
+
+  private boolean findMatchingMethod(String methodName, int nArgs, Method method) {
+    boolean hasMatchingName = method.getName().equals(methodName);
+    boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
+    return hasMatchingName && hasMatchingArguments;
   }
 
   protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {

--- a/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
@@ -10,6 +10,7 @@ import fitnesse.slim.ConverterSupport;
 import fitnesse.slim.MethodExecutionResult;
 import fitnesse.slim.SlimError;
 import fitnesse.slim.SlimServer;
+import org.apache.commons.lang.StringUtils;
 
 public class DefaultInteraction implements FixtureInteraction {
   private static final Method AROUND_METHOD;
@@ -22,138 +23,147 @@ public class DefaultInteraction implements FixtureInteraction {
     }
   }
 
-	@Override
-	public Object createInstance(List<String> paths, String className, Object[] args)
-			throws IllegalArgumentException, InstantiationException,
-			IllegalAccessException, InvocationTargetException {
-		Class<?> k = searchPathsForClass(paths, className);
-		Constructor<?> constructor = getConstructor(k, args);
-		if (constructor == null) {
-			throw new SlimError(String.format("message:<<%s %s>>",
-					SlimServer.NO_CONSTRUCTOR, className));
-		}
+  @Override
+  public Object createInstance(List<String> paths, String className, Object[] args)
+    throws IllegalArgumentException, InstantiationException,
+    IllegalAccessException, InvocationTargetException {
+    Class<?> k = searchPathsForClass(paths, className);
+    Constructor<?> constructor = getConstructor(k, args);
+    if (constructor == null) {
+      throw new SlimError(String.format("message:<<%s %s>>",
+        SlimServer.NO_CONSTRUCTOR, className));
+    }
 
-		return newInstance(args, constructor);
-	}
+    return newInstance(args, constructor);
+  }
 
-	private Object newInstance(Object[] args, Constructor<?> constructor)
-			throws IllegalAccessException, InstantiationException,
-			InvocationTargetException {
-		Object[] initargs = ConverterSupport.convertArgs(args,
-				constructor.getParameterTypes());
+  private Object newInstance(Object[] args, Constructor<?> constructor)
+    throws IllegalAccessException, InstantiationException,
+    InvocationTargetException {
+    Object[] initargs = ConverterSupport.convertArgs(args,
+      constructor.getParameterTypes());
 
-		return newInstance(constructor, initargs);
-	}
+    return newInstance(constructor, initargs);
+  }
 
 
-	protected Class<?> searchPathsForClass(List<String> paths, String className) {
-		Class<?> k = getClass(className);
+  protected Class<?> searchPathsForClass(List<String> paths, String className) {
+    Class<?> k = getClass(className);
 
-		if (k != null) {
-			return k;
-		}
-		for (String path : paths) {
-			k = getClass(path + "." + className);
-			if (k != null) {
-				return k;
-			}
-		}
-		throw new SlimError(String.format("message:<<%s %s>>", SlimServer.NO_CLASS, className));
-	}
+    if (k != null) {
+      return k;
+    }
+    for (String path : paths) {
+      k = getClass(path + "." + className);
+      if (k == null) {
+        k = getClass(path + "." + swapCaseOfFirstLetter(className));
+      }
+      if (k != null) {
+        return k;
+      }
+    }
+    throw new SlimError(String.format("message:<<%s %s>>", SlimServer.NO_CLASS, className));
+  }
 
-	protected Class<?> getClass(String className) {
-		try {
-			return Class.forName(className);
-		} catch (ClassNotFoundException e) {
-			return null;
-		}
-	}
+  private String swapCaseOfFirstLetter(String className) {
+    return StringUtils.swapCase(className.substring(0, 1)) + className.substring((1));
+  }
 
-	protected Constructor<?> getConstructor(Class<?> clazz,
-			Object[] args) {
+  protected Class<?> getClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (NoClassDefFoundError e) {
+      return null;
+    }
+  }
 
-		for (Constructor<?> constructor : clazz.getConstructors()) {
-			Class<?>[] arguments = constructor.getParameterTypes();
-			if (arguments.length == args.length) {
-				return constructor;
-			}
-		}
-		return null;
-	}
+  protected Constructor<?> getConstructor(Class<?> clazz,
+                                          Object[] args) {
 
-	protected Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
-		return constructor.newInstance(initargs);
-	}
+    for (Constructor<?> constructor : clazz.getConstructors()) {
+      Class<?>[] arguments = constructor.getParameterTypes();
+      if (arguments.length == args.length) {
+        return constructor;
+      }
+    }
+    return null;
+  }
 
-	@Override
-	public MethodExecutionResult findAndInvoke(String methodName, Object instance, Object... args) throws Throwable {
-		Method method = findMatchingMethod(methodName, instance, args);
-		if (method != null) {
-			return this.invokeMethod(instance, method, args);
-		}
-		return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
-	}
-
-	protected Method findMatchingMethod(String methodName, Object instance, Object... args) {
-    Class<?> k = instance.getClass();
-		Method[] methods = k.getMethods();
-
-    int nArgs = args.length;
-		for (Method method : methods) {
-			boolean hasMatchingName = method.getName().equals(methodName);
-			boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
-			if (hasMatchingName && hasMatchingArguments) {
-				return method;
-			}
-		}
-		return null;
-	}
-
-	protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {
-		Object[] convertedArgs = convertArgs(method, args);
-		Object retval = callMethod(instance, method, convertedArgs);
-		Class<?> retType = method.getReturnType();
-		return new MethodExecutionResult(retval, retType);
-	}
-
-	protected Object[] convertArgs(Method method, Object[] args) {
-		Type[] argumentParameterTypes = method.getGenericParameterTypes();
-		return ConverterSupport.convertArgs(args, argumentParameterTypes);
-	}
-
-	protected Object callMethod(Object instance, Method method, Object[] convertedArgs) throws Throwable {
-		try {
-			Object result;
-			if (instance instanceof InteractionAwareFixture) {
-				// invoke via interaction, so it can also do its thing on the aroundMethod invocation
-				Object[] args = { this, method, convertedArgs };
-        result = methodInvoke(AROUND_METHOD, instance, args);
-			} else {
-				result = methodInvoke(method, instance, convertedArgs);
-			}
-			return result;
-		} catch (InvocationTargetException e) {
-			if (e.getCause() != null) {
-				throw e.getCause();
-			} else {
-				throw e.getTargetException();
-			}
-		}
-	}
+  protected Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    return constructor.newInstance(initargs);
+  }
 
   @Override
-	public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws Throwable {
-		try {
-			return method.invoke(instance, convertedArgs);
-		} catch (InvocationTargetException e) {
-			if (e.getCause() != null) {
-				throw e.getCause();
-			} else {
-				throw e.getTargetException();
-			}
-		} catch (IllegalArgumentException e) {
-		  throw new RuntimeException("Bad call of: " + method.getDeclaringClass().getName() + "." + method.getName()
-                                  + ". On instance of: " + instance.getClass().getName(), e);
+  public MethodExecutionResult findAndInvoke(String methodName, Object instance, Object... args) throws Throwable {
+    Method method = findMatchingMethod(methodName, instance, args);
+    if (method != null) {
+      return this.invokeMethod(instance, method, args);
     }
-	}
+    return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
+  }
+
+  protected Method findMatchingMethod(String methodName, Object instance, Object... args) {
+    Class<?> k = instance.getClass();
+    Method[] methods = k.getMethods();
+
+    int nArgs = args.length;
+    for (Method method : methods) {
+      boolean hasMatchingName = method.getName().equals(methodName);
+      boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
+      if (hasMatchingName && hasMatchingArguments) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {
+    Object[] convertedArgs = convertArgs(method, args);
+    Object retval = callMethod(instance, method, convertedArgs);
+    Class<?> retType = method.getReturnType();
+    return new MethodExecutionResult(retval, retType);
+  }
+
+  protected Object[] convertArgs(Method method, Object[] args) {
+    Type[] argumentParameterTypes = method.getGenericParameterTypes();
+    return ConverterSupport.convertArgs(args, argumentParameterTypes);
+  }
+
+  protected Object callMethod(Object instance, Method method, Object[] convertedArgs) throws Throwable {
+    try {
+      Object result;
+      if (instance instanceof InteractionAwareFixture) {
+        // invoke via interaction, so it can also do its thing on the aroundMethod invocation
+        Object[] args = {this, method, convertedArgs};
+        result = methodInvoke(AROUND_METHOD, instance, args);
+      } else {
+        result = methodInvoke(method, instance, convertedArgs);
+      }
+      return result;
+    } catch (InvocationTargetException e) {
+      if (e.getCause() != null) {
+        throw e.getCause();
+      } else {
+        throw e.getTargetException();
+      }
+    }
+  }
+
+  @Override
+  public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws Throwable {
+    try {
+      return method.invoke(instance, convertedArgs);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() != null) {
+        throw e.getCause();
+      } else {
+        throw e.getTargetException();
+      }
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("Bad call of: " + method.getDeclaringClass().getName() + "." + method.getName()
+        + ". On instance of: " + instance.getClass().getName(), e);
+    }
+  }
 }

--- a/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
+++ b/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
@@ -1,11 +1,16 @@
 package fitnesse.slim.fixtureInteraction;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class DefaultInteractionTest {
   Class<Testee> testeeClass = Testee.class;
@@ -41,5 +46,21 @@ public class DefaultInteractionTest {
 
     String expectedMockingOnlyString = "----mockingOnly----";
     assertEquals("should be able create, and call setters and getters. These won't work", expectedMockingOnlyString, gotI);
+  }
+
+  @Test
+  public void createInstanceWithValidClassName() throws Exception{
+    DefaultInteraction interaction = new DefaultInteraction();
+
+    Object testee = interaction.createInstance(Arrays.asList("fitnesse.slim.fixtureInteraction"), "Testee", new Object[0]);
+    assertThat(testee, is(notNullValue()));
+  }
+
+  @Test
+  public void createInstanceWithInvalidCapitalizedClassName() throws Exception{
+    DefaultInteraction interaction = new DefaultInteraction();
+
+    Object testee = interaction.createInstance(Arrays.asList("fitnesse.slim.fixtureInteraction"), "testee", new Object[0]);
+    assertThat(testee, is(notNullValue()));
   }
 }

--- a/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
+++ b/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
@@ -63,4 +63,20 @@ public class DefaultInteractionTest {
     Object testee = interaction.createInstance(Arrays.asList("fitnesse.slim.fixtureInteraction"), "testee", new Object[0]);
     assertThat(testee, is(notNullValue()));
   }
+
+  @Test
+  public void findMatchingMethodWithCorrectCapitalization() {
+    DefaultInteraction interaction = new DefaultInteraction();
+
+    Method setI = interaction.findMatchingMethod("setI", new Testee(), new Integer(1));
+    assertThat(setI, is(notNullValue()));
+  }
+
+  @Test
+  public void findMatchingMethodWithIncorrectCapitalizationShouldReturnCorrectMethod() {
+    DefaultInteraction interaction = new DefaultInteraction();
+
+    Method setI = interaction.findMatchingMethod("SetI", new Testee(), new Integer(1));
+    assertThat(setI, is(notNullValue()));
+  }
 }


### PR DESCRIPTION
This fixes #859, fixes #863, fixes #655, fixes #783

The best way to fix the loading of classnames and matching methods was not in the Disgracer, which works fine.
The fix is a bit deeper in the system where the actual class or method is found, so we have a good fallback option.