### PR TITLE
Ensure commons-collections 3.2.2 and commons-lang 2.6 are used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
   compile "org.htmlparser:htmllexer:2.1"
   compile ("org.apache.velocity:velocity:1.7") {
       exclude group:"commons-collections", module: "commons-collections"
+      exclude group:"commons-lang", module: "commons-lang"
   }
   compile "commons-lang:commons-lang:2.6"
   compile "commons-collections:commons-collections:3.2.2"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,9 @@ targetCompatibility = '1.7'
 dependencies {
   compile "org.htmlparser:htmlparser:2.1"
   compile "org.htmlparser:htmllexer:2.1"
-  compile "org.apache.velocity:velocity:1.7"
+  compile ("org.apache.velocity:velocity:1.7") {
+      exclude group:"commons-collections", module: "commons-collections"
+  }
   compile "commons-lang:commons-lang:2.6"
   compile "commons-collections:commons-collections:3.2.2"
   compile "org.json:json:20151123"


### PR DESCRIPTION
Ensure commons-collections 3.2.1 is not included as transitive dependency (from velocity)

Since it was not explicitly excluded from velocity I found that my project that depended on fitnesse still got version 3.2.1. Probably because velocity is mentioned before commons-collections.
This change makes that explicit and removes the transitive dependency on 3.2.1, so we get the 3.2.2