### PR TITLE
Add ability to directly reference values in a hashtable like slim symbols

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HashTableTests/ReferenceHashTableValueFromSlimSymbol.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/HashTableTests/ReferenceHashTableValueFromSlimSymbol.wiki
@@ -1,0 +1,7 @@
+---
+Test
+---
+|script     |echo fixture                             |
+|$myHashMap=|echo|!{key1:value1,key2:!{subkey:subval}}|
+|check      |echo|$myHashMap.key1           |value1   |
+|check      |echo|$myHashMap.key2.subkey    |subval   |

--- a/src/fitnesse/slim/SlimSymbol.java
+++ b/src/fitnesse/slim/SlimSymbol.java
@@ -5,11 +5,11 @@ import java.util.regex.Pattern;
 
 public abstract class SlimSymbol {
   public static final Pattern SYMBOL_PATTERN = Pattern
-      .compile("\\$([A-Za-z\\p{L}][\\w\\p{L}]*)");
+      .compile("\\$([A-Za-z\\p{L}][.\\w\\p{L}]*)");
 // This would be a better pattern as it allows to define the end of a symbol name with another $ sign
-// but this could break existing tests. See discussion in #790  
+// but this could break existing tests. See discussion in #790
 //  public static final Pattern SYMBOL_PATTERN = Pattern
-//      .compile("\\$([A-Za-z\\p{L}][\\w\\p{L}]*)\\$?");  
+//      .compile("\\$([A-Za-z\\p{L}][\\w\\p{L}]*)\\$?");
   public static final Pattern SYMBOL_ASSIGNMENT_PATTERN = Pattern
       .compile("\\A\\s*\\$([A-Za-z\\p{L}][\\w\\p{L}]*)\\s*=\\s*\\Z");
 
@@ -26,14 +26,14 @@ public abstract class SlimSymbol {
 
 
 
-  
+
   public String replace(String s) {
     if(null == s) return null;
 
     // Don't replace assignments, return as is
     if (isSymbolAssignment(s) != null)
       return s;
-    
+
     replacedString = s;
     symbolMatcher = SYMBOL_PATTERN.matcher(s);
     replaceAllSymbols();

--- a/src/fitnesse/slim/VariableStore.java
+++ b/src/fitnesse/slim/VariableStore.java
@@ -1,5 +1,7 @@
 package fitnesse.slim;
 
+import fitnesse.slim.converters.MapConverter;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -78,15 +80,29 @@ public class VariableStore {
   }
 
   private String getStoreSymbolValue(String symbolName) {
-    if (variables.containsKey(symbolName)) {
-      String replacement = "null";
-      Object value = variables.get(symbolName);
-      if (value != null) {
-        replacement = value.toString();
+    Object value = null;
+    String replacement = "null";
+    if(symbolName.contains(".")) {
+      String[] symbolInfo = symbolName.split("\\.");
+      symbolName = symbolInfo[0];
+      if (variables.containsKey(symbolName)) {
+        value = variables.get(symbolName).toString();
+        for(int i = 1; i < symbolInfo.length; i++) {
+          value = getValueFromMap(value.toString(), symbolInfo[i]);
+        }
       }
-      return replacement;
+    } else if (variables.containsKey(symbolName)) {
+      value = variables.get(symbolName);
     }
-    return null;
+    if (value != null) {
+      replacement = value.toString();
+    }
+    return replacement;
   }
 
+  private Object getValueFromMap(String map, String key) {
+    MapConverter cnv = new MapConverter();
+    Map<String, String> mapObj = cnv.fromString(map);
+    return mapObj.get(key);
+  }
 }


### PR DESCRIPTION
Needs some polishing, would like some input on how to proceed.

What this PR achieves is that we can reference values from a hashtable directly in a slim table, using a dot notation on slim symbols.

Say we define a hashtable !{EN:!{flag:flag, cup:cup}, NL:!{flag:vlag, cup:beker}} and store it in a symbol $myMap
With this PR, we can directly reference values in the hashtable as if they were slim symbols:
```
$myMap.EN.flag returns 'flag'
$myMap.NL.cup returns 'beker'
```

At this point with this PR this functionality is usable, but the wiki doesn't show the actual value in the usual form: $myMap.EN.flag->[flag]. Instead it just display: $myMap.EN.flag

I've also added an example in an acceptance test. This renders the hashmap and then appends .result.

Any input is appreciated.