### PR TITLE
A SuiteQuery should not run test pages that are excluded

### DIFF
--- a/src/fitnesse/wiki/search/SuiteSpecificationMatchFinder.java
+++ b/src/fitnesse/wiki/search/SuiteSpecificationMatchFinder.java
@@ -1,6 +1,7 @@
 package fitnesse.wiki.search;
 
 import fitnesse.components.TraversalListener;
+import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 
 import java.util.regex.Matcher;
@@ -18,11 +19,18 @@ public class SuiteSpecificationMatchFinder extends WikiPageFinder {
 
   @Override
   protected boolean pageMatches(WikiPage page) {
+    if(isPruned(page)){
+      return false;
+    }
     if(!nullOrEmpty(titleRegEx) && !nullOrEmpty(contentRegEx))
        return patternMatches(titleRegEx, page.getName()) && patternMatches(contentRegEx,page.getData().getContent());
     else{
       return patternMatches(titleRegEx, page.getName()) || patternMatches(contentRegEx,page.getData().getContent());
     }
+  }
+
+  private boolean isPruned(WikiPage page) {
+    return page.getData().hasAttribute(PageData.PropertyPRUNE);
   }
 
   private boolean patternMatches(String regEx, String subject) {

--- a/test/fitnesse/wiki/search/SuiteSpecificationMatchFinderTest.java
+++ b/test/fitnesse/wiki/search/SuiteSpecificationMatchFinderTest.java
@@ -1,18 +1,20 @@
 package fitnesse.wiki.search;
 
-import fitnesse.wiki.WikiPageUtil;
 import fitnesse.components.TraversalListener;
-import fitnesse.wiki.fs.InMemoryPage;
+import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import fitnesse.wiki.WikiPageUtil;
+import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SuiteSpecificationMatchFinderTest implements TraversalListener<WikiPage> {
 
@@ -71,6 +73,14 @@ public class SuiteSpecificationMatchFinderTest implements TraversalListener<Wiki
     assertPagesFound("TestPageOne", "ChildPage");
   }
 
+  @Test
+  public void shouldExcludeSkippedPages() throws Exception {
+    finder = new SuiteSpecificationMatchFinder(null, ".*", this);
+    prunePage("TestPageTwo");
+    finder.search(root);
+    assertPagesFound("RooT", "TestPageOne", "ChildPage");
+  }
+
   @Override
   public void process(WikiPage page) {
     hits.add(page);
@@ -84,4 +94,12 @@ public class SuiteSpecificationMatchFinderTest implements TraversalListener<Wiki
       assertTrue(pageNameList.contains(page.getName()));
     }
   }
+
+  private void prunePage(String pageName) {
+    WikiPage testPageTwo = root.getChildPage(pageName);
+    PageData data = testPageTwo.getData();
+    data.setAttribute(PageData.PropertyPRUNE);
+    testPageTwo.commit(data);
+  }
+
 }


### PR DESCRIPTION
Current situation: When a test page is skipped, and there is a SuiteQuery that matches this page, it will execute the page although it is skipped.

This pull request addresses this situation and makes the SuiteQuery ignore skipped tests.

Note: Although the skipping is meant to be recursive, the SuiteQuery does not yet ignore children of a skipped test. This is a bit more complicated, and I will try to work on it. But I think even this small improvement is worthwhile, therefore I'm sending it as an individual PR.
