### PR TITLE
Add root page to fileset, to fix #987

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,8 @@
 		<include name="FrontPage/**"/>
 		<include name="PageHeader/**"/>
 		<include name="PageFooter/**"/>
+		<include name="content.txt"/>
+		<include name="properties.xml"/>
 		<include name="TemplateLibrary/**"/>
 		<exclude name="**/*.zip"/>
 	</zipfileset>


### PR DESCRIPTION
By ensuring these files exist FitNesse will detect it should not use the `ExternalSuitePageFactory`, even though .html files exist in the tree....