### PR TITLE
Adding run-time information to the JUnit test reports

### DIFF
--- a/src/fitnesse/junit/JavaFormatter.java
+++ b/src/fitnesse/junit/JavaFormatter.java
@@ -219,7 +219,9 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
       sb.append("<tr class=\"").append(getCssClass(testSummary)).append("\"><td>").append(
               "<a href=\"").append(testName).append(".html\">").append(testName).append("</a>").append(
               "</td><td>").append(testSummary.getRight()).append("</td><td>").append(testSummary.getWrong())
-              .append("</td><td>").append(testSummary.getExceptions()).append("</td></tr>");
+              .append("</td><td>").append(testSummary.getExceptions())
+              .append("</td><td>").append(testSummary.getRunTimeInMillis())
+              .append("</td></tr>");
       return sb.toString();
     }
 
@@ -236,7 +238,7 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
 
   public static class TestResultsSummaryTable {
     public static final String SUMMARY_FOOTER = "</table>";
-    public static final String SUMMARY_HEADER = "<table><tr><td>Name</td><td>Right</td><td>Wrong</td><td>Exceptions</td></tr>";
+    public static final String SUMMARY_HEADER = "<table><tr><td>Name</td><td>Right</td><td>Wrong</td><td>Exceptions</td><td>Runtime (in milliseconds)</td></tr>";
     private List<String> visitedTestPages;
     private Map<String, TestSummary> testSummaries;
 

--- a/src/fitnesse/testsystems/TestSummary.java
+++ b/src/fitnesse/testsystems/TestSummary.java
@@ -7,6 +7,7 @@ public class TestSummary {
   private int wrong = 0;
   private int ignores = 0;
   private int exceptions = 0;
+  private long runTimeInMillis = 0;
 
   public TestSummary(int right, int wrong, int ignores, int exceptions) {
     this.right = right;
@@ -20,6 +21,7 @@ public class TestSummary {
     wrong = testSummary.getWrong();
     ignores = testSummary.getIgnores();
     exceptions = testSummary.getExceptions();
+    runTimeInMillis = testSummary.getRunTimeInMillis();
   }
 
   public TestSummary() {
@@ -38,7 +40,7 @@ public class TestSummary {
     TestSummary other = (TestSummary) o;
     return getRight() == other.getRight() && getWrong() == other.getWrong()
     && getIgnores() == other.getIgnores()
-    && getExceptions() == other.getExceptions();
+    && getExceptions() == other.getExceptions() && getRunTimeInMillis() == other.getRunTimeInMillis();
   }
 
   @Override
@@ -46,12 +48,13 @@ public class TestSummary {
     assert false : "hashCode not designed";
     return 42;
   }
-  
+
   public void add(TestSummary testSummary) {
     right = getRight() + testSummary.getRight();
     wrong = getWrong() + testSummary.getWrong();
     ignores = getIgnores() + testSummary.getIgnores();
     exceptions = getExceptions() + testSummary.getExceptions();
+    runTimeInMillis = getRunTimeInMillis() + testSummary.getRunTimeInMillis();
   }
 
   public void clear() {
@@ -59,6 +62,7 @@ public class TestSummary {
     wrong = 0;
     ignores = 0;
     exceptions = 0;
+    runTimeInMillis = 0;
   }
 
   public int getRight() {
@@ -77,6 +81,8 @@ public class TestSummary {
     return exceptions;
   }
 
+  public long getRunTimeInMillis() { return runTimeInMillis; }
+
   public void add(ExecutionResult executionResult) {
     if (executionResult != null) {
      switch (executionResult) {
@@ -94,5 +100,9 @@ public class TestSummary {
          break;
      }
     }
+  }
+
+  public void setRunTimeInMillis(long runTimeInMillis) {
+    this.runTimeInMillis = runTimeInMillis;
   }
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -2,6 +2,8 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.testsystems.slim;
 
+import fitnesse.util.TimeMeasurement;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,11 +22,13 @@ public class SlimTestContextImpl implements SlimTestContext {
   private final Map<String, ScenarioTable> scenarios = new HashMap<>(512);
   private final TestSummary testSummary = new TestSummary();
   private final TestPage pageToTest;
+  private final TimeMeasurement timeMeasurement;
   private List<ScenarioTable> scenariosWithInputs = null;
   private boolean isSorted = true;
 
   public SlimTestContextImpl(TestPage pageToTest) {
     this.pageToTest = pageToTest;
+    this.timeMeasurement = new TimeMeasurement().start();
   }
 
   @Override
@@ -141,6 +145,7 @@ public class SlimTestContextImpl implements SlimTestContext {
   }
 
   public TestSummary getTestSummary() {
+    testSummary.setRunTimeInMillis(timeMeasurement.elapsed());
     return testSummary;
   }
 

--- a/test/fitnesse/junit/JavaFormatterTest.java
+++ b/test/fitnesse/junit/JavaFormatterTest.java
@@ -1,15 +1,17 @@
 package fitnesse.junit;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
 import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestSummary;
+import fitnesse.util.TimeMeasurement;
+import fitnesse.wiki.WikiPageDummy;
 import org.junit.Before;
 import org.junit.Test;
-import fitnesse.util.TimeMeasurement;
-import fitnesse.testsystems.TestSummary;
-import fitnesse.wiki.WikiPageDummy;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class JavaFormatterTest {
 
@@ -88,14 +90,20 @@ public class JavaFormatterTest {
   @Test
   public void summaryRowFormatsTestOutputRows(){
     assertEquals("pass, no errors or exceptions",
-            "<tr class=\"pass\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>0</td><td>0</td></tr>",
+            "<tr class=\"pass\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>0</td><td>0</td><td>0</td></tr>",
             new JavaFormatter.TestResultsSummaryTableRow("TestName", new TestSummary(5, 0, 0, 0)).toString());
-    assertEquals("red, 1 error ", 
-        "<tr class=\"fail\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>1</td><td>0</td></tr>",
+    assertEquals("red, 1 error ",
+        "<tr class=\"fail\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>1</td><td>0</td><td>0</td></tr>",
         new JavaFormatter.TestResultsSummaryTableRow("TestName", new TestSummary(5,1,0,0)).toString());
     assertEquals("error,exceptions",
-            "<tr class=\"error\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>6</td><td>7</td></tr>",
+            "<tr class=\"error\"><td><a href=\"TestName.html\">TestName</a></td><td>5</td><td>6</td><td>7</td><td>0</td></tr>",
             new JavaFormatter.TestResultsSummaryTableRow("TestName", new TestSummary(5, 6, 0, 7)).toString());
+
+    TestSummary testSummary = new TestSummary(1,0,0,0);
+    testSummary.setRunTimeInMillis(345);
+    assertEquals("pass, with duration",
+            "<tr class=\"pass\"><td><a href=\"TestName.html\">TestName</a></td><td>1</td><td>0</td><td>0</td><td>345</td></tr>",
+            new JavaFormatter.TestResultsSummaryTableRow("TestName", testSummary).toString());
   }
 
   @Test
@@ -109,7 +117,7 @@ public class JavaFormatterTest {
     TimeMeasurement timeMeasurement = new TimeMeasurement().start();
     jf.testComplete(buildNestedTestPage(), new TestSummary(5,6,7,8));
     jf.close();
-    verify(mockResultsRepository).open(suiteName);     
+    verify(mockResultsRepository).open(suiteName);
   }
 
   @Test
@@ -118,6 +126,6 @@ public class JavaFormatterTest {
     jf.setResultsRepository(mockResultsRepository);
     jf.testComplete(buildNestedTestPage(), new TestSummary(5,6,7,8));
     jf.close();
-    verify(mockResultsRepository,times(0)).open(nestedPageName);     
+    verify(mockResultsRepository,times(0)).open(nestedPageName);
   }
 }


### PR DESCRIPTION
Currently, when FitNesse tests are run via JUnit, each suite creates a nice overview report of the test results for each page contained in the suite. But what is missing in this overview is the duration that each test page took to run. This pull request adds the run-time information to these overview tables.

I tried to make the change as small as possible, therefore the TestSummary objects do not _require_ the run-time information (it is only added where needed). This seems a bit odd, but I did this because the TestSummary class is used all over the place, also in the old FIT code, and I did not want to touch that (the old code would not make use of the run-time information anyways).

Also, I did not find a good place for tests for my additions to SlimTestContextImpl. If you would like me to add tests, then please point me to a suitable location for them. Same for any other changes you'd prefer me to make.
