### PR TITLE
Add root page to fileset, to fix #987

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,8 @@ task compileBootstrap(type: LessCompiler) {
 task createUpdateLists(type: WikiFileListBuilderTask) {
   outputDirectory = "${sourceSets.main.output.resourcesDir}/Resources"
   doNotReplaceFiles = [
+    "FitNesseRoot/content.txt",
+    "FitNesseRoot/properties.xml",
     "FitNesseRoot/FrontPage/content.txt",
     "FitNesseRoot/FrontPage/properties.xml",
     "FitNesseRoot/PageHeader/content.txt",
@@ -150,6 +152,8 @@ jar {
   dependsOn createUpdateLists
   into('Resources') {
     from('.') {
+      include 'FitNesseRoot/content.txt'
+      include 'FitNesseRoot/properties.xml'
       include 'FitNesseRoot/FitNesse/**/content.txt'
       include 'FitNesseRoot/FitNesse/**/properties.xml'
       include 'FitNesseRoot/FrontPage/**/content.txt'


### PR DESCRIPTION
Add content.txt and properties.xml to FitNesseRoot created on initial run. So that .html files are allowed in the FitNesseRoot...