### PR TITLE
SliM execute fixture constructor based on parameters types #966

### DIFF
--- a/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
+++ b/src/fitnesse/slim/fixtureInteraction/DefaultInteraction.java
@@ -1,17 +1,17 @@
 package fitnesse.slim.fixtureInteraction;
 
+import fitnesse.slim.ConverterSupport;
+import fitnesse.slim.MethodExecutionResult;
+import fitnesse.slim.SlimError;
+import fitnesse.slim.SlimServer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import fitnesse.slim.ConverterSupport;
-import fitnesse.slim.MethodExecutionResult;
-import fitnesse.slim.SlimError;
-import fitnesse.slim.SlimServer;
-
 public class DefaultInteraction implements FixtureInteraction {
+
   private static final Method AROUND_METHOD;
 
   static {
@@ -22,138 +22,186 @@ public class DefaultInteraction implements FixtureInteraction {
     }
   }
 
-	@Override
-	public Object createInstance(List<String> paths, String className, Object[] args)
-			throws IllegalArgumentException, InstantiationException,
-			IllegalAccessException, InvocationTargetException {
-		Class<?> k = searchPathsForClass(paths, className);
-		Constructor<?> constructor = getConstructor(k, args);
-		if (constructor == null) {
-			throw new SlimError(String.format("message:<<%s %s>>",
-					SlimServer.NO_CONSTRUCTOR, className));
-		}
+  @Override
+  public Object createInstance(List<String> paths, String className, Object[] args)
+          throws IllegalArgumentException, InstantiationException,
+          IllegalAccessException, InvocationTargetException {
+    Class<?> k = searchPathsForClass(paths, className);
+    Constructor<?> constructor = getConstructor(k, args);
+    if (constructor == null) {
+      throw new SlimError(String.format("message:<<%s %s>>",
+              SlimServer.NO_CONSTRUCTOR, className));
+    }
 
-		return newInstance(args, constructor);
-	}
+    return newInstance(args, constructor);
+  }
 
-	private Object newInstance(Object[] args, Constructor<?> constructor)
-			throws IllegalAccessException, InstantiationException,
-			InvocationTargetException {
-		Object[] initargs = ConverterSupport.convertArgs(args,
-				constructor.getParameterTypes());
+  private Object newInstance(Object[] args, Constructor<?> constructor)
+          throws IllegalAccessException, InstantiationException,
+          InvocationTargetException {
+    Object[] initargs = ConverterSupport.convertArgs(args,
+            constructor.getParameterTypes());
 
-		return newInstance(constructor, initargs);
-	}
+    return newInstance(constructor, initargs);
+  }
 
+  protected Class<?> searchPathsForClass(List<String> paths, String className) {
+    Class<?> k = getClass(className);
 
-	protected Class<?> searchPathsForClass(List<String> paths, String className) {
-		Class<?> k = getClass(className);
+    if (k != null) {
+      return k;
+    }
+    for (String path : paths) {
+      k = getClass(path + "." + className);
+      if (k != null) {
+        return k;
+      }
+    }
+    throw new SlimError(String.format("message:<<%s %s>>", SlimServer.NO_CLASS, className));
+  }
 
-		if (k != null) {
-			return k;
-		}
-		for (String path : paths) {
-			k = getClass(path + "." + className);
-			if (k != null) {
-				return k;
-			}
-		}
-		throw new SlimError(String.format("message:<<%s %s>>", SlimServer.NO_CLASS, className));
-	}
+  protected Class<?> getClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
 
-	protected Class<?> getClass(String className) {
-		try {
-			return Class.forName(className);
-		} catch (ClassNotFoundException e) {
-			return null;
-		}
-	}
+  /**
+   *
+   * @param clazz the class to be executed
+   * @param args the class constructor arguments values
+   * @return the class constructor with the arguments types equals with
+   * {@code  args}, otherwise return the first constructor which matches as
+   * arguments number
+   */
+  protected Constructor<?> getConstructor(Class<?> clazz,
+          Object... args) {
+    /*in case no constructor has the args types, then return the first constructor which
+    * matches as args number, and not as args types
+     */
+    Constructor<?> defaultConstructor = null;
+    for (Constructor<?> constructor : clazz.getConstructors()) {
+      Class<?>[] constructorArgs = constructor.getParameterTypes();
+      if (constructorArgs.length == args.length) {
+        if (defaultConstructor == null) {
+          defaultConstructor = constructor;
+        }
+        if (hasConstructorArgsTypes(constructorArgs, args)) {
+          return constructor;
+        }
+      }
+    }
+    return defaultConstructor;
+  }
 
-	protected Constructor<?> getConstructor(Class<?> clazz,
-			Object[] args) {
+  private boolean hasConstructorArgsTypes(Class<?>[] constructorArgs, Object[] args) {
+    boolean constructorMatched = true;
+    for (int i = 0; i < constructorArgs.length; i++) {
+      if (args[i] == null) {
+        continue;
+      }
+      Class<?> classArg = constructorArgs[i];
+      Class<?> classInputArg = args[i].getClass();
+      if (!constructorArgs[i].isAssignableFrom(args[i].getClass())) {
+        if (constructorArgs[i].isPrimitive()) {
+          constructorMatched = isWrapper(classArg, classInputArg);
+        } else {
+          constructorMatched = false;
+        }
+      }
+      if (!constructorMatched) {
+        break;
+      }
+    }
+    return constructorMatched;
+  }
 
-		for (Constructor<?> constructor : clazz.getConstructors()) {
-			Class<?>[] arguments = constructor.getParameterTypes();
-			if (arguments.length == args.length) {
-				return constructor;
-			}
-		}
-		return null;
-	}
+  private boolean isWrapper(Class<?> classArg, Class<?> classInputArg) {
+    return ((Long.TYPE.equals(classArg)) && (Long.class.equals(classInputArg)))
+            || ((Double.TYPE.equals(classArg)) && (Double.class.equals(classInputArg)))
+            || ((Float.TYPE.equals(classArg)) && (Float.class.equals(classInputArg)))
+            || ((Integer.TYPE.equals(classArg)) && (Integer.class.equals(classInputArg)))
+            || ((Character.TYPE.equals(classArg)) && (Character.class.equals(classInputArg)))
+            || ((Short.TYPE.equals(classArg)) && (Short.class.equals(classInputArg)))
+            || ((Byte.TYPE.equals(classArg)) && (Byte.class.equals(classInputArg)))
+            || ((Boolean.TYPE.equals(classArg)) && (Boolean.class.equals(classInputArg)));
+  }
 
-	protected Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
-		return constructor.newInstance(initargs);
-	}
-
-	@Override
-	public MethodExecutionResult findAndInvoke(String methodName, Object instance, Object... args) throws Throwable {
-		Method method = findMatchingMethod(methodName, instance, args);
-		if (method != null) {
-			return this.invokeMethod(instance, method, args);
-		}
-		return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
-	}
-
-	protected Method findMatchingMethod(String methodName, Object instance, Object... args) {
-    Class<?> k = instance.getClass();
-		Method[] methods = k.getMethods();
-
-    int nArgs = args.length;
-		for (Method method : methods) {
-			boolean hasMatchingName = method.getName().equals(methodName);
-			boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
-			if (hasMatchingName && hasMatchingArguments) {
-				return method;
-			}
-		}
-		return null;
-	}
-
-	protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {
-		Object[] convertedArgs = convertArgs(method, args);
-		Object retval = callMethod(instance, method, convertedArgs);
-		Class<?> retType = method.getReturnType();
-		return new MethodExecutionResult(retval, retType);
-	}
-
-	protected Object[] convertArgs(Method method, Object[] args) {
-		Type[] argumentParameterTypes = method.getGenericParameterTypes();
-		return ConverterSupport.convertArgs(args, argumentParameterTypes);
-	}
-
-	protected Object callMethod(Object instance, Method method, Object[] convertedArgs) throws Throwable {
-		try {
-			Object result;
-			if (instance instanceof InteractionAwareFixture) {
-				// invoke via interaction, so it can also do its thing on the aroundMethod invocation
-				Object[] args = { this, method, convertedArgs };
-        result = methodInvoke(AROUND_METHOD, instance, args);
-			} else {
-				result = methodInvoke(method, instance, convertedArgs);
-			}
-			return result;
-		} catch (InvocationTargetException e) {
-			if (e.getCause() != null) {
-				throw e.getCause();
-			} else {
-				throw e.getTargetException();
-			}
-		}
-	}
+  protected Object newInstance(Constructor<?> constructor, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    return constructor.newInstance(initargs);
+  }
 
   @Override
-	public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws Throwable {
-		try {
-			return method.invoke(instance, convertedArgs);
-		} catch (InvocationTargetException e) {
-			if (e.getCause() != null) {
-				throw e.getCause();
-			} else {
-				throw e.getTargetException();
-			}
-		} catch (IllegalArgumentException e) {
-		  throw new RuntimeException("Bad call of: " + method.getDeclaringClass().getName() + "." + method.getName()
-                                  + ". On instance of: " + instance.getClass().getName(), e);
+  public MethodExecutionResult findAndInvoke(String methodName, Object instance, Object... args) throws Throwable {
+    Method method = findMatchingMethod(methodName, instance, args);
+    if (method != null) {
+      return this.invokeMethod(instance, method, args);
     }
-	}
+    return MethodExecutionResult.noMethod(methodName, instance.getClass(), args.length);
+  }
+
+  protected Method findMatchingMethod(String methodName, Object instance, Object... args) {
+    Class<?> k = instance.getClass();
+    Method[] methods = k.getMethods();
+
+    int nArgs = args.length;
+    for (Method method : methods) {
+      boolean hasMatchingName = method.getName().equals(methodName);
+      boolean hasMatchingArguments = method.getParameterTypes().length == nArgs;
+      if (hasMatchingName && hasMatchingArguments) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  protected MethodExecutionResult invokeMethod(Object instance, Method method, Object[] args) throws Throwable {
+    Object[] convertedArgs = convertArgs(method, args);
+    Object retval = callMethod(instance, method, convertedArgs);
+    Class<?> retType = method.getReturnType();
+    return new MethodExecutionResult(retval, retType);
+  }
+
+  protected Object[] convertArgs(Method method, Object[] args) {
+    Type[] argumentParameterTypes = method.getGenericParameterTypes();
+    return ConverterSupport.convertArgs(args, argumentParameterTypes);
+  }
+
+  protected Object callMethod(Object instance, Method method, Object[] convertedArgs) throws Throwable {
+    try {
+      Object result;
+      if (instance instanceof InteractionAwareFixture) {
+        // invoke via interaction, so it can also do its thing on the aroundMethod invocation
+        Object[] args = {this, method, convertedArgs};
+        result = methodInvoke(AROUND_METHOD, instance, args);
+      } else {
+        result = methodInvoke(method, instance, convertedArgs);
+      }
+      return result;
+    } catch (InvocationTargetException e) {
+      if (e.getCause() != null) {
+        throw e.getCause();
+      } else {
+        throw e.getTargetException();
+      }
+    }
+  }
+
+  @Override
+  public Object methodInvoke(Method method, Object instance, Object... convertedArgs) throws Throwable {
+    try {
+      return method.invoke(instance, convertedArgs);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() != null) {
+        throw e.getCause();
+      } else {
+        throw e.getTargetException();
+      }
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("Bad call of: " + method.getDeclaringClass().getName() + "." + method.getName()
+              + ". On instance of: " + instance.getClass().getName(), e);
+    }
+  }
 }

--- a/src/fitnesse/slim/fixtureInteraction/Testee.java
+++ b/src/fitnesse/slim/fixtureInteraction/Testee.java
@@ -1,9 +1,43 @@
 package fitnesse.slim.fixtureInteraction;
 
+import java.util.Date;
+
 public class Testee {
+
   int i;
+  String stringVal;
+  Date dateVal;
+  double doubleVal;
+  float floatVal;
+  Integer intWrapperVal;
+
+  public Testee(int i, float floatVal) {
+    this.i = i;
+    this.floatVal = floatVal;
+  }
+
+  public Testee(int i, String stringVal, Date dateVal) {
+    this.i = i;
+    this.stringVal = stringVal;
+    this.dateVal = dateVal;
+  }
+
+  public Testee(Integer intWrapperVal, String stringVal, Date dateVal) {
+    this.stringVal = stringVal;
+    this.dateVal = dateVal;
+    this.intWrapperVal = intWrapperVal;
+  }
+
+  public Testee(int i, double realVal) {
+    this.i = i;
+    this.doubleVal = realVal;
+  }
 
   public Testee() {
+  }
+
+  public Testee(int i) {
+    this.i = i;
   }
 
   public int getI() {
@@ -13,4 +47,25 @@ public class Testee {
   public void setI(int i) {
     this.i = i;
   }
+
+  public String getStringVal() {
+    return stringVal;
+  }
+
+  public Date getDateVal() {
+    return dateVal;
+  }
+
+  public double getDoubleVal() {
+    return doubleVal;
+  }
+
+  public float getFloatVal() {
+    return floatVal;
+  }
+
+  public Integer getIntWrapperVal() {
+    return intWrapperVal;
+  }
+
 }

--- a/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
+++ b/test/fitnesse/slim/fixtureInteraction/DefaultInteractionTest.java
@@ -2,12 +2,13 @@ package fitnesse.slim.fixtureInteraction;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-
+import java.util.Date;
+import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 public class DefaultInteractionTest {
+
   Class<Testee> testeeClass = Testee.class;
   Constructor<?> cstr = testeeClass.getConstructors()[0];
   Method setI;
@@ -19,12 +20,55 @@ public class DefaultInteractionTest {
   }
 
   @Test
+  public void canExecuteConstructorWhenIntArgType() throws Throwable {
+    //given 
+    DefaultInteraction defaultInteraction = new DefaultInteraction();
+    Constructor<?> constructor = null;
+    Date dateVal = new Date();
+    Object args[] = new Object[]{1, "stringVal", dateVal};
+    //when 
+    constructor = defaultInteraction.getConstructor(Testee.class, args);
+    Testee testee = (Testee) constructor.newInstance(args);
+    //then 
+    assertEquals(1, testee.getI());
+    assertEquals("stringVal", testee.getStringVal());
+    assertEquals(dateVal, testee.getDateVal());
+  }
+
+  @Test
+  public void canExecuteConstructorWhenDoubleArgType() throws Throwable {
+    //given 
+    DefaultInteraction defaultInteraction = new DefaultInteraction();
+    Constructor<?> constructor = null;
+    Object args[] = new Object[]{1, 2.0d};
+    //when 
+    constructor = defaultInteraction.getConstructor(Testee.class, args);
+    Testee testee = (Testee) constructor.newInstance(args);
+    //then 
+    assertEquals(2.0d, testee.getDoubleVal(), 0.0d);
+    assertEquals(1, testee.getI());
+  }
+
+  @Test
+  public void canExecuteConstructorWhenFloatArgType() throws Throwable {
+    //given 
+    DefaultInteraction defaultInteraction = new DefaultInteraction();
+    Constructor<?> constructor = null;
+    Object args[] = new Object[]{1, 2.0f};
+    //when 
+    constructor = defaultInteraction.getConstructor(Testee.class, args);
+    Testee testee = (Testee) constructor.newInstance(args);
+    //then 
+    Assert.assertEquals(2.0f, testee.getFloatVal(), 0.0f);
+    assertEquals(1, testee.getI());
+  }
+
+  @Test
   public void canCreateAndUseATestObject() throws Throwable {
     Integer expectedInt = new Integer(7);
     DefaultInteraction interaction = new DefaultInteraction();
 
-
-    Testee o = (Testee) interaction.newInstance(cstr, (Object[]) null);
+    Testee o = (Testee) interaction.newInstance(cstr, new Object[]{1});
     interaction.methodInvoke(setI, o, expectedInt);
     Integer gotI = (Integer) interaction.methodInvoke(getI, o);
 


### PR DESCRIPTION
The scope of this fix is that when a fixture is executed, the fixture class constructor should be selected by taking in consideration the constructor arguments types.