### PR TITLE
Fix !headings when an heading contains literal macro

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestHeadings.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestHeadings.wiki
@@ -10,7 +10,8 @@ First create a page with some headings.
 !3 Bla Bla Bla
 !4 Foo
 !5 Bar
-!6 Baz-!|               |true  |
+!6 Baz
+!6 41 !-NotFormatted Title-!-!|               |true  |
 
 Then request the page.
 
@@ -20,13 +21,20 @@ Then request the page.
 
 Examine the page to be sure it contains the headings list.
 
-!|Response Examiner                                                                            |
-|type    |pattern                                                               |matches?|value|
-|contents|Contents:                                                             |true    |     |
-|contents|<a href="#TitleofPage">Title of Page</a>                              |true    |     |
-|contents|<li class="heading1">.*<a href="#TitleofPage">Title of Page</a>.*</li>|true    |     |
-|contents|<li class="heading2">.*<a href="#Heading">Heading</a>.*</li>          |true    |     |
-|contents|<li class="heading3">.*<a href="#BlaBlaBla">Bla Bla Bla</a>.*</li>    |true    |     |
-|contents|<li class="heading4">.*<a href="#Foo">Foo</a>.*</li>                  |true    |     |
-|contents|<li class="heading5">.*<a href="#Bar">Bar</a>.*</li>                  |true    |     |
-|contents|<li class="heading6">.*<a href="#Baz">Baz</a>.*</li>                  |true    |     |
+!|Response Examiner                                                                                            |
+|type    |pattern                                                                               |matches?|value|
+|contents|Contents:                                                                             |true    |     |
+|contents|<li class="heading1">.*<a href="#TitleofPage">Title of Page</a>.*</li>                |true    |     |
+|contents|<h1 id="TitleofPage">Title of Page</h1>                                               |true    |     |
+|contents|<li class="heading2">.*<a href="#Heading">Heading</a>.*</li>                          |true    |     |
+|contents|<h2 id="Heading">Heading</h2>                                                         |true    |     |
+|contents|<li class="heading3">.*<a href="#BlaBlaBla">Bla Bla Bla</a>.*</li>                    |true    |     |
+|contents|<h3 id="BlaBlaBla">Bla Bla Bla</h3>                                                   |true    |     |
+|contents|<li class="heading4">.*<a href="#Foo">Foo</a>.*</li>                                  |true    |     |
+|contents|<h4 id="Foo">Foo</h4>                                                                 |true    |     |
+|contents|<li class="heading5">.*<a href="#Bar">Bar</a>.*</li>                                  |true    |     |
+|contents|<h5 id="Bar">Bar</h5>                                                                 |true    |     |
+|contents|<li class="heading6">.*<a href="#Baz">Baz</a>.*</li>                                  |true    |     |
+|contents|<h6 id="Baz">Baz</h6>                                                                 |true    |     |
+|contents|<li class="heading6">.*<a href="#41NotFormattedTitle">41 NotFormatted Title</a>.*</li>|true    |     |
+|contents|<h6 id="41NotFormattedTitle">41 NotFormatted Title</h6>                               |true    |     |

--- a/src/fitnesse/wikitext/parser/HeaderLine.java
+++ b/src/fitnesse/wikitext/parser/HeaderLine.java
@@ -37,18 +37,9 @@ public class HeaderLine extends SymbolType implements Translation {
 
   private void addAttributeId(final HtmlTag result, final Translator translator,
                               final Symbol symbol) {
-    String text = getText(symbol);
-    final String value = HtmlUtil.remainRfc3986UnreservedCharacters(text);
+    final String textFromHeaderLine = Headings.extractTextFromHeaderLine(symbol);
+    final String value = Headings.buildIdOfHeaderLine(textFromHeaderLine);
     result.addAttribute("id", value);
-  }
-
-  private String getText(final Symbol symbol) {
-    final List<Symbol> textSymbols = SymbolUtil.findSymbolsByType(symbol, Text, true);
-    final StringBuilder stringBuilder = new StringBuilder(textSymbols.size());
-    for (final Symbol texts : textSymbols) {
-      stringBuilder.append(texts.getContent());
-    }
-    return stringBuilder.toString();
   }
 
 }

--- a/src/fitnesse/wikitext/parser/Headings.java
+++ b/src/fitnesse/wikitext/parser/Headings.java
@@ -74,6 +74,30 @@ public class Headings extends SymbolType implements Rule, Translation {
 
   }
 
+  static String extractTextFromHeaderLine(final Symbol headerLine) {
+    final StringBuilder sb = new StringBuilder();
+    headerLine.walkPreOrder(new SymbolTreeWalker() {
+      @Override
+      public boolean visit(final Symbol node) {
+        if (node.isType(SymbolType.Text) || node.isType(Literal.symbolType) ||
+          node.isType(Whitespace)) {
+          sb.append(node.getContent());
+        }
+        return true;
+      }
+
+      @Override
+      public boolean visitChildren(final Symbol node) {
+        return true;
+      }
+    });
+    return sb.toString();
+  }
+  
+  static String buildIdOfHeaderLine(final String textFromHeaderLine) {
+	  return HtmlUtil.remainRfc3986UnreservedCharacters(textFromHeaderLine);
+  }
+
   class HeadingContentBuilder {
 
     private final List<Symbol> headerLines;
@@ -130,7 +154,7 @@ public class Headings extends SymbolType implements Rule, Translation {
         final String textFromHeaderLine = extractTextFromHeaderLine(headerLine);
         final HtmlTag anchorElement = new HtmlTag("a", textFromHeaderLine);
         anchorElement.addAttribute("href",
-          "#" + HtmlUtil.remainRfc3986UnreservedCharacters(textFromHeaderLine));
+          "#" + buildIdOfHeaderLine(textFromHeaderLine));
         listitemElement.add(anchorElement);
         stack.peek().add(listitemElement);
         processed = true;
@@ -143,26 +167,6 @@ public class Headings extends SymbolType implements Rule, Translation {
 
     private int getLevel(final Symbol headerLine) {
       return Integer.parseInt(headerLine.getProperty(LineRule.Level));
-    }
-
-    private String extractTextFromHeaderLine(final Symbol headerLine) {
-      final StringBuilder sb = new StringBuilder();
-      headerLine.walkPreOrder(new SymbolTreeWalker() {
-        @Override
-        public boolean visit(final Symbol node) {
-          if (node.isType(SymbolType.Text) || node.isType(Literal.symbolType) ||
-            node.isType(Whitespace)) {
-            sb.append(node.getContent());
-          }
-          return true;
-        }
-
-        @Override
-        public boolean visitChildren(final Symbol node) {
-          return true;
-        }
-      });
-      return sb.toString();
     }
 
   }


### PR DESCRIPTION
Fix an issue with the !headings markup.
Sometimes the id attribute set on the heading is not consistent with the anchor link from the table of contents; for instance when the title contains a literal markup:
!1 !- bla-!

The root cause is the duplicated (but not equivalent) code in HeaderLine and Headings