### PR TITLE
Improve messages in jUnit test run

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,5 +1,6 @@
 !2 ${FITNESSE_VERSION}
  * Add support to evaluate expression in/on Slim symbols (Java-only) ([[1123][https://github.com/unclebob/fitnesse/pull/1123]])
+ * Improve message on exception when test is run via jUnit ([[1134][https://github.com/unclebob/fitnesse/issues/1134]])
  * Under the hood:
   * Improved speed of Slim's calls to Java fixtures ([[1179][https://github.com/unclebob/fitnesse/pull/1179]])
 

--- a/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
+++ b/test/fitnesse/junit/JUnitRunNotifierResultsListenerTest.java
@@ -1,9 +1,11 @@
 package fitnesse.junit;
 
+import fitnesse.slim.SlimServer;
 import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
+import fitnesse.testsystems.slim.results.SlimExceptionResult;
 import fitnesse.testsystems.slim.results.SlimTestResult;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
@@ -18,7 +20,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class JUnitRunNotifierResultsListenerTest {
@@ -136,6 +138,20 @@ public class JUnitRunNotifierResultsListenerTest {
   }
 
   @Test
+  public void shouldProvideFirstFailureNoMessage() {
+    TestResult testResult = SlimTestResult.fail();
+
+    listener.testAssertionVerified(null, testResult);
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
+
+    assertThat(failure.getException(), instanceOf(AssertionError.class));
+    assertNull(failure.getMessage());
+  }
+
+  @Test
   public void shouldProvideFirstException() {
     TestResult testResult = SlimTestResult.error("Message", "Actual");
 
@@ -147,6 +163,68 @@ public class JUnitRunNotifierResultsListenerTest {
 
     assertThat(failure.getException(), instanceOf(Exception.class));
     assertThat(failure.getMessage(), is("[Actual] Message"));
+  }
+
+  @Test
+  public void shouldProvideFirstExceptionWithMessage() {
+    listener.testExceptionOccurred(null, new SlimExceptionResult("ex",
+      SlimServer.EXCEPTION_TAG + "message:<<Bad>>"));
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
+
+    assertThat(failure.getException(), instanceOf(Exception.class));
+    assertThat(failure.getMessage(), is("Bad"));
+  }
+
+  @Test
+  public void shouldProvideFirstExceptionWithoutMessage() {
+    listener.testExceptionOccurred(null, new SlimExceptionResult("ex",
+      SlimServer.EXCEPTION_TAG + "Bad"));
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
+
+    assertThat(failure.getException(), instanceOf(Exception.class));
+    assertThat(failure.getMessage(), is("Bad"));
+  }
+
+  @Test
+  public void shouldProvideFirstExceptionWithoutMessageTrimsStacktrace() {
+    listener.testExceptionOccurred(null, new SlimExceptionResult("ex",
+      SlimServer.EXCEPTION_TAG
+    + "java.lang.NullPointerException\n" +
+        "\tat fitnesse.fixtures.EchoFixture.nameContains(EchoFixture.java:17) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_192]\n" +
+        "\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_192]\n" +
+        "\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_192]\n" +
+        "\tat java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_192]\n" +
+        "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.methodInvoke(SimpleInteraction.java:256) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.callMethod(SimpleInteraction.java:241) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.invokeMethod(SimpleInteraction.java:223) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.findAndInvoke(SimpleInteraction.java:185) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.MethodExecutor.findAndInvoke(MethodExecutor.java:18) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.FixtureMethodExecutor.execute(FixtureMethodExecutor.java:18) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+        "\tat fitnesse.slim.StatementExecutor.getMethodExecutionResult(StatementExecutor.java:139) [file:/Users/fitnesse/build/classes/java/main/]"));
+    listener.testComplete(mockWikiTestPage(), summary("-"));
+
+    verify(notifier).fireTestFailure(arguments.capture());
+    Failure failure = arguments.getValue();
+
+    assertThat(failure.getException(), instanceOf(Exception.class));
+    assertEquals("java.lang.NullPointerException\n" +
+      "\tat fitnesse.fixtures.EchoFixture.nameContains(EchoFixture.java:17) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+      "\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_192]\n" +
+      "\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_192]\n" +
+      "\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_192]\n" +
+      "\tat java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_192]\n" +
+      "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.methodInvoke(SimpleInteraction.java:256) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+      "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.callMethod(SimpleInteraction.java:241) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+      "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.invokeMethod(SimpleInteraction.java:223) [file:/Users/fitnesse/build/classes/java/main/]\n" +
+      "\tat fitnesse.slim.fixtureInteraction.SimpleInteraction.findAndInvoke(SimpleInteraction.java:185) [file:/Users/fitnesse/build/classes/java/main/]",
+      failure.getMessage());
   }
 
   static WikiTestPage mockWikiTestPage() {


### PR DESCRIPTION
Better messages from exceptions from remote test system, addressing #1134.

Additionally, no longer add 'null' to message when a assertion failure occurs without message (e.g. Slim script table row returns 'false')