### PR TITLE
Allow Front matters to work with windows line endings

### DIFF
--- a/src/fitnesse/wikitext/parser/FrontMatter.java
+++ b/src/fitnesse/wikitext/parser/FrontMatter.java
@@ -8,7 +8,8 @@ public class FrontMatter extends SymbolType implements Rule, Translation {
   public static final FrontMatter symbolType = new FrontMatter();
   public static final SymbolType keyValueSymbolType = new SymbolType("KeyValue");
 
-  private static final String FRONT_MATTER_DELIMITER = "---\n";
+  private static final String FRONT_MATTER_DELIMITER_LF = "---\n";
+  private static final String FRONT_MATTER_DELIMITER_CRLF = "---\r\n";
 
   private static SymbolProvider SYMBOL_PROVIDER = new SymbolProvider(new SymbolType[] {
     CloseFrontMatter.symbolType, SymbolType.Colon, SymbolType.Whitespace, SymbolType.Newline, SymbolType.Text
@@ -16,7 +17,8 @@ public class FrontMatter extends SymbolType implements Rule, Translation {
 
   FrontMatter() {
     super("FrontMatter");
-    wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER));
+    wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER_LF));
+    wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER_CRLF));
     wikiRule(this);
     htmlTranslation(this);
   }
@@ -81,7 +83,8 @@ public class FrontMatter extends SymbolType implements Rule, Translation {
 
     private CloseFrontMatter() {
       super("EndOfFrontMatter");
-      wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER));
+      wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER_LF));
+      wikiMatcher(new Matcher().startLine().string(FRONT_MATTER_DELIMITER_CRLF));
     }
 
   }

--- a/test/fitnesse/wikitext/parser/FrontMatterTest.java
+++ b/test/fitnesse/wikitext/parser/FrontMatterTest.java
@@ -46,6 +46,16 @@ public class FrontMatterTest {
   }
 
   @Test
+  public void parseFrontMatterWithTextAndWindowsLineEndings() {
+    assertParses(
+      "---\r\n" +
+        "test\r\n" +
+        "---\r\n" +
+        "WikiText",
+      "SymbolList[FrontMatter[KeyValue[Text, Text]], Text]");
+  }
+
+  @Test
   public void parseFrontMatterWithKeyValueText() {
     assertParses(
         "---\n" +


### PR DESCRIPTION
Also match on CRLF line endings.

Fixes #1050.