### PR TITLE
Support system property based ExcludeSuiteFilter annotation

### DIFF
--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -89,6 +89,7 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   public @interface ExcludeSuiteFilter {
 
     public String value();
+    public String systemProperty() default "";
   }
   /**
    * The <code>FitnesseDir</code> annotation specifies the absolute or relative
@@ -297,7 +298,14 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
     if (excludeSuiteFilterAnnotation == null) {
       return null;
     }
-    return excludeSuiteFilterAnnotation.value();
+    if (!"".equals(excludeSuiteFilterAnnotation.value())) {
+      return excludeSuiteFilterAnnotation.value();
+    }
+    if (!"".equals(excludeSuiteFilterAnnotation.systemProperty())) {
+      return System.getProperty(excludeSuiteFilterAnnotation.systemProperty());
+    }
+    throw new InitializationError(
+            "In annotation @ExcludeSuiteFilter you have to specify either 'value' or 'systemProperty'");
   }
 
   protected boolean useDebugMode(Class<?> klass) throws Exception {

--- a/src/fitnesse/junit/FitNesseRunner.java
+++ b/src/fitnesse/junit/FitNesseRunner.java
@@ -44,8 +44,8 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface Suite {
 
-    public String value() default "";
-    public String systemProperty() default "";
+    String value() default "";
+    String systemProperty() default "";
   }
   /**
    * The <code>DebugMode</code> annotation specifies whether the test is run
@@ -55,7 +55,7 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface DebugMode {
 
-    public boolean value();
+    boolean value();
   }
 
   /**
@@ -65,7 +65,7 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface PreventSystemExit {
 
-    public boolean value() default true;
+    boolean value() default true;
   }
 
   /**
@@ -76,9 +76,9 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface SuiteFilter {
 
-    public String value() default "";
-    public String systemProperty() default "";
-    public boolean andStrategy() default false;
+    String value() default "";
+    String systemProperty() default "";
+    boolean andStrategy() default false;
   }
   /**
    * The <code>ExcludeSuiteFilter</code> annotation specifies a filter for excluding tests from the Fitnesse suite
@@ -88,8 +88,8 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface ExcludeSuiteFilter {
 
-    public String value();
-    public String systemProperty() default "";
+    String value();
+    String systemProperty() default "";
   }
   /**
    * The <code>FitnesseDir</code> annotation specifies the absolute or relative
@@ -106,9 +106,9 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface FitnesseDir {
 
-    public String value() default "";
-    public String systemProperty() default "";
-    public String fitNesseRoot() default ContextConfigurator.DEFAULT_ROOT;
+    String value() default "";
+    String systemProperty() default "";
+    String fitNesseRoot() default ContextConfigurator.DEFAULT_ROOT;
   }
   /**
    * The <code>OutputDir</code> annotation specifies where the html reports of
@@ -125,10 +125,10 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface OutputDir {
 
-    public String value() default "";
-    public String systemProperty() default "";
+    String value() default "";
+    String systemProperty() default "";
 
-    public String pathExtension() default "";
+    String pathExtension() default "";
 
   }
   /**
@@ -140,8 +140,8 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Deprecated
   public @interface Port {
 
-    public int value() default 0;
-    public String systemProperty() default "";
+    int value() default 0;
+    String systemProperty() default "";
 
   }
   /**
@@ -151,7 +151,7 @@ public class FitNesseRunner extends ParentRunner<WikiPage> {
   @Target(ElementType.TYPE)
   public @interface ConfigFile {
 
-    public String value();
+    String value();
   }
 
   private Class<?> suiteClass;


### PR DESCRIPTION
FitNesseRunner's SuiteFilter already supported getting a value from a system property, but the exclude  version does not. This pull requests allows the exclude filter to get its value from a system property also.

Furthermore I also removed the `public` modifier on FitNesseRunner's annotation's fields, as these are public by default.