### PR TITLE
Allow scenario table access via scenario context

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -313,7 +313,7 @@ public class ScenarioTable extends SlimTable {
 
   // This context is mainly used to determine if the scenario table evaluated successfully
   // This determines the execution result for the "calling" table row.
-  protected final class ScenarioTestContext implements SlimTestContext {
+  public final class ScenarioTestContext implements SlimTestContext {
 
     private final SlimTestContext testContext;
     private final TestSummary testSummary = new TestSummary();

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -322,6 +322,10 @@ public class ScenarioTable extends SlimTable {
       this.testContext = testContext;
     }
 
+    public ScenarioTable getScenarioTable() {
+      return ScenarioTable.this;
+    }
+
     @Override
     public String getSymbol(String symbolName) {
       return testContext.getSymbol(symbolName);

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 public class ScenarioAndDecisionTableExtensionTest {
   private static final String SCEN_EXTENSION_NAME = "diffScriptScenario";

--- a/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioAndDecisionTableExtensionTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ScenarioAndDecisionTableExtensionTest {
   private static final String SCEN_EXTENSION_NAME = "diffScriptScenario";
@@ -232,6 +233,10 @@ public class ScenarioAndDecisionTableExtensionTest {
 
     public DiffScriptTable(Table table, String tableId, SlimTestContext context) {
       super(table, tableId, context);
+
+      ScenarioTable scenarioTable = ((ScenarioTable.ScenarioTestContext) context).getScenarioTable();
+      assertEquals(ScenarioTableWithDifferentScript.class, scenarioTable.getClass());
+      assertEquals(SlimTestContextImpl.class, scenarioTable.getTestContext().getClass());
     }
     @Override
     protected String getTableType() {


### PR DESCRIPTION
Sometimes custom Slim tables may benefit from knowing they were called in context of a scenario, and even which scenario table instance called them.
This pull request exposes that information to them via their test context (which already had the information)