### PR TITLE
Allow Git version plugin to work on recent FitNesse versions when running via standalone.jar

### DIFF
--- a/src/fitnesse/ContextConfigurator.java
+++ b/src/fitnesse/ContextConfigurator.java
@@ -104,7 +104,7 @@ public class ContextConfigurator {
     updateFitNesseProperties(version);
 
     if (wikiPageFactory == null) {
-      wikiPageFactory = (WikiPageFactory) componentFactory.createComponent(WIKI_PAGE_FACTORY_CLASS, FileSystemPageFactory.class);
+      wikiPageFactory = componentFactory.createComponent(WIKI_PAGE_FACTORY_CLASS, FileSystemPageFactory.class);
     }
 
     if (versionsController == null) {

--- a/src/fitnesse/wiki/fs/FileSystemPageFactory.java
+++ b/src/fitnesse/wiki/fs/FileSystemPageFactory.java
@@ -33,8 +33,12 @@ public class FileSystemPageFactory implements WikiPageFactory, WikiPageFactoryRe
   }
 
   public FileSystemPageFactory(Properties properties) {
-    this(new DiskFileSystem(), new ComponentFactory(properties).createComponent(
-            ConfigurationParameter.VERSIONS_CONTROLLER_CLASS, ZipFileVersionsController.class));
+    this(new ComponentFactory(properties));
+  }
+
+  public FileSystemPageFactory(ComponentFactory componentFactory) {
+    this(new DiskFileSystem(), componentFactory.createComponent(
+      ConfigurationParameter.VERSIONS_CONTROLLER_CLASS, ZipFileVersionsController.class));
   }
 
   public FileSystemPageFactory(FileSystem fileSystem, VersionsController versionsController) {

--- a/src/fitnesse/wiki/fs/ZipFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/ZipFileVersionsController.java
@@ -1,5 +1,6 @@
 package fitnesse.wiki.fs;
 
+import fitnesse.components.ComponentFactory;
 import fitnesse.wiki.NoSuchVersionException;
 import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiImportProperty;
@@ -10,7 +11,10 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import java.util.zip.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 import static fitnesse.ConfigurationParameter.VERSIONS_CONTROLLER_DAYS;
 import static java.lang.String.format;
@@ -25,8 +29,8 @@ public class ZipFileVersionsController implements VersionsController {
 
   private VersionsController persistence;
 
-  public ZipFileVersionsController(Properties properties) {
-    this(getVersionDays(properties));
+  public ZipFileVersionsController(ComponentFactory componentFactory) {
+    this(getVersionDays(componentFactory));
   }
   public ZipFileVersionsController() {
     this(14);
@@ -38,8 +42,8 @@ public class ZipFileVersionsController implements VersionsController {
     persistence = new SimpleFileVersionsController(new DiskFileSystem());
   }
 
-  private static int getVersionDays(Properties properties) {
-    String days = properties.getProperty(VERSIONS_CONTROLLER_DAYS.getKey());
+  private static int getVersionDays(ComponentFactory componentFactory) {
+    String days = componentFactory.getProperty(VERSIONS_CONTROLLER_DAYS.getKey());
     return days == null ? 14 : Integer.parseInt(days);
   }
 

--- a/test/fitnesse/wiki/fs/FileSystemPageFactoryTest.java
+++ b/test/fitnesse/wiki/fs/FileSystemPageFactoryTest.java
@@ -1,10 +1,8 @@
 package fitnesse.wiki.fs;
 
 import fitnesse.ConfigurationParameter;
-import fitnesse.wiki.PathParser;
-import fitnesse.wiki.SystemVariableSource;
-import fitnesse.wiki.VersionInfo;
-import fitnesse.wiki.WikiPage;
+import fitnesse.components.ComponentFactory;
+import fitnesse.wiki.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +12,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Properties;
 
+import static fitnesse.ConfigurationParameter.VERSIONS_CONTROLLER_CLASS;
+import static fitnesse.ConfigurationParameter.WIKI_PAGE_FACTORY_CLASS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class FileSystemPageFactoryTest {
   private FileSystem fileSystem;
@@ -27,6 +28,17 @@ public class FileSystemPageFactoryTest {
     fileSystemPageFactory = new FileSystemPageFactory(fileSystem, new ZipFileVersionsController());
     fileSystem.makeFile(new File("./somepath/content.txt"), "");
     rootPage = fileSystemPageFactory.makePage(new File("./somepath"), "somepath", null, new SystemVariableSource());
+  }
+
+  @Test
+  public void getVersionControllerFromComponentFactoryWhenCreatedByComponentFactory() {
+    ComponentFactory c = new ComponentFactory(new Properties());
+
+    VersionsController vc = c.createComponent(VERSIONS_CONTROLLER_CLASS, ZipFileVersionsController.class);
+    FileSystemPageFactory f = c.createComponent(WIKI_PAGE_FACTORY_CLASS, FileSystemPageFactory.class);
+
+    assertSame("Did not use the version controller instance present in component factory",
+      vc, f.getVersionsController());
   }
 
   @Test


### PR DESCRIPTION
Fix #1181