### PR TITLE
Improve copying content of standard 'FitNesseRoot content'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,7 @@ jar {
   dependsOn createUpdateLists
   into('Resources') {
     from('.') {
+      setIncludeEmptyDirs(false)
       include 'FitNesseRoot/**/content.txt'
       include 'FitNesseRoot/**/properties.xml'
       include 'FitNesseRoot/**/*.wiki'

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,10 @@ task createUpdateLists(type: WikiFileListBuilderTask) {
     "FitNesseRoot/TemplateLibrary/SuitePage/properties.xml",
     "FitNesseRoot/TemplateLibrary/TestPage/content.txt",
     "FitNesseRoot/TemplateLibrary/TestPage/properties.xml" ]
+  skipFiles = [
+    "ErrorLogs",
+    "RecentChanges*"
+  ]
   mainDirectories = [
     "FitNesseRoot" ]
 }
@@ -155,6 +159,9 @@ jar {
       include 'FitNesseRoot/**/content.txt'
       include 'FitNesseRoot/**/properties.xml'
       include 'FitNesseRoot/**/*.wiki'
+      exclude 'FitNesseRoot/ErrorLogs*'
+      exclude 'FitNesseRoot/RecentChanges*'
+      exclude 'FitNesseRoot/files/testResults*'
     }
   }
   manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -119,12 +119,7 @@ task createUpdateLists(type: WikiFileListBuilderTask) {
     "FitNesseRoot/TemplateLibrary/TestPage/content.txt",
     "FitNesseRoot/TemplateLibrary/TestPage/properties.xml" ]
   mainDirectories = [
-    "FitNesseRoot/FitNesse",
-    "FitNesseRoot/FrontPage",
-    "FitNesseRoot/PageFooter",
-    "FitNesseRoot/PlugIns",
-    "FitNesseRoot/PageHeader",
-    "FitNesseRoot/TemplateLibrary" ]
+    "FitNesseRoot" ]
 }
 
 processResources.dependsOn "fitNesseVersion", "compileBootstrap", "createUpdateLists"
@@ -157,20 +152,9 @@ jar {
   dependsOn createUpdateLists
   into('Resources') {
     from('.') {
-      include 'FitNesseRoot/content.txt'
-      include 'FitNesseRoot/properties.xml'
-      include 'FitNesseRoot/FitNesse/**/content.txt'
-      include 'FitNesseRoot/FitNesse/**/properties.xml'
-      include 'FitNesseRoot/FrontPage/**/content.txt'
-      include 'FitNesseRoot/FrontPage/**/properties.xml'
-      include 'FitNesseRoot/PageFooter/**/content.txt'
-      include 'FitNesseRoot/PageFooter/**/properties.xml'
-      include 'FitNesseRoot/PlugIns/**/properties.xml'
-      include 'FitNesseRoot/PlugIns/**/content.txt'
-      include 'FitNesseRoot/PageHeader/**/content.txt'
-      include 'FitNesseRoot/PageHeader/**/properties.xml'
-      include 'FitNesseRoot/TemplateLibrary/**/content.txt'
-      include 'FitNesseRoot/TemplateLibrary/**/properties.xml'
+      include 'FitNesseRoot/**/content.txt'
+      include 'FitNesseRoot/**/properties.xml'
+      include 'FitNesseRoot/**/*.wiki'
     }
   }
   manifest {

--- a/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
+++ b/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
@@ -11,6 +11,7 @@ public class WikiFileListBuilder {
 
   private List<String> mainDirectories = []
   private List<String> doNotReplaceFiles = []
+  private List<String> skipFiles = []
 
   private File updateListFile
   private File updateDoNotCopyOverListFile
@@ -18,9 +19,10 @@ public class WikiFileListBuilder {
   private String updateListContent = "";
   private String updateDoNotCopyOverContent = "";
 
-  WikiFileListBuilder(List<String> mainDirectories, List<String> doNotReplaceFiles, File updateListFile, File updateDoNotCopyOverListFile) {
+  WikiFileListBuilder(List<String> mainDirectories, List<String> doNotReplaceFiles, List<String> skipFiles, File updateListFile, File updateDoNotCopyOverListFile) {
     this.mainDirectories = mainDirectories
     this.doNotReplaceFiles = doNotReplaceFiles
+    this.skipFiles = skipFiles;
     this.updateListFile = updateListFile
     this.updateDoNotCopyOverListFile = updateDoNotCopyOverListFile
   }
@@ -77,7 +79,22 @@ public class WikiFileListBuilder {
 
   private boolean isWikiFile(File childFile) {
     String name = childFile.getName();
-    return childFile.isDirectory() || VALID_FILE_NAMES.contains(name) || name.endsWith(".wiki");
+    return !isSkipped(childFile) && (childFile.isDirectory() || VALID_FILE_NAMES.contains(name) || name.endsWith(".wiki"));
+  }
+
+  private boolean isSkipped(File childFile) {
+    String name = childFile.getName()
+    boolean skipped = skipFiles.contains(name)
+    if (!skipped)
+      for (String skipFile : skipFiles) {
+        if (skipFile.endsWith("*")) {
+          def skipPrefix = skipFile.substring(0, skipFile.length() - 1)
+          skipped = name.startsWith(skipPrefix)
+        }
+        if (skipped)
+          break
+      }
+    return skipped
   }
 
   private void addFilePathToAppropriateList(String directoryPath, File childFile) {

--- a/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
+++ b/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
@@ -1,10 +1,4 @@
-import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskExecutionException
-
-import java.util.logging.Logger;
+import java.util.logging.Logger
 
 /**
  * Little utility to assemble the updateLists, used from build script.
@@ -83,7 +77,7 @@ public class WikiFileListBuilder {
 
   private boolean isWikiFile(File childFile) {
     String name = childFile.getName();
-    return childFile.isDirectory() || VALID_FILE_NAMES.contains(name);
+    return childFile.isDirectory() || VALID_FILE_NAMES.contains(name) || name.endsWith(".wiki");
   }
 
   private void addFilePathToAppropriateList(String directoryPath, File childFile) {

--- a/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
+++ b/buildSrc/src/main/groovy/WikiFileListBuilder.groovy
@@ -7,7 +7,7 @@ public class WikiFileListBuilder {
 
   private static final Logger LOG = Logger.getLogger(WikiFileListBuilder.class.getName());
 
-  private static final List<String> VALID_FILE_NAMES = Arrays.asList("content.txt", "properties.xml", ".gitignore");
+  private static final List<String> VALID_FILE_NAMES = Arrays.asList("content.txt", "properties.xml");
 
   private List<String> mainDirectories = []
   private List<String> doNotReplaceFiles = []

--- a/buildSrc/src/main/groovy/WikiFileListBuilderTask.groovy
+++ b/buildSrc/src/main/groovy/WikiFileListBuilderTask.groovy
@@ -1,14 +1,11 @@
-import java.io.File;
-import java.util.List;
-import java.util.Set;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
 
 public class WikiFileListBuilderTask extends DefaultTask {
   List<String> mainDirectories
   private List<String> doNotReplaceFiles
+  private List<String> skipFiles
 
   @OutputFile
   File updateListFile
@@ -17,12 +14,16 @@ public class WikiFileListBuilderTask extends DefaultTask {
 
   @TaskAction
   public void taskAction() {
-    def updater = new WikiFileListBuilder(mainDirectories, doNotReplaceFiles, updateListFile, updateDoNotCopyOverListFile)
+    def updater = new WikiFileListBuilder(mainDirectories, doNotReplaceFiles, skipFiles, updateListFile, updateDoNotCopyOverListFile)
     updater.createUpdateLists()
   }
 
   public void setDoNotReplaceFiles(final List<String> doNotReplaceFiles) {
     this.doNotReplaceFiles = doNotReplaceFiles
+  }
+
+  public void setSkipFiles(final List<String> skipFiles) {
+    this.skipFiles = skipFiles
   }
 
   public void setMainDirectories(final List<String> mainDirectories) {

--- a/buildSrc/src/test/groovy/WikiFileListBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/WikiFileListBuilderTest.groovy
@@ -55,10 +55,25 @@ class WikiFileListBuilderTest {
   }
 
   @Test
+  public void skippedFileNotIncluded() throws Exception {
+    String content = runCreateFileAndGetContent(["MasterFolder/TestFolder"], [], ["bla", "content.txt"]);
+    assertDoesntHaveRegexp("content.txt", content);
+  }
+
+  @Test
+  public void skippedWildcardFileNotIncluded() throws Exception {
+    String content = runCreateFileAndGetContent(["MasterFolder"], [], ["bla", "TestFolder2*"]);
+    assertSubString("MasterFolder/content.txt\n", content);
+    assertSubString("MasterFolder/TestFolder/content.txt\n", content);
+    assertDoesntHaveRegexp("TestFolder2.wiki", content);
+    assertDoesntHaveRegexp("MasterFolder/TestFolder2/Page.wiki", content);
+  }
+
+  @Test
   public void shouldPutSpecialFilesInDifferentList() throws Exception {
     String arg1 = "MasterFolder/TestFolder/content.txt";
     String arg2 = "MasterFolder/TestFolder/properties.xml";
-    def updater = new WikiFileListBuilder(["MasterFolder/TestFolder"], [arg1, arg2], updateList, updateDoNotCopyOverList)
+    def updater = new WikiFileListBuilder(["MasterFolder/TestFolder"], [arg1, arg2], [], updateList, updateDoNotCopyOverList)
     File doNotUpdateFile = updater.createDoNotUpdateList();
     String doNotUpdateContent = doNotUpdateFile.text
     doNotUpdateFile.delete()
@@ -84,8 +99,8 @@ class WikiFileListBuilderTest {
     updaterMock.createUpdateLists();
   }
 
-  private String runCreateFileAndGetContent(List<String> mainDirs = [], List<String> doNotCopyDirs = []) throws Exception {
-    WikiFileListBuilder updater = new WikiFileListBuilder(mainDirs, doNotCopyDirs, updateList, updateDoNotCopyOverList);
+  private String runCreateFileAndGetContent(List<String> mainDirs = [], List<String> doNotCopyDirs = [], List<String> skipFiles = []) throws Exception {
+    WikiFileListBuilder updater = new WikiFileListBuilder(mainDirs, doNotCopyDirs, skipFiles, updateList, updateDoNotCopyOverList);
     File resultFile = updater.createUpdateList();
     String content = resultFile.text
     resultFile.delete()

--- a/buildSrc/src/test/groovy/WikiFileListBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/WikiFileListBuilderTest.groovy
@@ -34,6 +34,8 @@ class WikiFileListBuilderTest {
     String content = runCreateFileAndGetContent(["MasterFolder"]);
     assertSubString("MasterFolder/content.txt\n", content);
     assertSubString("MasterFolder/TestFolder/content.txt\n", content);
+    assertSubString("MasterFolder/TestFolder2.wiki\n", content);
+    assertSubString("MasterFolder/TestFolder2/Page.wiki\n", content);
   }
 
   @Test
@@ -91,6 +93,9 @@ class WikiFileListBuilderTest {
   }
 
   private static void createMultiLevelDirectory() throws IOException {
+    new File("MasterFolder/TestFolder2").mkdirs()
+    new File("MasterFolder/TestFolder2.wiki").text = ""
+    new File("MasterFolder/TestFolder2/Page.wiki").text = ""
     new File("MasterFolder/TestFolder").mkdirs()
     new File("MasterFolder/content.txt").text = ""
     new File("MasterFolder/TestFolder/content.txt").text = ""


### PR DESCRIPTION
Ensure that all pages below the project's FitNesseRoot are included in the distribution and are also extracted on first startup of the wiki. 
Fixes #1111.