### PR TITLE
Changed ThreadPoolExecutor to SynchronousQueue

### DIFF
--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -5,7 +5,7 @@ package fitnesse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.ServerSocket;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
@@ -38,7 +38,7 @@ public class FitNesse {
         LOG.log(Level.WARNING, "Could not handle request. Thread pool is exhausted.");
       }
     };
-    this.executorService = new ThreadPoolExecutor(5, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2),
+    this.executorService = new ThreadPoolExecutor(5, 100, 10, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
             new DaemonThreadFactory(), rejectionHandler);
   }
 


### PR DESCRIPTION
Changed ThreadPoolExecutor to use SynchronousQueue for direct handoff queuing strategy. With long running test suites being concurrently executed by threads in the thread pool, the parsing of requests get queued for longer than 10 seconds waiting for a thread in the thread pool and then they timeout. Those requests are returned to the clients as 408 responses. Reference issue #922 