### PR TITLE
Fix crash when Table Table returns extra columns

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/ExtraColumnsInResult.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/ExtraColumnsInResult.wiki
@@ -1,0 +1,14 @@
+---
+Test
+---
+|import            |
+|fitnesse.slim.test|
+
+!1 A Table Table fixture can return extra columns in the result
+
+Even if the table in the test has only one column, if the rows in the result have two columns, they will be displayed.
+
+|table: Table Table Inc First Col|
+|1          |
+|2          |
+|3          |

--- a/src/fitnesse/testsystems/slim/tables/TableTable.java
+++ b/src/fitnesse/testsystems/slim/tables/TableTable.java
@@ -87,7 +87,7 @@ public class TableTable extends SlimTable {
   }
 
   private void extendExistingRows(Table table, List<List<Object>> tableResults) {
-    for (int row = 1; row < tableResults.size(); row++)
+    for (int row = 1; row <= tableResults.size(); row++)
       extendRow(table, row, tableResults.get(row - 1));
   }
 


### PR DESCRIPTION
As per the documentation, a table table fixture should be able to
return rows that are wider than in the input.  However, an off-by-one
error was preventing that.