### PR TITLE
Support running FitNesse test suites which use Fixture Interactions through the JUnit Test Runner

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,9 @@
+component_depth: 1
+languages:
+- java
+- javascript
+exclude:
+- /extra/.*
+- /src/fitnesse/resources/codemirror/.*
+- /src/fitnesse/resources/javascript/jquery.*.js
+- /src/fitnesse/resources/bootstrap/js/bootstrap.js


### PR DESCRIPTION
The [FitNesseRunner](https://github.com/unclebob/fitnesse/blob/master/src/fitnesse/junit/FitNesseRunner.java) class does not allow test suites to be run if they rely upon the use of Fixture Interactions. This is due to the InProcessSlimClientBuilder ignoring the interaction property.

This PR contains a fix for this.