### PR TITLE
Added two new keywords - 'check partial' and 'check partial not'

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -2,10 +2,6 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.testsystems.slim.tables;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import fitnesse.slim.converters.BooleanConverter;
 import fitnesse.slim.converters.VoidConverter;
 import fitnesse.slim.instructions.Instruction;
@@ -14,6 +10,10 @@ import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.slim.SlimTestContext;
 import fitnesse.testsystems.slim.Table;
 import fitnesse.testsystems.slim.results.SlimTestResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ScriptTable extends SlimTable {
   private static final String SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX = ";";
@@ -57,6 +57,25 @@ public class ScriptTable extends SlimTable {
   protected String getCheckKeyword() {
     return "check";
   }
+
+  /**
+   * Template method to provide the keyword for the {@code checkPartial} action.
+   *
+   * @return keyword for {@code checkPartial} action
+   */
+  protected String getCheckPartialKeyword() {
+    return "check partial";
+  }
+
+  /**
+   * Template method to provide the keyword for the {@code checkPartial} action.
+   *
+   * @return keyword for {@code checkPartial} action
+   */
+  protected String getCheckPartialNotKeyword() {
+    return "check partial not";
+  }
+
 
   /**
    * Template method to provide the keyword for the {@code checkNot} action.
@@ -127,6 +146,10 @@ public class ScriptTable extends SlimTable {
       assertions = startActor(row);
     else if (firstCell.equalsIgnoreCase(getCheckKeyword()))
       assertions = checkAction(row);
+    else if(firstCell.equalsIgnoreCase(getCheckPartialKeyword()))
+      assertions = checkPartialAction(row);
+    else if(firstCell.equalsIgnoreCase(getCheckPartialNotKeyword()))
+      assertions = checkPartialNotAction(row);
     else if (firstCell.equalsIgnoreCase(getCheckNotKeyword()))
       assertions = checkNotAction(row);
     else if (firstCell.equalsIgnoreCase(getRejectKeyword()))
@@ -237,6 +260,21 @@ public class ScriptTable extends SlimTable {
     return invokeAction(1, lastColInAction - 1, row,
             new RejectedValueExpectation(lastColInAction, row));
   }
+
+  protected List<SlimAssertion> checkPartialAction(int row) {
+    int lastColInAction = table.getColumnCountInRow(row) - 1;
+    table.getCellContents(lastColInAction, row);
+    return invokeAction(1, lastColInAction - 1, row,
+      new ReturnedValuePartialExpectation(lastColInAction, row));
+  }
+
+  protected List<SlimAssertion> checkPartialNotAction(int row) {
+    int lastColInAction = table.getColumnCountInRow(row) - 1;
+    table.getCellContents(lastColInAction, row);
+    return invokeAction(1, lastColInAction - 1, row,
+      new RejectedValuePartialExpectation(lastColInAction, row));
+  }
+
 
   protected List<SlimAssertion> invokeAction(int startingCol, int endingCol, int row, SlimExpectation expectation) {
     String actionName = getActionNameStartingAt(startingCol, endingCol, row);

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -264,15 +264,19 @@ public class ScriptTable extends SlimTable {
   protected List<SlimAssertion> checkPartialAction(int row) {
     int lastColInAction = table.getColumnCountInRow(row) - 1;
     table.getCellContents(lastColInAction, row);
+    String regexString = table.getCellContents(lastColInAction,row);
+    regexString = "=~/" + regexString + "/";
     return invokeAction(1, lastColInAction - 1, row,
-      new ReturnedValuePartialExpectation(lastColInAction, row));
+      new ReturnedValueExpectation(lastColInAction, row, regexString));
   }
 
   protected List<SlimAssertion> checkPartialNotAction(int row) {
     int lastColInAction = table.getColumnCountInRow(row) - 1;
     table.getCellContents(lastColInAction, row);
+    String regexString = table.getCellContents(lastColInAction,row);
+    regexString = "=~/" + regexString + "/";
     return invokeAction(1, lastColInAction - 1, row,
-      new RejectedValuePartialExpectation(lastColInAction, row));
+      new RejectedValueExpectation(lastColInAction, row, regexString));
   }
 
 

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -418,41 +418,6 @@ public abstract class SlimTable {
 
   }
 
-  class ReturnedValuePartialExpectation extends RowExpectation {
-    public ReturnedValuePartialExpectation(int col, int row) {
-      super(col, row, table.getCellContents(col, row));
-    }
-
-    public ReturnedValuePartialExpectation(int col, int row, String expected) {
-      super(col, row, expected);
-    }
-
-    @Override
-    protected SlimTestResult createEvaluationMessage(String actual, String expected) {
-      SlimTestResult testResult;
-      String replacedExpected = replaceSymbols(expected);
-
-      if (actual == null)
-        testResult = SlimTestResult.fail("null", replacedExpected); //todo can't be right message.
-      else if(actual.contains(replacedExpected))
-        testResult=SlimTestResult.pass(announceBlank(replaceSymbolsWithFullExpansion(expected)));
-      else if (replacedExpected.isEmpty())
-        testResult = SlimTestResult.ignore(actual);
-      else {
-        testResult = new Comparator(replacedExpected, actual, expected).evaluate();
-        if (testResult == null)
-          testResult = SlimTestResult.fail(actual, replaceSymbolsWithFullExpansion(expected));
-      }
-
-      return testResult;
-    }
-
-    private String announceBlank(String originalValue) {
-      return originalValue.isEmpty() ? "BLANK" : originalValue;
-    }
-
-  }
-
   class ReturnedSymbolExpectation extends ReturnedValueExpectation {
     private String symbolName;
     private String assignToName = null;
@@ -494,19 +459,8 @@ public abstract class SlimTable {
       super(col, row);
     }
 
-    @Override
-    protected SlimTestResult createEvaluationMessage(String actual, String expected) {
-      SlimTestResult testResult = super.createEvaluationMessage(actual, expected);
-      if (testResult != null)
-        return testResult.negateTestResult();
-      return null;
-    }
-  }
-
-
-  class RejectedValuePartialExpectation extends ReturnedValuePartialExpectation{
-    public RejectedValuePartialExpectation(int col, int row) {
-      super(col, row);
+    public RejectedValueExpectation(int col, int row, String content) {
+      super(col, row, content);
     }
 
     @Override

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
@@ -519,7 +519,7 @@ public class ScriptTableTest {
       asList(
         asList("scriptTable_id_0", "1234 saved.")
       ),
-      "[[Script], [check partial, func, pass(saved)]]", false
+      "[[Script], [check partial, func, pass(/saved/ found in: 1234 saved.)]]", false
     );
   }
 
@@ -529,7 +529,7 @@ public class ScriptTableTest {
       asList(
         asList("scriptTable_id_0", "successful")
       ),
-      "[[Script], [check partial, func, fail(a=successful;e=saved)]]", false
+      "[[Script], [check partial, func, fail(/saved/ not found in: successful)]]", false
     );
   }
 
@@ -539,7 +539,7 @@ public class ScriptTableTest {
       asList(
         asList("scriptTable_id_0", "success")
       ),
-      "[[Script], [check partial not, func, pass(a=success;e=saved)]]", false
+      "[[Script], [check partial not, func, pass(/saved/ not found in: success)]]", false
     );
   }
 
@@ -549,7 +549,7 @@ public class ScriptTableTest {
       asList(
         asList("scriptTable_id_0", "saved")
       ),
-      "[[Script], [check partial not, func, fail(saved)]]", false
+      "[[Script], [check partial not, func, fail(/saved/ found in: saved)]]", false
     );
   }
 

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
@@ -2,33 +2,26 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.testsystems.slim.tables;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import fitnesse.html.HtmlUtil;
-import fitnesse.testrunner.WikiTestPage;
-import fitnesse.testsystems.slim.SlimCommandRunningClient;
 import fitnesse.slim.converters.BooleanConverter;
 import fitnesse.slim.converters.VoidConverter;
 import fitnesse.slim.instructions.CallAndAssignInstruction;
 import fitnesse.slim.instructions.CallInstruction;
 import fitnesse.slim.instructions.Instruction;
 import fitnesse.slim.instructions.MakeInstruction;
-import fitnesse.testsystems.slim.HtmlTable;
-import fitnesse.testsystems.slim.HtmlTableScanner;
-import fitnesse.testsystems.slim.SlimTestContext;
-import fitnesse.testsystems.slim.SlimTestContextImpl;
-import fitnesse.testsystems.slim.Table;
-import fitnesse.testsystems.slim.TableScanner;
+import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.slim.*;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
-
 import org.apache.commons.collections.ListUtils;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -517,6 +510,46 @@ public class ScriptTableTest {
                     asList("localizedScriptTable_id_0", "3")
             ),
       "[[Script], [localized check, func, pass(3)]]", true
+    );
+  }
+
+  @Test
+  public void checkPartialPasses() throws Exception {
+    assertScriptResults("|check partial|func|saved|\n",
+      asList(
+        asList("scriptTable_id_0", "1234 saved.")
+      ),
+      "[[Script], [check partial, func, pass(saved)]]", false
+    );
+  }
+
+  @Test
+  public void checkPartialFails() throws Exception {
+    assertScriptResults("|check partial|func|saved|\n",
+      asList(
+        asList("scriptTable_id_0", "successful")
+      ),
+      "[[Script], [check partial, func, fail(a=successful;e=saved)]]", false
+    );
+  }
+
+  @Test
+  public void checkPartialNotPasses() throws Exception {
+    assertScriptResults("|check partial not|func|saved|\n",
+      asList(
+        asList("scriptTable_id_0", "success")
+      ),
+      "[[Script], [check partial not, func, pass(a=success;e=saved)]]", false
+    );
+  }
+
+  @Test
+  public void checkPartialNotFails() throws Exception {
+    assertScriptResults("|check partial not|func|saved|\n",
+      asList(
+        asList("scriptTable_id_0", "saved")
+      ),
+      "[[Script], [check partial not, func, fail(saved)]]", false
     );
   }
 


### PR DESCRIPTION
Many times we have to ensure that the text contains certain word to decide if the step is pass/fail. Keyword check is not sufficient as it checks the whole text. So, we have been writing extra code ( DoesContain(String,String) method in this example) to take care of partial validation like below.
![image](https://cloud.githubusercontent.com/assets/9042580/25554633/cb20669e-2c86-11e7-9c79-9d93c44a80cb.png)
With this pull request, this can be simplified in wiki and also we don't have to write native code to check text contain validation. The proposed way will be like this.
![image](https://cloud.githubusercontent.com/assets/9042580/25599593/41776c2c-2e92-11e7-9991-0e46399dd307.png)
Similarly, we can use 'check partial not' keyword for negative validations in steps.