### PR TITLE
Fix Table:Table resizing when the last line contains more results tha…

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/TableTable.java
+++ b/src/fitnesse/testsystems/slim/tables/TableTable.java
@@ -87,7 +87,7 @@ public class TableTable extends SlimTable {
   }
 
   private void extendExistingRows(Table table, List<List<Object>> tableResults) {
-    for (int row = 1; row < tableResults.size(); row++)
+    for (int row = 1; row < table.getRowCount(); row++)
       extendRow(table, row, tableResults.get(row - 1));
   }
 

--- a/test/fitnesse/testsystems/slim/tables/TableTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/TableTableTest.java
@@ -277,6 +277,16 @@ public class TableTableTest {
   }
 
   @Test
+  public void surplusExplicitOnLastLinePasses() throws Exception {
+    assertTableResults("|2|4|\n",
+            asList(
+                    asList("pass:x", "pass:y", "pass:z")
+            ),
+      "[[pass(Table:fixture), argument], [pass(x), pass(y), pass(z)]]"
+    );
+  }
+
+  @Test
   public void emptyTableWithResults() throws Exception {
     assertTableResults("",
             asList(


### PR DESCRIPTION
Fix Table:Table resizing when the last line contains more results than expected.

The last line of a table:table was never resized, even if there were more results than expected. It caused an IndexOutOfBoundsException.

This fix corrects this issue. I also added a unit test which cover this use case.