### PR TITLE
Only fail test run if too few tests are executed

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -1,6 +1,8 @@
 package fitnesse.junit;
 
 import java.io.Closeable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import fitnesse.testrunner.TestsRunnerListener;
 import fitnesse.testsystems.Assertion;
@@ -17,6 +19,7 @@ import org.junit.runner.notification.RunNotifier;
 
 public class JUnitRunNotifierResultsListener
         implements TestSystemListener, TestsRunnerListener, Closeable {
+  private static final Logger LOG = Logger.getLogger(JUnitRunNotifierResultsListener.class.getName());
 
   private final Class<?> mainClass;
   private final RunNotifier notifier;
@@ -91,12 +94,20 @@ public class JUnitRunNotifierResultsListener
 
   @Override
   public void close() {
-    if (completedTests != totalNumberOfTests) {
+    if (completedTests < totalNumberOfTests) {
       String msg = String.format(
               "Not all tests executed. Completed %s of %s tests.",
               completedTests, totalNumberOfTests);
       Exception e = new Exception(msg);
       notifier.fireTestFailure(new Failure(suiteDescription(), e));
+    }
+    if (completedTests > totalNumberOfTests) {
+      if (LOG.isLoggable(Level.WARNING)) {
+        String msg = String.format(
+          "Too many tests completed. Completed %s of %s tests.",
+          completedTests, totalNumberOfTests);
+        LOG.log(Level.WARNING, msg);
+      }
     }
   }
 

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -38,9 +38,36 @@ public class JUnitRunNotifierResultsListenerTest {
   public void shouldFinishSuccessfully() {
     TestResult testResult = SlimTestResult.ok("-");
 
+    listener.announceNumberTestsToRun(1);
     listener.testAssertionVerified(null, testResult);
     listener.testComplete(mockWikiTestPage(), summary("-"));
+    listener.close();
 
+    verify(notifier).fireTestFinished(description);
+  }
+
+  @Test
+  public void shouldFinishSuccessfullyWithTooManyTests() {
+    TestResult testResult = SlimTestResult.ok("-");
+
+    listener.announceNumberTestsToRun(0);
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+    listener.close();
+
+    verify(notifier).fireTestFinished(description);
+  }
+
+  @Test
+  public void shouldFailOnTooFewTests() {
+    TestResult testResult = SlimTestResult.ok("-");
+
+    listener.announceNumberTestsToRun(2);
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+    listener.close();
+
+    verify(notifier).fireTestFailure(any(Failure.class));
     verify(notifier).fireTestFinished(description);
   }
 


### PR DESCRIPTION
Currently a jUnit test run is failed if the number of executed tests is different from what is expected.

This pull request ensures that only too FEW tests fail a run, too MANY is logged as a warning.
Furthermore it adds unit tests for this behaviour (the old behaviour was not covered in a test).