### PR TITLE
Log messages instead of failing on classcast, addressing #1092

### DIFF
--- a/src/fitnesse/components/PluginsClassLoader.java
+++ b/src/fitnesse/components/PluginsClassLoader.java
@@ -4,9 +4,28 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 public class PluginsClassLoader {
+  private static final Logger LOG = Logger.getLogger(PluginsClassLoader.class.getName());
+  private final static Method ADD_URL_METHOD;
+
+  static {
+    Method method = null;
+    ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+    if (systemClassLoader instanceof URLClassLoader) {
+      try {
+        Class<URLClassLoader> sysClass = URLClassLoader.class;
+        method = sysClass.getDeclaredMethod("addURL", new Class[]{URL.class});
+        method.setAccessible(true);
+      } catch (NoSuchMethodException e) {
+        throw new IllegalStateException("Unable to find 'addURL' method in URLClassLoader", e);
+      }
+    }
+    ADD_URL_METHOD = method;
+  }
 
   private File pluginsDirectory;
 
@@ -15,10 +34,18 @@ public class PluginsClassLoader {
   }
 
   public void addPluginsToClassLoader() throws Exception {
+    boolean logged = false;
     if (pluginsDirectory.exists())
       for (File plugin : pluginsDirectory.listFiles())
-        if (plugin.getName().endsWith("jar"))
+        if (plugin.getName().endsWith("jar")) {
+          if (ADD_URL_METHOD == null && !logged) {
+            LOG.log(Level.WARNING,
+              "Unable to add plugin to classpath. Are you running Java 9? "
+                + "Please ensure you add the required plugins to the wiki's classpath through other means.");
+            logged = true;
+          }
           addItemsToClasspath(plugin.getCanonicalPath());
+      }
   }
 
   public static void addItemsToClasspath(String classpathItems) throws Exception {
@@ -36,11 +63,11 @@ public class PluginsClassLoader {
   }
 
   public static void addUrlToClasspath(URL u) throws Exception {
-    URLClassLoader sysLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
-    Class<URLClassLoader> sysClass = URLClassLoader.class;
-    Method method = sysClass.getDeclaredMethod("addURL", new Class[]{URL.class});
-    method.setAccessible(true);
-    method.invoke(sysLoader, new Object[]{u});
+    ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+    if (ADD_URL_METHOD != null && systemClassLoader instanceof URLClassLoader) {
+      ADD_URL_METHOD.invoke(systemClassLoader, new Object[]{u});
+    } else {
+      LOG.log(Level.WARNING, "Unable to extend classpath to include plugin: " + u.getFile());
+    }
   }
-
 }


### PR DESCRIPTION
When running on Java 9 the following message is produced (while Java 8 works as before, the plugins' jar files are loaded and FitNesse can start)

```
WARNING: Unable to add plugin to classpath. Are you running Java 9? Please ensure you add the required plugins to the wiki's classpath through other means.
WARNING: Unable to extend classpath to include plugin: /Users/fried/dev/hsac-fitnesse-fixtures/wiki/plugins/maven-classpath-plugin-1.9-jar-with-dependencies.jar
WARNING: Unable to extend classpath to include plugin: /Users/fried/dev/hsac-fitnesse-fixtures/wiki/plugins/hsac-fitnesse-plugin-1.18.4-SNAPSHOT.jar
SEVERE: Error while starting the FitNesse [Unable to load class fitnesse.wikitext.widgets.MavenClasspathSymbolType]
fitnesse.plugins.PluginException: Unable to load class fitnesse.wikitext.widgets.MavenClasspathSymbolType
	at fitnesse.plugins.PropertyBasedPluginFeatureFactory.forName(PropertyBasedPluginFeatureFactory.java:200)
	at fitnesse.plugins.PropertyBasedPluginFeatureFactory.forEachClass(PropertyBasedPluginFeatureFactory.java:143)
	at fitnesse.plugins.PropertyBasedPluginFeatureFactory.forEachObject(PropertyBasedPluginFeatureFactory.java:150)
	at fitnesse.plugins.PropertyBasedPluginFeatureFactory.registerSymbolTypes(PropertyBasedPluginFeatureFactory.java:75)
	at fitnesse.plugins.PluginsLoader.loadSymbolTypes(PluginsLoader.java:87)
	at fitnesse.ContextConfigurator.makeFitNesseContext(ContextConfigurator.java:151)
	at fitnesseMain.FitNesseMain.launchFitNesse(FitNesseMain.java:69)
	at fitnesseMain.FitNesseMain.launchFitNesse(FitNesseMain.java:58)
	at fitnesseMain.FitNesseMain.main(FitNesseMain.java:38)
Caused by: java.lang.ClassNotFoundException: fitnesse.wikitext.widgets.MavenClasspathSymbolType
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:582)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:185)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:496)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:292)
	at fitnesse.plugins.PropertyBasedPluginFeatureFactory.forName(PropertyBasedPluginFeatureFactory.java:198)
	... 8 more
[ERROR] Command execution failed.
```