### PR TITLE
Decision table and script subclass

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScriptSubclassUsedForDecisionTable/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScriptSubclassUsedForDecisionTable/content.txt
@@ -1,0 +1,36 @@
+Scenarios can be called from decision tables. They should respect the actor (i.e. fixture instance) and Slim table type (i.e. script table or a subclass) of the last script created.
+
+!2 When we create a script using Slim's standard script table, the decision table should use that subtype also.
+
+|scenario      |my division1|numerator||denominator||expected|
+|setNumerator  |@numerator                                   |
+|setDenominator|@denominator                                 |
+|check         |quotient    |@expected                       |
+
+
+Get the Division implementation from the eg package, and use a script subclass that uses 'verify' instead of the 'check' keyword.
+|script|eg.Division|
+
+
+
+|my division1                  |
+|numerator|denominator|expected|
+|10       |2          |5.0     |
+
+
+!2 When we create a script using a subclass of Slim's standard script table, the decision table should use that subtype also.
+
+|scenario      |my division2|numerator||denominator||expected|
+|setNumerator  |@numerator                                   |
+|setDenominator|@denominator                                 |
+|verify        |quotient    |@expected                       |
+
+
+Get the Division implementation from the eg package, and use a script subclass that uses 'verify' instead of the 'check' keyword.
+|verify script|eg.Division|
+
+
+
+|my division2                  |
+|numerator|denominator|expected|
+|10       |2          |5.0     |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScriptSubclassUsedForDecisionTable/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScriptSubclassUsedForDecisionTable/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/src/fitnesse/testsystems/slim/SlimTestContext.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContext.java
@@ -8,6 +8,7 @@ import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.tables.ScenarioTable;
+import fitnesse.testsystems.slim.tables.ScriptTable;
 
 public interface SlimTestContext {
   String getSymbol(String symbolName);
@@ -35,4 +36,10 @@ public interface SlimTestContext {
   void increment(TestSummary testSummary);
 
   TestPage getPageToTest();
+
+  void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName);
+
+  Class<? extends ScriptTable> getCurrentScriptClass();
+
+  String getCurrentScriptActor();
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContext.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContext.java
@@ -37,9 +37,11 @@ public interface SlimTestContext {
 
   TestPage getPageToTest();
 
-  void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName);
+  void setCurrentScriptClass(Class<? extends ScriptTable> currentScriptClass);
 
   Class<? extends ScriptTable> getCurrentScriptClass();
+
+  void setCurrentScriptActor(String currentScriptActor);
 
   String getCurrentScriptActor();
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -14,6 +14,7 @@ import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.slim.tables.ScenarioTable;
+import fitnesse.testsystems.slim.tables.ScriptTable;
 
 public class SlimTestContextImpl implements SlimTestContext {
   private final Map<String, String> symbols = new HashMap<>();
@@ -22,6 +23,8 @@ public class SlimTestContextImpl implements SlimTestContext {
   private final TestPage pageToTest;
   private List<ScenarioTable> scenariosWithInputs = null;
   private boolean isSorted = true;
+  private String currentScriptActor;
+  private Class<? extends ScriptTable> currentScriptClass;
 
   public SlimTestContextImpl(TestPage pageToTest) {
     this.pageToTest = pageToTest;
@@ -147,5 +150,21 @@ public class SlimTestContextImpl implements SlimTestContext {
   @Override
   public TestPage getPageToTest() {
     return pageToTest;
+  }
+
+  @Override
+  public void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName) {
+    currentScriptActor = actorName;
+    currentScriptClass = scriptTableClass;
+  }
+
+  @Override
+  public Class<? extends ScriptTable> getCurrentScriptClass() {
+    return currentScriptClass;
+  }
+
+  @Override
+  public String getCurrentScriptActor() {
+    return currentScriptActor;
   }
 }

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -24,7 +24,7 @@ public class SlimTestContextImpl implements SlimTestContext {
   private List<ScenarioTable> scenariosWithInputs = null;
   private boolean isSorted = true;
   private String currentScriptActor;
-  private Class<? extends ScriptTable> currentScriptClass;
+  private Class<? extends ScriptTable> currentScriptClass = ScriptTable.class;
 
   public SlimTestContextImpl(TestPage pageToTest) {
     this.pageToTest = pageToTest;
@@ -153,14 +153,18 @@ public class SlimTestContextImpl implements SlimTestContext {
   }
 
   @Override
-  public void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName) {
-    currentScriptActor = actorName;
-    currentScriptClass = scriptTableClass;
+  public void setCurrentScriptClass(Class<? extends ScriptTable> currentScriptClass) {
+    this.currentScriptClass = currentScriptClass;
   }
 
   @Override
   public Class<? extends ScriptTable> getCurrentScriptClass() {
     return currentScriptClass;
+  }
+
+  @Override
+  public void setCurrentScriptActor(String currentScriptActor) {
+    this.currentScriptActor = currentScriptActor;
   }
 
   @Override

--- a/src/fitnesse/testsystems/slim/tables/DecisionTable.java
+++ b/src/fitnesse/testsystems/slim/tables/DecisionTable.java
@@ -121,7 +121,7 @@ public class DecisionTable extends SlimTable {
         String assignedSymbol = isSymbolAssignment(col, row);
         SlimAssertion assertion;
         if (assignedSymbol != null) {
-        	assertion= makeAssertion(callAndAssign(assignedSymbol, "scriptTable" + "Actor", "cloneSymbol", "$"+name),
+        	assertion= makeAssertion(callAndAssign(assignedSymbol, getTestContext().getCurrentScriptActor(), "cloneSymbol", "$"+name),
         			new ReturnedSymbolExpectation(col, row, name, assignedSymbol));
         } else {
           assertion = makeAssertion(Instruction.NOOP_INSTRUCTION, new ReturnedSymbolExpectation(getDTCellContents(col, row), col, row, name));

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -400,13 +400,18 @@ public class ScenarioTable extends SlimTable {
     }
 
     @Override
-    public void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName) {
-      testContext.setCurrentScript(scriptTableClass, actorName);
+    public void setCurrentScriptClass(Class<? extends ScriptTable> currentScriptClass) {
+      testContext.setCurrentScriptClass(currentScriptClass);
     }
 
     @Override
     public Class<? extends ScriptTable> getCurrentScriptClass() {
       return testContext.getCurrentScriptClass();
+    }
+
+    @Override
+    public void setCurrentScriptActor(String currentScriptActor) {
+      testContext.setCurrentScriptActor(currentScriptActor);
     }
 
     @Override

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -33,8 +33,6 @@ import org.apache.commons.lang.StringUtils;
 public class ScenarioTable extends SlimTable {
   private static final String instancePrefix = "scenarioTable";
   private static final String underscorePattern = "\\W_(?=\\W|$)";
-  // TODO: This property should not be static! This could cause race conditions
-  private Class<? extends ScriptTable> defaultChildClass = ScriptTable.class;
   private String name;
   private List<String> inputs = new ArrayList<>();
   private Set<String> outputs = new HashSet<>();
@@ -213,10 +211,6 @@ public class ScenarioTable extends SlimTable {
 
   protected ScriptTable createChild(Class<? extends ScriptTable> parentTableClass, Table newTable, SlimTestContext testContext) throws TableCreationException {
       return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
-  }
-
-  public void setDefaultChildClass(Class<? extends ScriptTable> defaultChildClass) {
-    this.defaultChildClass = defaultChildClass;
   }
 
   public List<SlimAssertion> call(String[] args, ScriptTable parentTable, int row) throws TestExecutionException {

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -201,7 +201,7 @@ public class ScenarioTable extends SlimTable {
     if (parentTable instanceof ScriptTable) {
       scriptTable = createChild((ScriptTable) parentTable, newTable, testContext);
     } else {
-      scriptTable = createChild(defaultChildClass, newTable, testContext);
+      scriptTable = createChild(getTestContext().getCurrentScriptClass(), newTable, testContext);
     }
     scriptTable.setCustomComparatorRegistry(customComparatorRegistry);
     return scriptTable;
@@ -397,6 +397,21 @@ public class ScenarioTable extends SlimTable {
     @Override
     public TestPage getPageToTest() {
       return testContext.getPageToTest();
+    }
+
+    @Override
+    public void setCurrentScript(Class<? extends ScriptTable> scriptTableClass, String actorName) {
+      testContext.setCurrentScript(scriptTableClass, actorName);
+    }
+
+    @Override
+    public Class<? extends ScriptTable> getCurrentScriptClass() {
+      return testContext.getCurrentScriptClass();
+    }
+
+    @Override
+    public String getCurrentScriptActor() {
+      return testContext.getCurrentScriptActor();
     }
   }
 }

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -109,6 +109,7 @@ public class ScriptTable extends SlimTable {
     List<SlimAssertion> assertions = new ArrayList<>();
     // TODO: Should take into account here that a table can be assigned as
     if (isTopLevelTable()) {
+      getTestContext().setCurrentScriptClass(getClass());
       List<SlimAssertion> createAssertions = startActor();
       if (createAssertions != null) {
         assertions.addAll(createAssertions);
@@ -300,7 +301,7 @@ public class ScriptTable extends SlimTable {
     List<SlimAssertion> assertions = new ArrayList<>();
     String className = Disgracer.disgraceClassName(cellContents);
     String actorName = getTableType() + "Actor";
-    getTestContext().setCurrentScript(getClass(), actorName);
+    getTestContext().setCurrentScriptActor(actorName);
     assertions.add(constructInstance(actorName, className, classNameColumn, row));
     getArgumentsStartingAt(classNameColumn + 1, table.getColumnCountInRow(row) - 1, row, assertions);
     return assertions;

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -299,7 +299,9 @@ public class ScriptTable extends SlimTable {
   protected List<SlimAssertion> startActor(int row, String cellContents, int classNameColumn) {
     List<SlimAssertion> assertions = new ArrayList<>();
     String className = Disgracer.disgraceClassName(cellContents);
-    assertions.add(constructInstance(getTableType() + "Actor", className, classNameColumn, row));
+    String actorName = getTableType() + "Actor";
+    getTestContext().setCurrentScript(getClass(), actorName);
+    assertions.add(constructInstance(actorName, className, classNameColumn, row));
     getArgumentsStartingAt(classNameColumn + 1, table.getColumnCountInRow(row) - 1, row, assertions);
     return assertions;
   }

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -196,8 +196,6 @@ public class ScriptTable extends SlimTable {
     }
     if (scenario != null) {
       scenario.setCustomComparatorRegistry(customComparatorRegistry);
-      // TODO: ensure our scenario has the right table type
-      scenario.setDefaultChildClass(getClass());
       assertions.addAll(scenario.call(args, this, row));
     }
     return assertions;

--- a/src/fitnesse/testsystems/slim/tables/ScriptTableWithVerify.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTableWithVerify.java
@@ -1,0 +1,28 @@
+package fitnesse.testsystems.slim.tables;
+
+import fitnesse.testsystems.slim.SlimTestContext;
+import fitnesse.testsystems.slim.Table;
+
+/**
+ * ScriptTable subclass to use in acceptance test to see that DecisionTable based on scenario respects subclasses
+ * used in previous script definition.
+ */
+public class ScriptTableWithVerify extends ScriptTable {
+  public ScriptTableWithVerify(Table table, String tableId, SlimTestContext context) {
+    super(table, tableId, context);
+  }
+
+  @Override
+  protected String getTableType() {
+    return "scriptWithVerifyTable";
+  }
+
+  protected String getTableKeyword() {
+    return "verify script";
+  }
+
+  @Override
+  protected String getCheckKeyword() {
+    return "verify";
+  }
+}

--- a/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTableFactory.java
@@ -33,6 +33,7 @@ public class SlimTableFactory {
     addTableType("table", TableTable.class);
     addTableType("script", ScriptTable.class);
     addTableType("script:", ScriptTable.class);
+    addTableType("verify script", ScriptTableWithVerify.class);
     addTableType("scenario", ScenarioTable.class);
     addTableType("import", ImportTable.class);
     addTableType("library", LibraryTable.class);


### PR DESCRIPTION
This pull request ensures that one can still use a custom ScriptTable subclass for a decision table based on a scenario. This was possible in the previous release, but broke due to #1029 

The ScriptTable used for the DecisionTable's assertions will be the last one created.