### PR TITLE
Allow table table access to symbol as object

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/SymbolsInTableTableManagedByTheFixture/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/SymbolsInTableTableManagedByTheFixture/content.txt
@@ -3,7 +3,7 @@
 
 !1 Symbol Handling by Fixtures
 
-If you need advanced symbol handling in your TableTable fixtures than your fixture code must handle this.
+If you need advanced symbol handling in your [[!-TableTable-!][.FitNesse.FullReferenceGuide.UserGuide.WritingAcceptanceTests.SliM.TableTable]] fixtures than your fixture code must handle this.
 Advanced means that you assign to a symbol a value and need to reference this new value again in the same table.
 Think if you really need this as it makes your code more complicated.
 
@@ -11,8 +11,8 @@ Think if you really need this as it makes your code more complicated.
 !3 Load the symbol aware fixture
 |import                                      |
 |fitnesse.slim.test.statementexecutorconsumer|
- 
- 
+
+
 !include SymbolAssignmentAndReferenceOfTheSameInOneTable
 
 
@@ -24,7 +24,7 @@ Think if you really need this as it makes your code more complicated.
 
 
 
-!3 The fixture handles a chain of assignments 
+!3 The fixture handles a chain of assignments
 
 |script     |
 |$X=|echo|99|

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/SymbolsInTableTableManagedByTheFixture/properties.xml
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TableTableSuite/SymbolsInTableTableManagedByTheFixture/properties.xml
@@ -2,7 +2,6 @@
 <properties>
 <Edit>true</Edit>
 <Files>true</Files>
-<LastModifyingUser>six42</LastModifyingUser>
 <Properties>true</Properties>
 <RecentChanges>true</RecentChanges>
 <Refactor>true</Refactor>

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -74,6 +74,15 @@ public class StatementExecutor implements StatementExecutorInterface {
   }
 
   @Override
+  public Object getSymbolObject(String symbolName) {
+    MethodExecutionResult result = context.getVariable(symbolName);
+    if (result == null) {
+      return null;
+    }
+    return result.getObject();
+  }
+
+  @Override
   public void create(String instanceName, String className, Object... args) throws SlimException {
     try {
       context.create(instanceName, className, args);

--- a/src/fitnesse/slim/StatementExecutorInterface.java
+++ b/src/fitnesse/slim/StatementExecutorInterface.java
@@ -10,7 +10,7 @@ public interface StatementExecutorInterface extends InstructionExecutor {
    * both assign and resolve any symbols on their own.
    *
    * Have a look to this FitNesse page for some examples:
-   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
+   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.SymbolsInTableTableManagedByTheFixture
    *
    * Please note: this method returns a String version (after conversion by converter as configured in
    * {@link fitnesse.slim.converters.ConverterRegistry}) of the symbol's value, unless it is a List.
@@ -28,7 +28,7 @@ public interface StatementExecutorInterface extends InstructionExecutor {
    * both assign and resolve any symbols on their own.
    *
    * Have a look to this FitNesse page for some examples:
-   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
+   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.SymbolsInTableTableManagedByTheFixture
    *
    * This method is similar to {@link #getSymbol(String)}, but it always returns the Object for the object, without
    * conversion by converter as configured in {@link fitnesse.slim.converters.ConverterRegistry}.

--- a/src/fitnesse/slim/StatementExecutorInterface.java
+++ b/src/fitnesse/slim/StatementExecutorInterface.java
@@ -4,16 +4,40 @@ import fitnesse.slim.instructions.InstructionExecutor;
 
 public interface StatementExecutorInterface extends InstructionExecutor {
 
-  /*
+  /**
    * This method can be used by TableTable custom fixtures to have access
    * to the table of symbols. This enables elaborate fixtures that can
    * both assign and resolve any symbols on their own.
-   * 
+   *
    * Have a look to this FitNesse page for some examples:
    * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
+   *
+   * Please note: this method returns a String version (after conversion by converter as configured in
+   * {@link fitnesse.slim.converters.ConverterRegistry}) of the symbol's value, unless it is a List.
+   * For Lists it returns the actual List.
+   * To access the actual/raw object use {@link #getSymbolObject(String)}.
+   *
+   * @param symbolName name of symbol to retrieve value for.
+   * @return value of symbol, after conversion by {@link fitnesse.slim.converters.ConverterRegistry}.
    */
   Object getSymbol(String symbolName);
-	
+
+  /**
+   * This method can be used by TableTable custom fixtures to have access
+   * to the table of symbols. This enables elaborate fixtures that can
+   * both assign and resolve any symbols on their own.
+   *
+   * Have a look to this FitNesse page for some examples:
+   * FitNesse.SuiteAcceptanceTests.SuiteSlimTests.TableTableSuite.TestTableTableImplementingStatementExecutorConsumer
+   *
+   * This method is similar to {@link #getSymbol(String)}, but it always returns the Object for the object, without
+   * conversion by converter as configured in {@link fitnesse.slim.converters.ConverterRegistry}.
+   *
+   * @param symbolName name of symbol to retrieve value for.
+   * @return value of symbol.
+   */
+  Object getSymbolObject(String symbolName);
+
   Object getInstance(String instanceName);
 
   boolean stopHasBeenRequested();

--- a/src/fitnesse/slim/StatementTimeoutExecutor.java
+++ b/src/fitnesse/slim/StatementTimeoutExecutor.java
@@ -35,6 +35,11 @@ public class StatementTimeoutExecutor implements StatementExecutorInterface {
   }
 
   @Override
+  public Object getSymbolObject(String symbolName) {
+    return inner.getSymbolObject(symbolName);
+  }
+
+  @Override
   public Object getInstance(String instanceName) {
     return inner.getInstance(instanceName);
   }

--- a/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
@@ -58,16 +58,21 @@ public abstract class SymbolManagingTableTable implements StatementExecutorConsu
     return arg;
   }
 
-  protected String replaceSymbolInArg(Matcher symbolMatcher, String arg,
-                                      String symbolName) {
+  protected String replaceSymbolInArg(Matcher symbolMatcher, String arg, String symbolName) {
+    String argBeforeSymbol = arg.substring(0, symbolMatcher.start());
+    String replacement = getSymbolReplacement(symbolName);
+    String argAfterSymbol = arg.substring(symbolMatcher.end());
+
+    return argBeforeSymbol + replacement + argAfterSymbol;
+  }
+
+  protected String getSymbolReplacement(String symbolName) {
     String replacement = "null";
     Object value = context.getSymbolObject(symbolName);
     if (value != null) {
       replacement = value.toString();
     }
-    arg = arg.substring(0, symbolMatcher.start()) + replacement
-        + arg.substring(symbolMatcher.end());
-    return arg;
+    return replacement;
   }
 
   protected void assignSymbolIfApplicable(String text, Object value) {

--- a/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
@@ -1,0 +1,79 @@
+package fitnesse.slim.test.statementexecutorconsumer;
+
+import fitnesse.slim.SlimSymbol;
+import fitnesse.slim.StatementExecutor;
+import fitnesse.slim.StatementExecutorConsumer;
+import fitnesse.slim.StatementExecutorInterface;
+
+import java.util.List;
+import java.util.regex.Matcher;
+
+/**
+ * Base class for TableTables wanting do their own symbol management.
+ */
+public abstract class SymbolManagingTableTable implements StatementExecutorConsumer {
+  protected StatementExecutorInterface context;
+
+  public List<List<String>> doTable(List<List<?>> table) {
+    try {
+      return doTableImpl(table);
+    } finally {
+      // IMPORTANT: Switch symbol replacement on again
+      //            or you get bad surprises
+      context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS, null);
+    }
+  }
+
+  /**
+   * Override this method to perform actual table table work.
+   * @param table wiki content.
+   * @return result table.
+   */
+  protected abstract List<List<String>> doTableImpl(List<List<?>> table);
+
+  @Override
+  public void setStatementExecutor(StatementExecutorInterface statementExecutor) {
+    context = statementExecutor;
+
+    // Tell Slim Agent that the fixture takes care of symbol replacements in all "doTable" methods
+    // IMPORTANT: Don't forget to set this back to null at the end of your fixture code
+    context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS,"tableTable.*\\.doTable");
+  }
+
+  protected String replaceSymbolsInString(String arg) {
+    int startingPosition = 0;
+    while (true) {
+      if ("".equals(arg) || null == arg) {
+        break;
+      }
+      Matcher symbolMatcher = SlimSymbol.SYMBOL_PATTERN.matcher(arg);
+      if (symbolMatcher.find(startingPosition)) {
+        String symbolName = symbolMatcher.group(1);
+        arg = replaceSymbolInArg(symbolMatcher, arg, symbolName);
+        startingPosition = symbolMatcher.start(1);
+      } else {
+        break;
+      }
+    }
+    return arg;
+  }
+
+  protected String replaceSymbolInArg(Matcher symbolMatcher, String arg,
+                                      String symbolName) {
+    String replacement = "null";
+    Object value = context.getSymbolObject(symbolName);
+    if (value != null) {
+      replacement = value.toString();
+    }
+    arg = arg.substring(0, symbolMatcher.start()) + replacement
+        + arg.substring(symbolMatcher.end());
+    return arg;
+  }
+
+  protected void assignSymbolIfApplicable(String text, Object value) {
+    String symbol = SlimSymbol.isSymbolAssignment(text);
+    if (symbol != null) {
+      context.assign(symbol, value);
+    }
+  }
+}

--- a/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
@@ -12,9 +12,22 @@ import java.util.regex.Matcher;
  * Base class for TableTables wanting do their own symbol management.
  */
 public abstract class SymbolManagingTableTable implements StatementExecutorConsumer {
-  protected StatementExecutorInterface context;
+  private StatementExecutorInterface context;
 
-  public List<List<String>> doTable(List<List<?>> table) {
+  @Override
+  public void setStatementExecutor(StatementExecutorInterface statementExecutor) {
+    context = statementExecutor;
+
+    // Tell Slim Agent that the fixture takes care of symbol replacements in all "doTable" methods
+    // IMPORTANT: Don't forget to set this back to null at the end of your fixture code
+    context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS,"tableTable.*\\.doTable");
+  }
+  
+  protected StatementExecutorInterface getStatementExecutor() {
+    return context;
+  }
+
+  public List<List<String>> doTable(List<List<String>> table) {
     try {
       return doTableImpl(table);
     } finally {
@@ -29,20 +42,7 @@ public abstract class SymbolManagingTableTable implements StatementExecutorConsu
    * @param table wiki content.
    * @return result table.
    */
-  protected abstract List<List<String>> doTableImpl(List<List<?>> table);
-
-  @Override
-  public void setStatementExecutor(StatementExecutorInterface statementExecutor) {
-    context = statementExecutor;
-
-    // Tell Slim Agent that the fixture takes care of symbol replacements in all "doTable" methods
-    // IMPORTANT: Don't forget to set this back to null at the end of your fixture code
-    context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS,"tableTable.*\\.doTable");
-  }
-
-  protected StatementExecutorInterface getStatementExecutor() {
-    return context;
-  }
+  protected abstract List<List<String>> doTableImpl(List<List<String>> table);
 
   protected String replaceSymbolsInString(String arg) {
     int startingPosition = 0;
@@ -52,8 +52,7 @@ public abstract class SymbolManagingTableTable implements StatementExecutorConsu
       }
       Matcher symbolMatcher = SlimSymbol.SYMBOL_PATTERN.matcher(arg);
       if (symbolMatcher.find(startingPosition)) {
-        String symbolName = symbolMatcher.group(1);
-        arg = replaceSymbolInArg(symbolMatcher, arg, symbolName);
+        arg = replaceSymbolInArg(symbolMatcher, arg);
         startingPosition = symbolMatcher.start(1);
       } else {
         break;
@@ -62,27 +61,29 @@ public abstract class SymbolManagingTableTable implements StatementExecutorConsu
     return arg;
   }
 
-  protected String replaceSymbolInArg(Matcher symbolMatcher, String arg, String symbolName) {
-    String argBeforeSymbol = arg.substring(0, symbolMatcher.start());
-    String replacement = getSymbolReplacement(symbolName);
-    String argAfterSymbol = arg.substring(symbolMatcher.end());
-
-    return argBeforeSymbol + replacement + argAfterSymbol;
-  }
-
-  protected String getSymbolReplacement(String symbolName) {
+  protected String replaceSymbolInArg(Matcher symbolMatcher, String arg) {
     String replacement = "null";
-    Object value = context.getSymbolObject(symbolName);
+    Object value = getSymbolValue(symbolMatcher);
     if (value != null) {
       replacement = value.toString();
     }
-    return replacement;
+    String prefix = arg.substring(0, symbolMatcher.start());
+    String postfix = arg.substring(symbolMatcher.end());
+    arg = prefix + replacement + postfix;
+    return arg;
   }
 
-  protected void assignSymbolIfApplicable(String text, Object value) {
+  protected Object getSymbolValue(Matcher symbolMatcher) {
+    String symbolName = symbolMatcher.group(1);
+    return context.getSymbolObject(symbolName);
+  }
+
+  protected boolean assignSymbolIfApplicable(String text, Object value) {
     String symbol = SlimSymbol.isSymbolAssignment(text);
-    if (symbol != null) {
+    boolean result = symbol != null;
+    if (result) {
       context.assign(symbol, value);
     }
+    return result;
   }
 }

--- a/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/SymbolManagingTableTable.java
@@ -40,6 +40,10 @@ public abstract class SymbolManagingTableTable implements StatementExecutorConsu
     context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS,"tableTable.*\\.doTable");
   }
 
+  protected StatementExecutorInterface getStatementExecutor() {
+    return context;
+  }
+
   protected String replaceSymbolsInString(String arg) {
     int startingPosition = 0;
     while (true) {

--- a/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
@@ -6,16 +6,16 @@ import java.util.List;
 public class TableTableIncFirstCol extends SymbolManagingTableTable {
 
   @Override
-  protected List<List<String>> doTableImpl(List<List<?>> table) {
+  protected List<List<String>> doTableImpl(List<List<String>> table) {
     List<List<String>> ret = new ArrayList<>();
-    for (List<?> line : table) {
+    for (List<String> line : table) {
       List<String> retLine = new ArrayList<>();
       ret.add(retLine);
 
       retLine.add("no change");
-      String oldValue = replaceSymbolsInString(line.get(0).toString());
+      String oldValue = replaceSymbolsInString(line.get(0));
       int newValue = Integer.parseInt(oldValue) + 1;
-      assignSymbolIfApplicable(line.get(1).toString(), newValue);
+      assignSymbolIfApplicable(line.get(1), newValue);
       retLine.add("pass:" + newValue);
     }
     return ret;

--- a/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
@@ -76,7 +76,7 @@ public class TableTableIncFirstCol implements StatementExecutorConsumer {
   private String replaceSymbolInArg(Matcher symbolMatcher, String arg,
       String symbolName) {
     String replacement = "null";
-    Object value = context.getSymbol(symbolName);
+    Object value = context.getSymbolObject(symbolName);
     if (value != null) {
       replacement = value.toString();
     }

--- a/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
+++ b/src/fitnesse/slim/test/statementexecutorconsumer/TableTableIncFirstCol.java
@@ -2,94 +2,22 @@ package fitnesse.slim.test.statementexecutorconsumer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 
-import fitnesse.slim.SlimSymbol;
-import fitnesse.slim.StatementExecutor;
-import fitnesse.slim.StatementExecutorConsumer;
-import fitnesse.slim.StatementExecutorInterface;
+public class TableTableIncFirstCol extends SymbolManagingTableTable {
 
-public class TableTableIncFirstCol implements StatementExecutorConsumer {
-
-
-  private StatementExecutorInterface context;
-
-  /*
-   * (non-Javadoc)
-   *
-   * @see
-   * fitnesse.slim.StatementExecutorConsumer#setStatementExecutor(fitnesse.slim
-   * .StatementExecutorInterface)
-   */
   @Override
-  public void setStatementExecutor(StatementExecutorInterface statementExecutor) {
-    this.context = statementExecutor;
-
-    // Tell Slim Agent that the fixture takes care of symbol replacements in all "doTable" methods
-    // IMPORTANT: Don't forget to set this back to null at the end of your fixture code
-    this.context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS,"tableTable.*\\.doTable");
-  }
-
-  public List<List<String>> doTable(List<List<?>> table) {
+  protected List<List<String>> doTableImpl(List<List<?>> table) {
     List<List<String>> ret = new ArrayList<>();
-    try {
+    for (List<?> line : table) {
+      List<String> retLine = new ArrayList<>();
+      ret.add(retLine);
 
-
-      for (List<?> line : table) {
-        List<String> retLine = new ArrayList<>();
-        ret.add(retLine);
-
-        retLine.add("no change");
-        String oldValue = replaceSymbolsInString(line.get(0).toString());
-        int newValue = Integer.parseInt(oldValue) + 1;
-        assignSymbolIfApplicable(line.get(1).toString(), newValue);
-        retLine.add("pass:" + newValue);
-      }
-
-    } finally {
-      // IMPORTANT: Switch symbol replacement on again
-      //            or you get bad surprises
-      this.context.assign(StatementExecutor.SLIM_AGENT_FIXTURE_HANDLES_SYMBOLS, null);
-
+      retLine.add("no change");
+      String oldValue = replaceSymbolsInString(line.get(0).toString());
+      int newValue = Integer.parseInt(oldValue) + 1;
+      assignSymbolIfApplicable(line.get(1).toString(), newValue);
+      retLine.add("pass:" + newValue);
     }
     return ret;
   }
-
-  private String replaceSymbolsInString(String arg) {
-    int startingPosition = 0;
-    while (true) {
-      if ("".equals(arg) || null == arg) {
-        break;
-      }
-      Matcher symbolMatcher = SlimSymbol.SYMBOL_PATTERN.matcher(arg);
-      if (symbolMatcher.find(startingPosition)) {
-        String symbolName = symbolMatcher.group(1);
-        arg = replaceSymbolInArg(symbolMatcher, arg, symbolName);
-        startingPosition = symbolMatcher.start(1);
-      } else {
-        break;
-      }
-    }
-    return arg;
-  }
-
-  private String replaceSymbolInArg(Matcher symbolMatcher, String arg,
-      String symbolName) {
-    String replacement = "null";
-    Object value = context.getSymbolObject(symbolName);
-    if (value != null) {
-      replacement = value.toString();
-    }
-    arg = arg.substring(0, symbolMatcher.start()) + replacement
-        + arg.substring(symbolMatcher.end());
-    return arg;
-  }
-
-  private void assignSymbolIfApplicable(String text, int value) {
-    String symbol = SlimSymbol.isSymbolAssignment(text);
-    if (symbol != null) {
-      context.assign(symbol, value);
-    }
-  }
-
 }

--- a/test/fitnesse/slim/SlimGetSymbolTestBase.java
+++ b/test/fitnesse/slim/SlimGetSymbolTestBase.java
@@ -29,4 +29,18 @@ public abstract class SlimGetSymbolTestBase {
     assertEquals("thisisassigned", symbol);
   }
 
+  @Test
+  public void getSetSymbolInteger() throws Exception {
+    caller.assign("vavavar", 12);
+    Object symbol = caller.getSymbol("vavavar");
+    assertEquals("12", symbol);
+  }
+
+  @Test
+  public void getSetSymbolObjectInteger() throws Exception {
+    caller.assign("vavavar", 12);
+    Object symbol = caller.getSymbolObject("vavavar");
+    assertEquals(12, symbol);
+  }
+
 }


### PR DESCRIPTION
StatementExecutorConsumer previously only allowed access to the 'converted' version of symbols. This pull request also offers access to actual Java objects stored.

Furthermore extracted a base class from an example which helps implement a table table doing its own symbol handling by offering some of the important boilerplate code.