### PR TITLE
Make request data available to responders

### DIFF
--- a/src/fitnesse/authentication/NegotiateAuthenticator.java
+++ b/src/fitnesse/authentication/NegotiateAuthenticator.java
@@ -114,13 +114,13 @@ public class NegotiateAuthenticator extends Authenticator {
     public Response makeResponse(FitNesseContext context, Request request) throws Exception {
       SimpleResponse response = new SimpleResponse(401);
       response.addHeader("WWW-Authenticate", token == null ? NEGOTIATE : NEGOTIATE + " " + token);
-      HtmlPage html = context.pageFactory.newPage(request);
+      HtmlPage html = context.pageFactory.newPage();
       html.addTitles("Negotiated authentication required");
       if (request == null)
         html.setMainTemplate("authRequired.vm");
       else
         html.setMainTemplate("authFailed.vm");
-      response.setContent(html.html());
+      response.setContent(html.html(request));
       return response;
     }
   }

--- a/src/fitnesse/authentication/NegotiateAuthenticator.java
+++ b/src/fitnesse/authentication/NegotiateAuthenticator.java
@@ -114,7 +114,7 @@ public class NegotiateAuthenticator extends Authenticator {
     public Response makeResponse(FitNesseContext context, Request request) throws Exception {
       SimpleResponse response = new SimpleResponse(401);
       response.addHeader("WWW-Authenticate", token == null ? NEGOTIATE : NEGOTIATE + " " + token);
-      HtmlPage html = context.pageFactory.newPage();
+      HtmlPage html = context.pageFactory.newPage(request);
       html.addTitles("Negotiated authentication required");
       if (request == null)
         html.setMainTemplate("authRequired.vm");

--- a/src/fitnesse/authentication/UnauthorizedResponder.java
+++ b/src/fitnesse/authentication/UnauthorizedResponder.java
@@ -26,7 +26,7 @@ public class UnauthorizedResponder implements Responder {
     SimpleResponse response = new SimpleResponse(401);
     response.addHeader("WWW-Authenticate", "Basic realm=\"" + realm + "\"");
 
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.addTitles("401 Unauthorized");
     page.put("resource", request.getResource());
     page.setMainTemplate("unauthorized.vm");

--- a/src/fitnesse/authentication/UnauthorizedResponder.java
+++ b/src/fitnesse/authentication/UnauthorizedResponder.java
@@ -26,11 +26,11 @@ public class UnauthorizedResponder implements Responder {
     SimpleResponse response = new SimpleResponse(401);
     response.addHeader("WWW-Authenticate", "Basic realm=\"" + realm + "\"");
 
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.addTitles("401 Unauthorized");
     page.put("resource", request.getResource());
     page.setMainTemplate("unauthorized.vm");
-    response.setContent(page.html());
+    response.setContent(page.html(request));
 
     return response;
   }

--- a/src/fitnesse/html/template/HtmlPage.java
+++ b/src/fitnesse/html/template/HtmlPage.java
@@ -19,7 +19,7 @@ public class HtmlPage {
 
   private String templateFileName;
 
-  public HtmlPage(VelocityEngine velocityEngine, String templateFileName, String theme, String contextRoot, Request request) {
+  public HtmlPage(VelocityEngine velocityEngine, String templateFileName, String theme, String contextRoot) {
     super();
 
     this.velocityEngine = velocityEngine;
@@ -31,7 +31,6 @@ public class HtmlPage {
     setTitle(TITLE);
     velocityContext.put("theme", theme);
     velocityContext.put("contextRoot", contextRoot);
-    velocityContext.put("request", request);
   }
 
   public void setHeaderTemplate(String headerTemplate) {
@@ -72,14 +71,15 @@ public class HtmlPage {
     velocityContext.put(key, value);
   }
 
-  public String html() {
+  public String html(Request request) {
     StringWriter writer = new StringWriter();
-    render(writer);
+    render(writer, request);
     return writer.toString();
   }
 
-  public void render(Writer writer) {
+  public void render(Writer writer, Request request) {
     Template template = velocityEngine.getTemplate(templateFileName);
+    put("request", request);
     template.merge(velocityContext, writer);
   }
 

--- a/src/fitnesse/html/template/HtmlPage.java
+++ b/src/fitnesse/html/template/HtmlPage.java
@@ -5,6 +5,7 @@ package fitnesse.html.template;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import fitnesse.http.Request;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -18,7 +19,7 @@ public class HtmlPage {
 
   private String templateFileName;
 
-  public HtmlPage(VelocityEngine velocityEngine, String templateFileName, String theme, String contextRoot) {
+  public HtmlPage(VelocityEngine velocityEngine, String templateFileName, String theme, String contextRoot, Request request) {
     super();
 
     this.velocityEngine = velocityEngine;
@@ -27,9 +28,10 @@ public class HtmlPage {
     velocityContext =  new VelocityContext();
 
     setHeaderTemplate(HEADER_TEMPLATE);
-    setTitle("FitNesse");
+    setTitle(TITLE);
     velocityContext.put("theme", theme);
     velocityContext.put("contextRoot", contextRoot);
+    velocityContext.put("request", request);
   }
 
   public void setHeaderTemplate(String headerTemplate) {

--- a/src/fitnesse/html/template/PageFactory.java
+++ b/src/fitnesse/html/template/PageFactory.java
@@ -29,8 +29,8 @@ public class PageFactory {
     this.contextRoot = context.contextRoot;
   }
 
-  public HtmlPage newPage(Request request) {
-    return new HtmlPage(getVelocityEngine(), "skeleton.vm", theme, contextRoot, request);
+  public HtmlPage newPage() {
+    return new HtmlPage(getVelocityEngine(), "skeleton.vm", theme, contextRoot);
   }
 
   public String render(VelocityContext context, String templateName) {

--- a/src/fitnesse/html/template/PageFactory.java
+++ b/src/fitnesse/html/template/PageFactory.java
@@ -3,6 +3,7 @@
 package fitnesse.html.template;
 
 import fitnesse.FitNesseContext;
+import fitnesse.http.Request;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -28,8 +29,8 @@ public class PageFactory {
     this.contextRoot = context.contextRoot;
   }
 
-  public HtmlPage newPage() {
-    return new HtmlPage(getVelocityEngine(), "skeleton.vm", theme, contextRoot);
+  public HtmlPage newPage(Request request) {
+    return new HtmlPage(getVelocityEngine(), "skeleton.vm", theme, contextRoot, request);
   }
 
   public String render(VelocityContext context, String templateName) {

--- a/src/fitnesse/http/Request.java
+++ b/src/fitnesse/http/Request.java
@@ -68,18 +68,18 @@ public class Request {
   }
 
   public String getCookie(String name) {
-    String cookies = headers.get("cookie");
-    if(null != cookies) {
-      String[] rawCookies = cookies.split(";");
-      for(String cookie : rawCookies) {
+    if (hasHeader("cookie")) {
+      String[] rawCookies = getHeader("cookie").split(";");
+      for (String cookie : rawCookies) {
         String[] pair = cookie.split("=");
-        if(pair[0].trim().equalsIgnoreCase(name) && pair.length == 2) {
+        if (pair.length == 2 && pair[0].trim().equalsIgnoreCase(name)) {
           return pair[1].trim();
         }
       }
     }
     return "";
   }
+
 
   private void readAndParseRequestLine() throws IOException, HttpException {
     String request = input.readLine();

--- a/src/fitnesse/http/Request.java
+++ b/src/fitnesse/http/Request.java
@@ -67,6 +67,20 @@ public class Request {
     hasBeenParsed = true;
   }
 
+  public String getCookie(String name) {
+    String cookies = headers.get("cookie");
+    if(null != cookies) {
+      String[] rawCookies = cookies.split(";");
+      for(String cookie : rawCookies) {
+        String[] pair = cookie.split("=");
+        if(pair[0].trim().equalsIgnoreCase(name) && pair.length == 2) {
+          return pair[1].trim();
+        }
+      }
+    }
+    return "";
+  }
+
   private void readAndParseRequestLine() throws IOException, HttpException {
     String request = input.readLine();
     if ("".equals(request)) {
@@ -265,7 +279,7 @@ public class Request {
     buffer.append("Request URI:  ").append(requestURI).append('\n');
     buffer.append("Resource:     ").append(resource).append('\n');
     buffer.append("Query String: ").append(queryString).append('\n');
-    buffer.append("Hearders: (").append(headers.size()).append(")\n");
+    buffer.append("Headers: (").append(headers.size()).append(")\n");
     addMap(headers, buffer);
     buffer.append("Form Inputs: (").append(inputs.size()).append(")\n");
     addMap(inputs, buffer);

--- a/src/fitnesse/responders/BasicResponder.java
+++ b/src/fitnesse/responders/BasicResponder.java
@@ -16,11 +16,12 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 
 public abstract class BasicResponder implements SecureResponder {
+  protected Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     WikiPage requestedPage = getRequestedPage(request, context);
-
+    requestData = request;
     Response response;
     if (requestedPage == null)
       response = pageNotFoundResponse(context, request);

--- a/src/fitnesse/responders/BasicResponder.java
+++ b/src/fitnesse/responders/BasicResponder.java
@@ -16,12 +16,11 @@ import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 
 public abstract class BasicResponder implements SecureResponder {
-  protected Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     WikiPage requestedPage = getRequestedPage(request, context);
-    requestData = request;
+
     Response response;
     if (requestedPage == null)
       response = pageNotFoundResponse(context, request);

--- a/src/fitnesse/responders/DefaultResponder.java
+++ b/src/fitnesse/responders/DefaultResponder.java
@@ -21,7 +21,7 @@ public class DefaultResponder extends BasicResponder {
   }
 
   private HtmlPage prepareResponseDocument(FitNesseContext context) {
-    HtmlPage responseDocument = context.pageFactory.newPage();
+    HtmlPage responseDocument = context.pageFactory.newPage(requestData);
     responseDocument.addTitles("Default Responder");
     responseDocument.setMainTemplate("defaultPage.vm");
     return responseDocument;

--- a/src/fitnesse/responders/DefaultResponder.java
+++ b/src/fitnesse/responders/DefaultResponder.java
@@ -17,11 +17,11 @@ public class DefaultResponder extends BasicResponder {
 
   @Override
   protected String contentFrom(FitNesseContext context, Request request, WikiPage requestedPage) {
-    return prepareResponseDocument(context).html();
+    return prepareResponseDocument(context).html(request);
   }
 
   private HtmlPage prepareResponseDocument(FitNesseContext context) {
-    HtmlPage responseDocument = context.pageFactory.newPage(requestData);
+    HtmlPage responseDocument = context.pageFactory.newPage();
     responseDocument.addTitles("Default Responder");
     responseDocument.setMainTemplate("defaultPage.vm");
     return responseDocument;

--- a/src/fitnesse/responders/DisabledResponder.java
+++ b/src/fitnesse/responders/DisabledResponder.java
@@ -7,21 +7,18 @@ import fitnesse.http.Response;
 import fitnesse.wiki.WikiPage;
 
 public class DisabledResponder extends BasicResponder {
-
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
-    requestData = request;
     return responseWith(contentFrom(context, request, null));
   }
 
   @Override
   protected String contentFrom(FitNesseContext context, Request request, WikiPage requestedPage) {
-    requestData= request;
-    return prepareResponseDocument(context).html();
+    return prepareResponseDocument(context).html(request);
   }
 
   private HtmlPage prepareResponseDocument(FitNesseContext context) {
-    HtmlPage responseDocument = context.pageFactory.newPage(requestData);
+    HtmlPage responseDocument = context.pageFactory.newPage();
     responseDocument.addTitles("Default Responder");
     responseDocument.setMainTemplate("disabledPage.vm");
     return responseDocument;

--- a/src/fitnesse/responders/DisabledResponder.java
+++ b/src/fitnesse/responders/DisabledResponder.java
@@ -10,16 +10,18 @@ public class DisabledResponder extends BasicResponder {
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    requestData = request;
     return responseWith(contentFrom(context, request, null));
   }
 
   @Override
   protected String contentFrom(FitNesseContext context, Request request, WikiPage requestedPage) {
+    requestData= request;
     return prepareResponseDocument(context).html();
   }
 
   private HtmlPage prepareResponseDocument(FitNesseContext context) {
-    HtmlPage responseDocument = context.pageFactory.newPage();
+    HtmlPage responseDocument = context.pageFactory.newPage(requestData);
     responseDocument.addTitles("Default Responder");
     responseDocument.setMainTemplate("disabledPage.vm");
     return responseDocument;

--- a/src/fitnesse/responders/ErrorResponder.java
+++ b/src/fitnesse/responders/ErrorResponder.java
@@ -31,7 +31,7 @@ public class ErrorResponder implements Responder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse(statusCode);
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     html.addTitles("Error Occurred");
     html.setMainTemplate("error");
     html.put("exception", exception);
@@ -39,7 +39,7 @@ public class ErrorResponder implements Responder {
       html.put("exception", exception);
     if (message != null)
       html.put("message", message);
-    response.setContent(html.html());
+    response.setContent(html.html(request));
 
     return response;
   }

--- a/src/fitnesse/responders/ErrorResponder.java
+++ b/src/fitnesse/responders/ErrorResponder.java
@@ -31,7 +31,7 @@ public class ErrorResponder implements Responder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse(statusCode);
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     html.addTitles("Error Occurred");
     html.setMainTemplate("error");
     html.put("exception", exception);

--- a/src/fitnesse/responders/NotFoundResponder.java
+++ b/src/fitnesse/responders/NotFoundResponder.java
@@ -14,24 +14,22 @@ import fitnesse.wiki.PathParser;
 // scenarios (we skip directly to an EditResponder...).
 public class NotFoundResponder implements Responder {
   private String resource;
-  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse(404);
-    requestData = request;
     resource = request.getResource();
 
-    response.setContent(makeHtml(context));
+    response.setContent(makeHtml(context, request));
     return response;
   }
 
-  private String makeHtml(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage(requestData);
+  private String makeHtml(FitNesseContext context, Request request) {
+    HtmlPage page = context.pageFactory.newPage();
     page.addTitles("Not Found:" + resource);
     page.put("name", resource);
     page.put("shouldCreate", PathParser.isWikiPath(resource));
     page.setMainTemplate("notFoundPage.vm");
-    return page.html();
+    return page.html(request);
   }
 }

--- a/src/fitnesse/responders/NotFoundResponder.java
+++ b/src/fitnesse/responders/NotFoundResponder.java
@@ -14,10 +14,12 @@ import fitnesse.wiki.PathParser;
 // scenarios (we skip directly to an EditResponder...).
 public class NotFoundResponder implements Responder {
   private String resource;
+  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse(404);
+    requestData = request;
     resource = request.getResource();
 
     response.setContent(makeHtml(context));
@@ -25,7 +27,7 @@ public class NotFoundResponder implements Responder {
   }
 
   private String makeHtml(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(requestData);
     page.addTitles("Not Found:" + resource);
     page.put("name", resource);
     page.put("shouldCreate", PathParser.isWikiPath(resource));

--- a/src/fitnesse/responders/ShutdownResponder.java
+++ b/src/fitnesse/responders/ShutdownResponder.java
@@ -22,7 +22,7 @@ public class ShutdownResponder implements SecureResponder {
   public Response makeResponse(final FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse();
 
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     html.setTitle("Shutdown");
     html.setPageTitle(new PageTitle("Shutdown"));
 

--- a/src/fitnesse/responders/ShutdownResponder.java
+++ b/src/fitnesse/responders/ShutdownResponder.java
@@ -22,12 +22,12 @@ public class ShutdownResponder implements SecureResponder {
   public Response makeResponse(final FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse();
 
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     html.setTitle("Shutdown");
     html.setPageTitle(new PageTitle("Shutdown"));
 
     html.setMainTemplate("shutdownPage.vm");
-    response.setContent(html.html());
+    response.setContent(html.html(request));
 
     Thread shutdownThread = new Thread() {
       @Override

--- a/src/fitnesse/responders/WikiImportingResponder.java
+++ b/src/fitnesse/responders/WikiImportingResponder.java
@@ -8,6 +8,7 @@ import fitnesse.authentication.SecureWriteOperation;
 import fitnesse.http.ChunkedResponse;
 import fitnesse.html.template.HtmlPage;
 import fitnesse.html.template.PageTitle;
+import fitnesse.http.Request;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
@@ -63,7 +64,7 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
   }
 
   private HtmlPage makeHtml() throws Exception {
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     String title = "Wiki Import";
     if (wikiImportingTraverser.isUpdate())
       title += " Update";

--- a/src/fitnesse/responders/WikiImportingResponder.java
+++ b/src/fitnesse/responders/WikiImportingResponder.java
@@ -44,7 +44,7 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
     wikiImportingTraverser = initializeImporter();
     HtmlPage htmlPage = makeHtml();
 
-    htmlPage.render(response.getWriter());
+    htmlPage.render(response.getWriter(), request);
 
     response.close();
   }
@@ -64,7 +64,7 @@ public class WikiImportingResponder extends ChunkingResponder implements SecureR
   }
 
   private HtmlPage makeHtml() throws Exception {
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     String title = "Wiki Import";
     if (wikiImportingTraverser.isUpdate())
       title += " Update";

--- a/src/fitnesse/responders/WikiPageResponder.java
+++ b/src/fitnesse/responders/WikiPageResponder.java
@@ -22,8 +22,11 @@ import fitnesse.wiki.*;
 
 public class WikiPageResponder implements SecureResponder {
 
+  private Request requestData;
+
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    requestData = request;
     WikiPage page = loadPage(context, request.getResource(), request.getMap());
     if (page == null)
       return notFoundResponse(context, request);
@@ -65,7 +68,7 @@ public class WikiPageResponder implements SecureResponder {
 
   public String makeHtml(FitNesseContext context, WikiPage page) {
     PageData pageData = page.getData();
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(requestData);
     WikiPagePath fullPath = page.getPageCrawler().getFullPath();
     String fullPathName = PathParser.render(fullPath);
     PageTitle pt = new PageTitle(fullPath);

--- a/src/fitnesse/responders/WikiPageResponder.java
+++ b/src/fitnesse/responders/WikiPageResponder.java
@@ -22,11 +22,11 @@ import fitnesse.wiki.*;
 
 public class WikiPageResponder implements SecureResponder {
 
-  private Request requestData;
+  private Request request;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
-    requestData = request;
+    this.request = request;
     WikiPage page = loadPage(context, request.getResource(), request.getMap());
     if (page == null)
       return notFoundResponse(context, request);
@@ -68,7 +68,7 @@ public class WikiPageResponder implements SecureResponder {
 
   public String makeHtml(FitNesseContext context, WikiPage page) {
     PageData pageData = page.getData();
-    HtmlPage html = context.pageFactory.newPage(requestData);
+    HtmlPage html = context.pageFactory.newPage();
     WikiPagePath fullPath = page.getPageCrawler().getFullPath();
     String fullPathName = PathParser.render(fullPath);
     PageTitle pt = new PageTitle(fullPath);
@@ -96,7 +96,7 @@ public class WikiPageResponder implements SecureResponder {
     html.setFooterTemplate("wikiFooter");
     html.put("footerContent", new WikiPageFooterRenderer(page));
     handleSpecialProperties(html, page);
-    return html.html();
+    return html.html(request);
   }
 
   private void handleSpecialProperties(HtmlPage html, WikiPage page) {

--- a/src/fitnesse/responders/editing/ContentFilterResponder.java
+++ b/src/fitnesse/responders/editing/ContentFilterResponder.java
@@ -14,29 +14,27 @@ import fitnesse.wiki.PathParser;
 public class ContentFilterResponder implements Responder {
 
   private final ContentFilter contentFilter;
-  private Request requestData;
   public ContentFilterResponder(ContentFilter contentFilter) {
     this.contentFilter = contentFilter;
   }
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
-    requestData = request;
     String resource = request.getResource();
     String content = request.getInput(EditResponder.CONTENT_INPUT_NAME);
 
     if (!contentFilter.isContentAcceptable(content, resource))
-      return makeBannedContentResponse(context, resource);
+      return makeBannedContentResponse(context, resource, request);
     return null;
   }
 
-  private Response makeBannedContentResponse(FitNesseContext context, String resource) throws IOException {
+  private Response makeBannedContentResponse(FitNesseContext context, String resource, Request request) throws IOException {
     SimpleResponse response = new SimpleResponse();
-    HtmlPage html = context.pageFactory.newPage(requestData);
+    HtmlPage html = context.pageFactory.newPage();
     html.setTitle("Edit " + resource);
     html.setPageTitle(new PageTitle("Banned Content", PathParser.parse(resource)));
     html.setMainTemplate("bannedPage.vm");
-    response.setContent(html.html());
+    response.setContent(html.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/editing/ContentFilterResponder.java
+++ b/src/fitnesse/responders/editing/ContentFilterResponder.java
@@ -14,13 +14,14 @@ import fitnesse.wiki.PathParser;
 public class ContentFilterResponder implements Responder {
 
   private final ContentFilter contentFilter;
-
+  private Request requestData;
   public ContentFilterResponder(ContentFilter contentFilter) {
     this.contentFilter = contentFilter;
   }
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    requestData = request;
     String resource = request.getResource();
     String content = request.getInput(EditResponder.CONTENT_INPUT_NAME);
 
@@ -31,7 +32,7 @@ public class ContentFilterResponder implements Responder {
 
   private Response makeBannedContentResponse(FitNesseContext context, String resource) throws IOException {
     SimpleResponse response = new SimpleResponse();
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(requestData);
     html.setTitle("Edit " + resource);
     html.setPageTitle(new PageTitle("Banned Content", PathParser.parse(resource)));
     html.setMainTemplate("bannedPage.vm");

--- a/src/fitnesse/responders/editing/EditResponder.java
+++ b/src/fitnesse/responders/editing/EditResponder.java
@@ -81,7 +81,7 @@ public class EditResponder implements SecureResponder {
   }
 
   private String doMakeHtml(String resource, FitNesseContext context, boolean firstTimeForNewPage) {
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     String title = firstTimeForNewPage ? "Page doesn't exist. Edit: " : "Edit: ";
     html.setTitle(title + resource);
 

--- a/src/fitnesse/responders/editing/EditResponder.java
+++ b/src/fitnesse/responders/editing/EditResponder.java
@@ -81,7 +81,7 @@ public class EditResponder implements SecureResponder {
   }
 
   private String doMakeHtml(String resource, FitNesseContext context, boolean firstTimeForNewPage) {
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     String title = firstTimeForNewPage ? "Page doesn't exist. Edit: " : "Edit: ";
     html.setTitle(title + resource);
 
@@ -89,7 +89,7 @@ public class EditResponder implements SecureResponder {
     html.setMainTemplate("editPage");
     makeEditForm(html, resource, firstTimeForNewPage, NewPageResponder.getDefaultContent(page));
 
-    return html.html();
+    return html.html(request);
   }
 
   private void makeEditForm(HtmlPage html, String resource, boolean firstTimeForNewPage, String defaultNewPageContent) {

--- a/src/fitnesse/responders/editing/MergeResponder.java
+++ b/src/fitnesse/responders/editing/MergeResponder.java
@@ -43,7 +43,7 @@ public class MergeResponder implements Responder {
   }
 
   private String makePageHtml(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("Merge " + resource);
     page.setPageTitle(new PageTitle("Merge Changes", PathParser.parse(resource)));
     page.setMainTemplate("mergePage");

--- a/src/fitnesse/responders/editing/MergeResponder.java
+++ b/src/fitnesse/responders/editing/MergeResponder.java
@@ -43,7 +43,7 @@ public class MergeResponder implements Responder {
   }
 
   private String makePageHtml(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Merge " + resource);
     page.setPageTitle(new PageTitle("Merge Changes", PathParser.parse(resource)));
     page.setMainTemplate("mergePage");
@@ -52,7 +52,7 @@ public class MergeResponder implements Responder {
     page.put("oldContent", HtmlUtil.escapeHTML(existingContent));
     page.put("newContent", newContent);
     addHiddenAttributes(page);
-    return page.html();
+    return page.html(request);
   }
 
 

--- a/src/fitnesse/responders/editing/NewPageResponder.java
+++ b/src/fitnesse/responders/editing/NewPageResponder.java
@@ -34,14 +34,14 @@ public class NewPageResponder implements Responder {
   }
 
   private String doMakeHtml(FitNesseContext context, Request request) {
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     html.setTitle("New page");
 
     html.setPageTitle(new PageTitle("New Page", PathParser.parse(request.getResource())));
     html.setMainTemplate("editPage");
     makeEditForm(html, context, request);
 
-    return html.html();
+    return html.html(request);
   }
 
   private void makeEditForm(HtmlPage html, FitNesseContext context, Request request) {

--- a/src/fitnesse/responders/editing/NewPageResponder.java
+++ b/src/fitnesse/responders/editing/NewPageResponder.java
@@ -34,7 +34,7 @@ public class NewPageResponder implements Responder {
   }
 
   private String doMakeHtml(FitNesseContext context, Request request) {
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     html.setTitle("New page");
 
     html.setPageTitle(new PageTitle("New Page", PathParser.parse(request.getResource())));

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -114,7 +114,7 @@ public class PropertiesResponder implements SecureResponder {
   }
 
   private String makeHtml(FitNesseContext context, Request request) {
-    html = context.pageFactory.newPage();
+    html = context.pageFactory.newPage(request);
     html.setNavTemplate("viewNav");
     html.put("viewLocation", request.getResource());
     html.setTitle("Properties: " + resource);

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -114,7 +114,7 @@ public class PropertiesResponder implements SecureResponder {
   }
 
   private String makeHtml(FitNesseContext context, Request request) {
-    html = context.pageFactory.newPage(request);
+    html = context.pageFactory.newPage();
     html.setNavTemplate("viewNav");
     html.put("viewLocation", request.getResource());
     html.setTitle("Properties: " + resource);
@@ -130,7 +130,7 @@ public class PropertiesResponder implements SecureResponder {
     makeLastModifiedTag();
     makeFormSections();
 
-    return html.html();
+    return html.html(request);
   }
 
   private void makeLastModifiedTag() {

--- a/src/fitnesse/responders/files/DeleteConfirmationResponder.java
+++ b/src/fitnesse/responders/files/DeleteConfirmationResponder.java
@@ -16,9 +16,11 @@ import fitnesse.html.template.PageTitle;
 
 public class DeleteConfirmationResponder implements SecureResponder {
   private String resource;
+  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    requestData = request;
     SimpleResponse response = new SimpleResponse();
     resource = request.getResource();
     String filename = request.getInput("filename");
@@ -27,7 +29,7 @@ public class DeleteConfirmationResponder implements SecureResponder {
   }
 
   private String makeDirectoryListingPage(String pageName, String filename, FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(requestData);
     page.setTitle("Delete File(s)");
     page.setPageTitle(new PageTitle("Delete File", resource + filename, "/"));
     page.put("resource", resource);

--- a/src/fitnesse/responders/files/DeleteConfirmationResponder.java
+++ b/src/fitnesse/responders/files/DeleteConfirmationResponder.java
@@ -16,27 +16,25 @@ import fitnesse.html.template.PageTitle;
 
 public class DeleteConfirmationResponder implements SecureResponder {
   private String resource;
-  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
-    requestData = request;
     SimpleResponse response = new SimpleResponse();
     resource = request.getResource();
     String filename = request.getInput("filename");
-    response.setContent(makeDirectoryListingPage(resource, filename, context));
+    response.setContent(makeDirectoryListingPage(resource, filename, context, request));
     return response;
   }
 
-  private String makeDirectoryListingPage(String pageName, String filename, FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage(requestData);
+  private String makeDirectoryListingPage(String pageName, String filename, FitNesseContext context, Request request) {
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Delete File(s)");
     page.setPageTitle(new PageTitle("Delete File", resource + filename, "/"));
     page.put("resource", resource);
     makeConfirmationHTML(page, filename, context);
     page.setMainTemplate("deleteConfirmation");
 
-    return page.html();
+    return page.html(request);
   }
 
   private void makeConfirmationHTML(HtmlPage page, String filename, FitNesseContext context) {

--- a/src/fitnesse/responders/files/DirectoryResponder.java
+++ b/src/fitnesse/responders/files/DirectoryResponder.java
@@ -28,7 +28,6 @@ class DirectoryResponder implements SecureResponder {
   private File requestedDirectory;
   private FitNesseContext context;
   private SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd, yyyy, hh:mm a");
-  private Request requestData;
 
   public DirectoryResponder(String resource, File requestedFile) {
     this.resource = resource;
@@ -38,13 +37,12 @@ class DirectoryResponder implements SecureResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     this.context = context;
-    requestData = request;
     if (!resource.endsWith("/")) {
       return setRedirectForDirectory(request.getQueryString());
     } else if ("json".equals(request.getInput("format"))) {
       return makeDirectoryListingJsonPage();
     } else {
-      return makeDirectoryListingPage();
+      return makeDirectoryListingPage(request);
     }
   }
 
@@ -54,15 +52,15 @@ class DirectoryResponder implements SecureResponder {
     return simpleResponse;
   }
 
-  private Response makeDirectoryListingPage() throws UnsupportedEncodingException {
-    HtmlPage page = context.pageFactory.newPage(requestData);
+  private Response makeDirectoryListingPage(Request request) throws UnsupportedEncodingException {
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Files: " + resource);
     //page.header.use(HtmlUtil.makeBreadCrumbsWithPageType(resource, "/", "Files Section"));
     page.setPageTitle(new PageTitle("Files Section", resource, "/"));
     page.put("fileInfoList", makeFileInfo(FileUtil.getDirectoryListing(requestedDirectory)));
     page.setMainTemplate("directoryPage");
     SimpleResponse simpleResponse = new SimpleResponse();
-    simpleResponse.setContent(page.html());
+    simpleResponse.setContent(page.html(request));
     return simpleResponse;
   }
 

--- a/src/fitnesse/responders/files/DirectoryResponder.java
+++ b/src/fitnesse/responders/files/DirectoryResponder.java
@@ -28,6 +28,7 @@ class DirectoryResponder implements SecureResponder {
   private File requestedDirectory;
   private FitNesseContext context;
   private SimpleDateFormat dateFormat = new SimpleDateFormat("MMM dd, yyyy, hh:mm a");
+  private Request requestData;
 
   public DirectoryResponder(String resource, File requestedFile) {
     this.resource = resource;
@@ -37,7 +38,7 @@ class DirectoryResponder implements SecureResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     this.context = context;
-
+    requestData = request;
     if (!resource.endsWith("/")) {
       return setRedirectForDirectory(request.getQueryString());
     } else if ("json".equals(request.getInput("format"))) {
@@ -54,7 +55,7 @@ class DirectoryResponder implements SecureResponder {
   }
 
   private Response makeDirectoryListingPage() throws UnsupportedEncodingException {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(requestData);
     page.setTitle("Files: " + resource);
     //page.header.use(HtmlUtil.makeBreadCrumbsWithPageType(resource, "/", "Files Section"));
     page.setPageTitle(new PageTitle("Files Section", resource, "/"));

--- a/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
+++ b/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
@@ -19,7 +19,7 @@ public class RenameFileConfirmationResponder implements SecureResponder {
     String resource = request.getResource();
     String filename = request.getInput("filename");
     
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Rename " + filename);
     page.setPageTitle(new PageTitle("Rename File", resource + filename, "/"));
     page.setMainTemplate("renameFileConfirmation");
@@ -27,7 +27,7 @@ public class RenameFileConfirmationResponder implements SecureResponder {
     page.put("resource", resource);
 
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
+++ b/src/fitnesse/responders/files/RenameFileConfirmationResponder.java
@@ -19,7 +19,7 @@ public class RenameFileConfirmationResponder implements SecureResponder {
     String resource = request.getResource();
     String filename = request.getInput("filename");
     
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("Rename " + filename);
     page.setPageTitle(new PageTitle("Rename File", resource + filename, "/"));
     page.setMainTemplate("renameFileConfirmation");

--- a/src/fitnesse/responders/refactoring/DeletePageResponder.java
+++ b/src/fitnesse/responders/refactoring/DeletePageResponder.java
@@ -25,9 +25,11 @@ public class DeletePageResponder implements SecureResponder {
   private String qualifiedPageName;
   private WikiPagePath path;
   private FitNesseContext context;
+  private Request requestData;
 
   @Override
   public Response makeResponse(final FitNesseContext context, final Request request) throws Exception {
+    requestData = request;
     this.context = context;
     intializeResponse(request);
 
@@ -73,7 +75,7 @@ public class DeletePageResponder implements SecureResponder {
   }
 
   private String buildConfirmationHtml(final WikiPage root, final String qualifiedPageName, final FitNesseContext context) {
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(requestData);
 
     String tags = "";
 

--- a/src/fitnesse/responders/refactoring/DeletePageResponder.java
+++ b/src/fitnesse/responders/refactoring/DeletePageResponder.java
@@ -25,11 +25,9 @@ public class DeletePageResponder implements SecureResponder {
   private String qualifiedPageName;
   private WikiPagePath path;
   private FitNesseContext context;
-  private Request requestData;
 
   @Override
   public Response makeResponse(final FitNesseContext context, final Request request) throws Exception {
-    requestData = request;
     this.context = context;
     intializeResponse(request);
 
@@ -44,7 +42,7 @@ public class DeletePageResponder implements SecureResponder {
   private void tryToDeletePage(Request request) throws UnsupportedEncodingException {
     String confirmedString = request.getInput("confirmed");
     if (!"yes".equalsIgnoreCase(confirmedString)) {
-      response.setContent(buildConfirmationHtml(context.getRootPage(), qualifiedPageName, context));
+      response.setContent(buildConfirmationHtml(context.getRootPage(), qualifiedPageName, context, request));
     } else {
       WikiPage parentOfPageToBeDeleted = context.getRootPage().getPageCrawler().getPage(path);
       if (parentOfPageToBeDeleted != null) {
@@ -74,8 +72,8 @@ public class DeletePageResponder implements SecureResponder {
     }
   }
 
-  private String buildConfirmationHtml(final WikiPage root, final String qualifiedPageName, final FitNesseContext context) {
-    HtmlPage html = context.pageFactory.newPage(requestData);
+  private String buildConfirmationHtml(final WikiPage root, final String qualifiedPageName, final FitNesseContext context, Request request) {
+    HtmlPage html = context.pageFactory.newPage();
 
     String tags = "";
 
@@ -92,7 +90,7 @@ public class DeletePageResponder implements SecureResponder {
 
     makeMainContent(html, root, qualifiedPageName);
     html.setMainTemplate("deletePage");
-    return html.html();
+    return html.html(request);
   }
 
   private void makeMainContent(final HtmlPage html, final WikiPage root, final String qualifiedPageName) {

--- a/src/fitnesse/responders/refactoring/MovePageResponder.java
+++ b/src/fitnesse/responders/refactoring/MovePageResponder.java
@@ -12,7 +12,6 @@ import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPagePath;
 
 public class MovePageResponder extends PageMovementResponder {
-
   private String newParentName;
 
   @Override

--- a/src/fitnesse/responders/refactoring/RefactorPageResponder.java
+++ b/src/fitnesse/responders/refactoring/RefactorPageResponder.java
@@ -27,7 +27,6 @@ public class RefactorPageResponder implements SecureResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     String resource = request.getResource();
-
     String tags = "";
     WikiPage wikiPage = null;
     if(context.getRootPage() != null){
@@ -39,7 +38,7 @@ public class RefactorPageResponder implements SecureResponder {
       }
     }
 
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     String type = request.getInput("type");
 
     page.setMainTemplate("refactorForm");

--- a/src/fitnesse/responders/refactoring/RefactorPageResponder.java
+++ b/src/fitnesse/responders/refactoring/RefactorPageResponder.java
@@ -38,7 +38,7 @@ public class RefactorPageResponder implements SecureResponder {
       }
     }
 
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     String type = request.getInput("type");
 
     page.setMainTemplate("refactorForm");
@@ -52,7 +52,7 @@ public class RefactorPageResponder implements SecureResponder {
       page.put("suiteMap", collectPageNames(wikiPage, context.getRootPage()));
     }
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/run/StopTestResponder.java
+++ b/src/fitnesse/responders/run/StopTestResponder.java
@@ -14,11 +14,12 @@ import fitnesse.http.SimpleResponse;
 public class StopTestResponder implements SecureResponder {
 
   String testId = null;
+  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse();
-
+    requestData = request;
     if (request.hasInput("id")) {
       testId = request.getInput("id");
     }
@@ -29,7 +30,7 @@ public class StopTestResponder implements SecureResponder {
   }
 
   private String html(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(requestData);
     page.addTitles("Stopping tests");
     page.put("testId", testId);
     page.put("runningTestingTracker", SuiteResponder.runningTestingTracker);

--- a/src/fitnesse/responders/run/StopTestResponder.java
+++ b/src/fitnesse/responders/run/StopTestResponder.java
@@ -14,28 +14,26 @@ import fitnesse.http.SimpleResponse;
 public class StopTestResponder implements SecureResponder {
 
   String testId = null;
-  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     SimpleResponse response = new SimpleResponse();
-    requestData = request;
     if (request.hasInput("id")) {
       testId = request.getInput("id");
     }
 
-    response.setContent(html(context));
+    response.setContent(html(context, request));
 
     return response;
   }
 
-  private String html(FitNesseContext context) {
-    HtmlPage page = context.pageFactory.newPage(requestData);
+  private String html(FitNesseContext context, Request request) {
+    HtmlPage page = context.pageFactory.newPage();
     page.addTitles("Stopping tests");
     page.put("testId", testId);
     page.put("runningTestingTracker", SuiteResponder.runningTestingTracker);
     page.setMainTemplate("stopTestPage.vm");
-    return page.html();
+    return page.html(request);
   }
 
   @Override

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -83,6 +83,8 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
   private boolean includeHtml = false;
   private int exitCode;
 
+  private Request request;
+
   public SuiteResponder() {
     this(new WikiImporter());
   }
@@ -98,6 +100,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    this.request = request;
     Response result = super.makeResponse(context, request);
     if (result != response){
         return result;
@@ -117,7 +120,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
     createMainFormatter();
 
     if (isInteractive()) {
-      makeHtml().render(response.getWriter());
+      makeHtml().render(response.getWriter(), request);
     } else {
       doExecuteTests();
     }
@@ -179,7 +182,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
     PageCrawler pageCrawler = page.getPageCrawler();
     WikiPagePath fullPath = pageCrawler.getFullPath();
     String fullPathName = PathParser.render(fullPath);
-    HtmlPage htmlPage = context.pageFactory.newPage(request);
+    HtmlPage htmlPage = context.pageFactory.newPage();
     htmlPage.setTitle(getTitle() + ": " + fullPathName);
     htmlPage.setPageTitle(new PageTitle(getTitle(), fullPath, data.getAttribute(PageData.PropertySUITES)));
     htmlPage.setNavTemplate("testNav.vm");

--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -179,7 +179,7 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
     PageCrawler pageCrawler = page.getPageCrawler();
     WikiPagePath fullPath = pageCrawler.getFullPath();
     String fullPathName = PathParser.render(fullPath);
-    HtmlPage htmlPage = context.pageFactory.newPage();
+    HtmlPage htmlPage = context.pageFactory.newPage(request);
     htmlPage.setTitle(getTitle() + ": " + fullPathName);
     htmlPage.setPageTitle(new PageTitle(getTitle(), fullPath, data.getAttribute(PageData.PropertySUITES)));
     htmlPage.setNavTemplate("testNav.vm");

--- a/src/fitnesse/responders/search/ResultResponder.java
+++ b/src/fitnesse/responders/search/ResultResponder.java
@@ -64,7 +64,7 @@ public abstract class ResultResponder extends ChunkingResponder implements
 
     PageTitle pageTitle = new PageTitle(page.getPageCrawler().getFullPath() );
 
-    HtmlPage htmlPage = context.pageFactory.newPage(request);
+    HtmlPage htmlPage = context.pageFactory.newPage();
     htmlPage.setTitle(getTitle());
     htmlPage.setPageTitle(pageTitle);
     htmlPage.setMainTemplate(getTemplate());
@@ -82,7 +82,7 @@ public abstract class ResultResponder extends ChunkingResponder implements
     htmlPage.put("specialAttributes", SPECIAL_ATTRIBUTES);
     htmlPage.put("request", request);
 
-    htmlPage.render(response.getWriter());
+    htmlPage.render(response.getWriter(), request);
 
     response.close();
   }

--- a/src/fitnesse/responders/search/ResultResponder.java
+++ b/src/fitnesse/responders/search/ResultResponder.java
@@ -64,7 +64,7 @@ public abstract class ResultResponder extends ChunkingResponder implements
 
     PageTitle pageTitle = new PageTitle(page.getPageCrawler().getFullPath() );
 
-    HtmlPage htmlPage = context.pageFactory.newPage();
+    HtmlPage htmlPage = context.pageFactory.newPage(request);
     htmlPage.setTitle(getTitle());
     htmlPage.setPageTitle(pageTitle);
     htmlPage.setMainTemplate(getTemplate());

--- a/src/fitnesse/responders/testHistory/ExecutionLogResponder.java
+++ b/src/fitnesse/responders/testHistory/ExecutionLogResponder.java
@@ -58,7 +58,7 @@ public class ExecutionLogResponder implements SecureResponder {
   private Response makeExecutionLogResponse(Request request, Date resultDate, TestResultRecord testResultRecord) throws Exception {
     String content = FileUtil.getFileContent(testResultRecord.getFile());
     ExecutionReport report = ExecutionReport.makeReport(content);
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     String tags = "";
     if (report instanceof TestExecutionReport && !((TestExecutionReport) report).getResults().isEmpty()) {
       tags = ((TestExecutionReport) report).getResults().get(0).getTags();
@@ -75,7 +75,7 @@ public class ExecutionLogResponder implements SecureResponder {
     page.put("logs", report.getExecutionLogs());
     page.setMainTemplate("executionLog");
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/testHistory/ExecutionLogResponder.java
+++ b/src/fitnesse/responders/testHistory/ExecutionLogResponder.java
@@ -58,7 +58,7 @@ public class ExecutionLogResponder implements SecureResponder {
   private Response makeExecutionLogResponse(Request request, Date resultDate, TestResultRecord testResultRecord) throws Exception {
     String content = FileUtil.getFileContent(testResultRecord.getFile());
     ExecutionReport report = ExecutionReport.makeReport(content);
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     String tags = "";
     if (report instanceof TestExecutionReport && !((TestExecutionReport) report).getResults().isEmpty()) {
       tags = ((TestExecutionReport) report).getResults().get(0).getTags();

--- a/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
+++ b/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
@@ -116,7 +116,7 @@ public class HistoryComparerResponder implements Responder {
 
   private Response makeValidResponse(Request request) throws UnsupportedEncodingException {
     int count = 0;
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("History Comparison");
     page.setPageTitle(makePageTitle(request.getResource()));
     if (!testing) {

--- a/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
+++ b/src/fitnesse/responders/testHistory/HistoryComparerResponder.java
@@ -116,7 +116,7 @@ public class HistoryComparerResponder implements Responder {
 
   private Response makeValidResponse(Request request) throws UnsupportedEncodingException {
     int count = 0;
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("History Comparison");
     page.setPageTitle(makePageTitle(request.getResource()));
     if (!testing) {
@@ -132,7 +132,7 @@ public class HistoryComparerResponder implements Responder {
     page.setMainTemplate("compareHistory");
 
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/testHistory/PageHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PageHistoryResponder.java
@@ -56,7 +56,7 @@ public class PageHistoryResponder implements SecureResponder {
     page.setNavTemplate("viewNav");
     page.put("viewLocation", request.getResource());
     page.setMainTemplate("pageHistory");
-    return makeResponse();
+    return makeResponse(request);
   }
 
   private Response makePageHistoryXmlResponse() throws UnsupportedEncodingException {
@@ -120,7 +120,7 @@ public class PageHistoryResponder implements SecureResponder {
     PageTitle pageTitle = new PageTitle("Suite History", PathParser.parse(request.getResource()), "");
     page.setPageTitle(pageTitle);
 
-    return makeResponse();
+    return makeResponse(request);
   }
 
   private Response generateHtmlTestExecutionResponse(Request request, TestExecutionReport report) throws Exception {
@@ -138,7 +138,7 @@ public class PageHistoryResponder implements SecureResponder {
     PageTitle pageTitle = new PageTitle("Test History", PathParser.parse(request.getResource()), tags);
     page.setPageTitle(pageTitle);
 
-    return makeResponse();
+    return makeResponse(request);
   }
 
   private Response generateXMLResponse(File file) throws UnsupportedEncodingException {
@@ -151,8 +151,8 @@ public class PageHistoryResponder implements SecureResponder {
     return response;
   }
 
-  private Response makeResponse() throws UnsupportedEncodingException {
-    response.setContent(page.html());
+  private Response makeResponse(Request request) throws UnsupportedEncodingException {
+    response.setContent(page.html(request));
     return response;
   }
 
@@ -162,7 +162,7 @@ public class PageHistoryResponder implements SecureResponder {
     String pageName = request.getResource();
     TestHistory history = new TestHistory(resultsDirectory, pageName);
     pageHistory = history.getPageHistory(pageName);
-    page = context.pageFactory.newPage(request);
+    page = context.pageFactory.newPage();
     PageTitle pageTitle = new PageTitle("Test History", PathParser.parse(request.getResource()), "");
     page.setPageTitle(pageTitle);
   }

--- a/src/fitnesse/responders/testHistory/PageHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PageHistoryResponder.java
@@ -162,7 +162,7 @@ public class PageHistoryResponder implements SecureResponder {
     String pageName = request.getResource();
     TestHistory history = new TestHistory(resultsDirectory, pageName);
     pageHistory = history.getPageHistory(pageName);
-    page = context.pageFactory.newPage();
+    page = context.pageFactory.newPage(request);
     PageTitle pageTitle = new PageTitle("Test History", PathParser.parse(request.getResource()), "");
     page.setPageTitle(pageTitle);
   }

--- a/src/fitnesse/responders/testHistory/SuiteOverviewResponder.java
+++ b/src/fitnesse/responders/testHistory/SuiteOverviewResponder.java
@@ -45,7 +45,7 @@ public class SuiteOverviewResponder implements Responder {
   private SimpleResponse makeResponse(SuiteOverviewTree treeview, WikiPagePath path, Request request) throws UnsupportedEncodingException {
     SimpleResponse response = new SimpleResponse();
 
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("Suite Overview");
     page.setPageTitle(new PageTitle("Suite Overview", path));
     page.put("treeRoot", treeview.getTreeRoot());

--- a/src/fitnesse/responders/testHistory/SuiteOverviewResponder.java
+++ b/src/fitnesse/responders/testHistory/SuiteOverviewResponder.java
@@ -45,13 +45,13 @@ public class SuiteOverviewResponder implements Responder {
   private SimpleResponse makeResponse(SuiteOverviewTree treeview, WikiPagePath path, Request request) throws UnsupportedEncodingException {
     SimpleResponse response = new SimpleResponse();
 
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Suite Overview");
     page.setPageTitle(new PageTitle("Suite Overview", path));
     page.put("treeRoot", treeview.getTreeRoot());
     page.put("viewLocation", request.getResource());
     page.setMainTemplate("suiteOverview");
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 }

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -37,7 +37,7 @@ public class TestHistoryResponder implements SecureResponder {
   }
 
   private Response makeTestHistoryResponse(TestHistory testHistory, Request request, String pageName) throws UnsupportedEncodingException {
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Test History");
     page.setPageTitle(new PageTitle(PathParser.parse(pageName)));
     page.setNavTemplate("viewNav");
@@ -45,7 +45,7 @@ public class TestHistoryResponder implements SecureResponder {
     page.put("testHistory", testHistory);
     page.setMainTemplate("testHistory");
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -37,7 +37,7 @@ public class TestHistoryResponder implements SecureResponder {
   }
 
   private Response makeTestHistoryResponse(TestHistory testHistory, Request request, String pageName) throws UnsupportedEncodingException {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("Test History");
     page.setPageTitle(new PageTitle(PathParser.parse(pageName)));
     page.setNavTemplate("viewNav");

--- a/src/fitnesse/responders/versions/VersionComparerResponder.java
+++ b/src/fitnesse/responders/versions/VersionComparerResponder.java
@@ -98,7 +98,7 @@ public class VersionComparerResponder implements Responder {
   }
 
   private Response makeValidResponse(Request request) throws IOException {
-    HtmlPage page = context.pageFactory.newPage(request);
+    HtmlPage page = context.pageFactory.newPage();
     page.setTitle("Version Comparison");
     page.setPageTitle(makePageTitle(request.getResource()));
     page.setNavTemplate("compareVersionsNav.vm");
@@ -110,7 +110,7 @@ public class VersionComparerResponder implements Responder {
       page.setMainTemplate("compareVersions");
     }
     SimpleResponse response = new SimpleResponse();
-    response.setContent(page.html());
+    response.setContent(page.html(request));
     return response;
   }
 

--- a/src/fitnesse/responders/versions/VersionComparerResponder.java
+++ b/src/fitnesse/responders/versions/VersionComparerResponder.java
@@ -98,7 +98,7 @@ public class VersionComparerResponder implements Responder {
   }
 
   private Response makeValidResponse(Request request) throws IOException {
-    HtmlPage page = context.pageFactory.newPage();
+    HtmlPage page = context.pageFactory.newPage(request);
     page.setTitle("Version Comparison");
     page.setPageTitle(makePageTitle(request.getResource()));
     page.setNavTemplate("compareVersionsNav.vm");

--- a/src/fitnesse/responders/versions/VersionResponder.java
+++ b/src/fitnesse/responders/versions/VersionResponder.java
@@ -30,11 +30,13 @@ import fitnesse.wiki.WikiPageUtil;
 public class VersionResponder implements SecureResponder {
   private String version;
   private String resource;
+  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception{
     resource = request.getResource();
     version = request.getInput("version");
+    requestData = request;
     if (version == null)
       return new ErrorResponder("No version specified.").makeResponse(context, request);
 
@@ -55,7 +57,7 @@ public class VersionResponder implements SecureResponder {
 
   private HtmlPage makeHtml(String name, WikiPage page, FitNesseContext context) {
     WikiPage pageVersion = page.getVersion(version);
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(requestData);
     html.setTitle("Version " + version + ": " + name);
     html.setPageTitle(new PageTitle("Version " + version, PathParser.parse(resource), pageVersion.getData().getAttribute(PageData.PropertySUITES)));
     // TODO: subclass actions for specific rollback behaviour.

--- a/src/fitnesse/responders/versions/VersionResponder.java
+++ b/src/fitnesse/responders/versions/VersionResponder.java
@@ -30,13 +30,11 @@ import fitnesse.wiki.WikiPageUtil;
 public class VersionResponder implements SecureResponder {
   private String version;
   private String resource;
-  private Request requestData;
 
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception{
     resource = request.getResource();
     version = request.getInput("version");
-    requestData = request;
     if (version == null)
       return new ErrorResponder("No version specified.").makeResponse(context, request);
 
@@ -50,14 +48,14 @@ public class VersionResponder implements SecureResponder {
     HtmlPage html = makeHtml(fullPathName, page, context);
 
     SimpleResponse response = new SimpleResponse();
-    response.setContent(html.html());
+    response.setContent(html.html(request));
 
     return response;
   }
 
   private HtmlPage makeHtml(String name, WikiPage page, FitNesseContext context) {
     WikiPage pageVersion = page.getVersion(version);
-    HtmlPage html = context.pageFactory.newPage(requestData);
+    HtmlPage html = context.pageFactory.newPage();
     html.setTitle("Version " + version + ": " + name);
     html.setPageTitle(new PageTitle("Version " + version, PathParser.parse(resource), pageVersion.getData().getAttribute(PageData.PropertySUITES)));
     // TODO: subclass actions for specific rollback behaviour.

--- a/src/fitnesse/responders/versions/VersionSelectionResponder.java
+++ b/src/fitnesse/responders/versions/VersionSelectionResponder.java
@@ -39,10 +39,10 @@ public class VersionSelectionResponder implements SecureResponder {
     PageData pageData = page.getData();
     List<VersionInfo> versions = getVersionsList(page);
 
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(request);
     html.setTitle("Version Selection: " + resource);
     html.setPageTitle(new PageTitle("Version Selection", PathParser.parse(resource), pageData.getAttribute(PageData.PropertySUITES)));
-  html.put("lastModified", makeLastModifiedTag(pageData));
+    html.put("lastModified", makeLastModifiedTag(pageData));
     html.put("versions", versions);
     html.setNavTemplate("viewNav");
     html.put("viewLocation", request.getResource());

--- a/src/fitnesse/responders/versions/VersionSelectionResponder.java
+++ b/src/fitnesse/responders/versions/VersionSelectionResponder.java
@@ -39,7 +39,7 @@ public class VersionSelectionResponder implements SecureResponder {
     PageData pageData = page.getData();
     List<VersionInfo> versions = getVersionsList(page);
 
-    HtmlPage html = context.pageFactory.newPage(request);
+    HtmlPage html = context.pageFactory.newPage();
     html.setTitle("Version Selection: " + resource);
     html.setPageTitle(new PageTitle("Version Selection", PathParser.parse(resource), pageData.getAttribute(PageData.PropertySUITES)));
     html.put("lastModified", makeLastModifiedTag(pageData));
@@ -48,7 +48,7 @@ public class VersionSelectionResponder implements SecureResponder {
     html.put("viewLocation", request.getResource());
     html.setMainTemplate("versionSelection");
 
-    response.setContent(html.html());
+    response.setContent(html.html(request));
 
     return response;
   }

--- a/test/fitnesse/html/HtmlUtilTest.java
+++ b/test/fitnesse/html/HtmlUtilTest.java
@@ -4,6 +4,7 @@ package fitnesse.html;
 
 import fitnesse.FitNesseContext;
 import fitnesse.html.template.HtmlPage;
+import fitnesse.http.Request;
 import fitnesse.reporting.JavascriptUtil;
 import fitnesse.responders.WikiPageActions;
 import fitnesse.testutil.FitNesseUtil;
@@ -84,10 +85,10 @@ public class HtmlUtilTest {
 
   private String getActionsHtml(String pageName) {
     WikiPageUtil.addPage(context.getRootPage(), PathParser.parse(pageName), "");
-    HtmlPage htmlPage = context.pageFactory.newPage(null);
+    HtmlPage htmlPage = context.pageFactory.newPage();
     htmlPage.setNavTemplate("wikiNav.vm");
     htmlPage.put("actions", new WikiPageActions(context.getRootPage().getChildPage(pageName)));
-    return htmlPage.html();
+    return htmlPage.html(null);
   }
 
   private void verifyDefaultLinks(String html, String pageName) {

--- a/test/fitnesse/html/HtmlUtilTest.java
+++ b/test/fitnesse/html/HtmlUtilTest.java
@@ -84,7 +84,7 @@ public class HtmlUtilTest {
 
   private String getActionsHtml(String pageName) {
     WikiPageUtil.addPage(context.getRootPage(), PathParser.parse(pageName), "");
-    HtmlPage htmlPage = context.pageFactory.newPage();
+    HtmlPage htmlPage = context.pageFactory.newPage(null);
     htmlPage.setNavTemplate("wikiNav.vm");
     htmlPage.put("actions", new WikiPageActions(context.getRootPage().getChildPage(pageName)));
     return htmlPage.html();

--- a/test/fitnesse/html/template/HtmlPageTest.java
+++ b/test/fitnesse/html/template/HtmlPageTest.java
@@ -24,7 +24,7 @@ public class HtmlPageTest {
     Properties properties = new Properties();
     properties.setProperty("Theme", "fitnesse_straight");
     FitNesseContext context = FitNesseUtil.makeTestContext(properties);
-    page = new HtmlPage(context.pageFactory.getVelocityEngine(), "skeleton.vm", "fitnesse_theme", "/");
+    page = new HtmlPage(context.pageFactory.getVelocityEngine(), "skeleton.vm", "fitnesse_theme", "/", null);
     html = page.html();
   }
 

--- a/test/fitnesse/html/template/HtmlPageTest.java
+++ b/test/fitnesse/html/template/HtmlPageTest.java
@@ -24,8 +24,8 @@ public class HtmlPageTest {
     Properties properties = new Properties();
     properties.setProperty("Theme", "fitnesse_straight");
     FitNesseContext context = FitNesseUtil.makeTestContext(properties);
-    page = new HtmlPage(context.pageFactory.getVelocityEngine(), "skeleton.vm", "fitnesse_theme", "/", null);
-    html = page.html();
+    page = new HtmlPage(context.pageFactory.getVelocityEngine(), "skeleton.vm", "fitnesse_theme", "/");
+    html = page.html(null);
   }
 
   @Test
@@ -62,7 +62,7 @@ public class HtmlPageTest {
   @Test
   public void testMainBar() throws Exception {
     assertSubString("<article>", html);
-    String mainHtml = page.html();
+    String mainHtml = page.html(null);
     assertSubString("<header>", mainHtml);
     assertSubString("<article>", mainHtml);
   }
@@ -76,7 +76,7 @@ public class HtmlPageTest {
   public void testBreadCrumbsWithCurrentPageLinked() throws Exception {
     String trail = "TstPg1.TstPg2.TstPg3.TstPg4";
     page.setPageTitle(new PageTitle(PathParser.parse(trail)));
-    String breadcrumbs = page.html();
+    String breadcrumbs = page.html(null);
     assertSubString("<a href=\"/TstPg1\">TstPg1</a>", breadcrumbs);
     assertSubString("<a href=\"/TstPg1.TstPg2\">TstPg2</a>", breadcrumbs);
     assertSubString("<a href=\"/TstPg1.TstPg2.TstPg3\">TstPg3</a>", breadcrumbs);
@@ -87,7 +87,7 @@ public class HtmlPageTest {
   public void testBreadCrumbsWithCurrentPageNotLinked() throws Exception {
     String trail = "TstPg1.TstPg2.TstPg3.TstPg4";
     page.setPageTitle(new PageTitle(PathParser.parse(trail)).notLinked());
-    String breadcrumbs = page.html();
+    String breadcrumbs = page.html(null);
     assertSubString("<a href=\"/TstPg1\">TstPg1</a>", breadcrumbs);
     assertSubString("<a href=\"/TstPg1.TstPg2\">TstPg2</a>", breadcrumbs);
     assertSubString("<a href=\"/TstPg1.TstPg2.TstPg3\">TstPg3</a>", breadcrumbs);
@@ -98,7 +98,7 @@ public class HtmlPageTest {
   public void testBreadCrumbsWithPageType() throws Exception {
     String trail = "TstPg1.TstPg2.TstPg3.TstPg4";
     page.setPageTitle(new PageTitle("Some Type", PathParser.parse(trail)));
-    String breadcrumbs = page.html();
+    String breadcrumbs = page.html(null);
     assertSubString("<a href=\"/TstPg1.TstPg2.TstPg3.TstPg4\">TstPg4</a>", breadcrumbs);
   }
 

--- a/test/fitnesse/responders/WikiImportingResponderTest.java
+++ b/test/fitnesse/responders/WikiImportingResponderTest.java
@@ -331,11 +331,11 @@ public class WikiImportingResponderTest {
   }
 
   private String getContentAfterSpecialImportHandling() {
-    HtmlPage html = new PageFactory(FitNesseUtil.makeTestContext()).newPage(null);
+    HtmlPage html = new PageFactory(FitNesseUtil.makeTestContext()).newPage();
     WikiImportingResponder.handleImportProperties(html, page);
     html.setNavTemplate("wikiNav.vm");
     html.put("actions", new WikiPageActions(page));
-    return html.html();
+    return html.html(null);
   }
 
 }

--- a/test/fitnesse/responders/WikiImportingResponderTest.java
+++ b/test/fitnesse/responders/WikiImportingResponderTest.java
@@ -331,7 +331,7 @@ public class WikiImportingResponderTest {
   }
 
   private String getContentAfterSpecialImportHandling() {
-    HtmlPage html = new PageFactory(FitNesseUtil.makeTestContext()).newPage();
+    HtmlPage html = new PageFactory(FitNesseUtil.makeTestContext()).newPage(null);
     WikiImportingResponder.handleImportProperties(html, page);
     html.setNavTemplate("wikiNav.vm");
     html.put("actions", new WikiPageActions(page));

--- a/test/fitnesse/responders/run/slimResponder/SlimResponder.java
+++ b/test/fitnesse/responders/run/slimResponder/SlimResponder.java
@@ -41,10 +41,10 @@ public abstract class SlimResponder implements Responder, TestSystemListener {
     loadPage(request.getResource(), context);
 
     SimpleResponse response = new SimpleResponse();
-    HtmlPage html = context.pageFactory.newPage(null);
+    HtmlPage html = context.pageFactory.newPage();
     html.setMainTemplate("render.vm");
     html.put("content", new SlimRenderer());
-    response.setContent(html.html());
+    response.setContent(html.html(request));
     return response;
   }
 

--- a/test/fitnesse/responders/run/slimResponder/SlimResponder.java
+++ b/test/fitnesse/responders/run/slimResponder/SlimResponder.java
@@ -41,7 +41,7 @@ public abstract class SlimResponder implements Responder, TestSystemListener {
     loadPage(request.getResource(), context);
 
     SimpleResponse response = new SimpleResponse();
-    HtmlPage html = context.pageFactory.newPage();
+    HtmlPage html = context.pageFactory.newPage(null);
     html.setMainTemplate("render.vm");
     html.put("content", new SlimRenderer());
     response.setContent(html.html());


### PR DESCRIPTION
This PR makes request data available to velocity in all available responders, so that we have access to the request data from our velocity templates. This enables the use of cookies in templates to store user preferences/settings.

To make the latter easier, a getCookie method is added to the request class, allowing to get cookie data bty its key.