### PR TITLE
Permit multiline arguments for custom comparators

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -466,7 +466,7 @@ public abstract class SlimTable {
     );
 
     private Pattern regexPattern = Pattern.compile("\\s*=~/(.*)/");
-    private Pattern customComparatorPattern = Pattern.compile("\\s*(\\w*):(.*)");
+    private Pattern customComparatorPattern = Pattern.compile("\\s*(\\w*):(.*)", Pattern.DOTALL);
     private double v;
     private double arg1;
     private double arg2;

--- a/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
+++ b/test/fitnesse/responders/run/slimResponder/HtmlSlimResponderTest.java
@@ -355,6 +355,15 @@ public class HtmlSlimResponderTest {
   }
 
   @Test
+  public void customComparatorMultilineReturnsPass() throws Exception {
+    customComparatorRegistry.addCustomComparator("equalsIgnoreCase", new EqualsIgnoreCaseComparator());
+    getResultsForPageContents("!|script|\n"
+        + "|start|fitnesse.slim.test.TestSlim|\n"
+        + "|check|echo string|{{{!-hello\nworld-!}}}|equalsIgnoreCase:{{{!-HELLO\nWORLD-!}}}|\n");
+    assertTestResultsContain("<td><span class=\"pass\">{{{HELLO\nWORLD}}} matches {{{hello\nworld}}}</span></td>");
+  }
+
+  @Test
   public void customComparatorReturnsFail() throws Exception {
     customComparatorRegistry.addCustomComparator("equalsIgnoreCase", new EqualsIgnoreCaseComparator());
     getResultsForPageContents("!|script|\n"


### PR DESCRIPTION
This pull request permits line terminators in the arguments to custom comparators such that you can use pre-formatted blocks in your tables.

This is particularly useful when comparing JSON; it's much more readable to format longer JSON snippets over multiple lines.

E.g.:

~~~
|Animals API                     |
|URL                 |response?  |
|/names/dreadnoughtus|json:{{{!-{
  "name": "Dreadnoughtus",
  "order": "Saurischia",
  "kingdom": "Animalia"
}-!}}}|
~~~

<img width="500" alt="screen shot 2018-06-11 at 14 45 49" src="https://user-images.githubusercontent.com/302799/41235223-38bc330e-6d86-11e8-982b-eee2083844bc.png">