### PR TITLE
Issue 1125: Remove non-standard XML transformer attribute

### DIFF
--- a/src/fitnesse/util/XmlUtil.java
+++ b/src/fitnesse/util/XmlUtil.java
@@ -121,7 +121,6 @@ public class XmlUtil {
 
   public static String xmlAsString(Document doc) throws IOException {
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
-    transformerFactory.setAttribute("indent-number", 0);
 
     StringWriter sw = new StringWriter();
     try {


### PR DESCRIPTION
Removes the attribute intended to specify the indent settings for XML
transformation settings that may not be supported by all transformers.
Specifically, the library xalan-2.7.1 throws an exception when this code
is encountered.