### PR TITLE
Added publishing in-execution individual test results to JMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,12 @@ dependencies {
   compile "org.htmlparser:htmlparser:2.1"
   compile "org.htmlparser:htmllexer:2.1"
   compile "org.apache.velocity:velocity:1.7"
+  compile "org.apache.activemq:activemq-all:5.15.0"
   compile "commons-lang:commons-lang:2.6"
   compile "commons-collections:commons-collections:3.2.2"
   compile "org.json:json:20151123"
   compile "com.googlecode.java-diff-utils:diffutils:1.3.0"
+  compile "javax.jms:javax.jms-api:2.0.1"
   optional "org.apache.ant:ant:1.9.6"
   optional "junit:junit:4.12"
 

--- a/src/fitnesse/components/MessagePublisher.java
+++ b/src/fitnesse/components/MessagePublisher.java
@@ -1,0 +1,48 @@
+package fitnesse.components;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import fitnesse.testsystems.TestPage;
+import fitnesse.testsystems.TestSummary;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.json.JSONObject;
+
+import javax.jms.*;
+
+public class MessagePublisher {
+  public static void publishStatusToJMSSend(TestPage sourcePage, TestSummary summary) {
+    try {
+      String textToPublish = getStringifiedMessageToPublish(sourcePage, summary);
+      String serverAddress = sourcePage.getVariable(WikiPageIdentity.MESSAGE_BROKER_ADDRESS);
+      String queueName = sourcePage.getVariable(WikiPageIdentity.QUEUE_NAME);
+
+      ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(serverAddress);
+      Connection connection = connectionFactory.createConnection();
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+      connection.start();
+      Destination destination = session.createQueue(queueName);
+      MessageProducer producer = session.createProducer(destination);
+      producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+      //To ensure real-time consumption of the messages by subscribers, the message will be available only for a minute to consume.
+      producer.setTimeToLive(60000);
+      TextMessage message = session.createTextMessage(textToPublish);
+      producer.send(message);
+      session.close();
+      connection.close();
+    } catch (Exception e) {
+      System.out.println("Error during publishing result to JMS: "+e.toString());
+    }
+  }
+
+  private static String getStringifiedMessageToPublish(TestPage sourcePage, TestSummary summary) {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("testName", sourcePage.getName());
+    jsonObject.put("testPath", sourcePage.getFullPath());
+    jsonObject.put("right", summary.getRight());
+    jsonObject.put("wrong", summary.getWrong());
+    jsonObject.put("ignores", summary.getIgnores());
+    jsonObject.put("exceptions", summary.getExceptions());
+    return jsonObject.toString();
+  }
+}
+

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -67,6 +67,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
   private static final String AND_FILTER_ARG = "runTestsMatchingAllTags";
   private static final String OR_FILTER_ARG_1 = "runTestsMatchingAnyTag";
   private static final String OR_FILTER_ARG_2 = "suiteFilter";
+  public static boolean publish = false;
 
   static final RunningTestingTracker runningTestingTracker = new RunningTestingTracker();
 
@@ -112,6 +113,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
     debug |= request.hasInput("debug");
     remoteDebug |= request.hasInput("remote_debug");
     includeHtml |= request.hasInput("includehtml");
+    publish = request.hasInput("publish");
     data = page.getData();
 
     createMainFormatter();
@@ -125,6 +127,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
     closeHtmlResponse(exitCode);
 
     cleanHistoryForSuite();
+    publish = false;
   }
 
   private void cleanHistoryForSuite() {

--- a/src/fitnesse/testrunner/WikiPageIdentity.java
+++ b/src/fitnesse/testrunner/WikiPageIdentity.java
@@ -7,6 +7,8 @@ public class WikiPageIdentity {
   public static final String COMMAND_PATTERN = "COMMAND_PATTERN";
   public static final String TEST_RUNNER = "TEST_RUNNER";
   public static final String TEST_SYSTEM = "TEST_SYSTEM";
+  public static final String MESSAGE_BROKER_ADDRESS = "MESSAGE_BROKER_ADDRESS";
+  public static final String QUEUE_NAME = "QUEUE_NAME";
   private WikiPage page;
 
   public WikiPageIdentity(WikiPage page) {

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import fitnesse.components.MessagePublisher;
+import fitnesse.responders.run.SuiteResponder;
 import fitnesse.slim.instructions.AssignInstruction;
 import fitnesse.slim.instructions.Instruction;
 import fitnesse.testsystems.*;
@@ -88,6 +90,9 @@ public abstract class SlimTestSystem implements TestSystem {
     try {
       processAllTablesOnPage(pageToTest);
       testComplete(pageToTest, testContext.getTestSummary());
+      if (SuiteResponder.publish)
+        MessagePublisher.publishStatusToJMSSend(pageToTest, testContext.getTestSummary());
+
     } catch (Exception e) {
       stopTestSystem(e);
       throw new TestExecutionException(e);


### PR DESCRIPTION
Let's say, Fitnesse suite execution is triggered from standalone program/script/Jenkins. If the execution runs for hours (e.g. Selenium tests), there is no easy way to programmatically know the real time execution status before its completion. Real time status will be useful for : 
- Programmatic real time display of test progress. 
- Real time result update in test management system (JIRA/ALM/TFS etc.) using their Rest API. 
- Alert/email stakeholders for specific failure(s) without waiting for hours till suite execution completion.

This pull request uses JMS and ActiveMQ libraries to publish the results in real time. Below are the steps to achieve this goal:

1. In Fitnesse root, we have to add two variables 
``` 
!define MESSAGE_BROKER_ADDRESS {tcp://<server>:61616}
!define QUEUE_NAME {FitnesseExecution.TESTQ}
 ```
2. Ensure ActiveMQ is running in the address specified above as MESSAGE_BROKER_ADDRESS. ActiveMQ will capture test result in below format:
`{"ignores":0,"testPath":"<suitePath.testName>","right":1,"exceptions":0,"testName":"<testName>","wrong":0}`
3. Execute suite with additional query parameter (publish) like below
`http://<fitnesseServerUrl>/<suiteName>?suite&publish`
4. Consume the service from ActiveMQ as needed (display/update test management system/alert).

I have tested it and it does not impact the old functionality. New functionality can be achieved by using above steps. Since I am not very familiar with gradle, I used below command to successfully test this idea
`java -cp activemq-all-5.15.0.jar;javax.jms-api-2.0.1.jar;fitnesse-standalone.jar fitnesseMain.FitNesseMain -e 0 -a passwords.txt -p 9090`

Improvements (unit test, documentation update, program refactor etc.) can be made in future commits if this idea and approach is approved.