### PR TITLE
Possible fix for https://github.com/unclebob/fitnesse/issues/1187

### DIFF
--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -337,7 +337,6 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
       setClosed();
       response.closeChunks();
       response.addTrailingHeader("Exit-Code", String.valueOf(exitCode));
-      response.closeTrailer();
       response.close();
     }
   }


### PR DESCRIPTION
Clean version now.
Removed closeTrailer() call from SuiteResponder to prevent socket connection to be dropped before close() is called in some circumstances.

See https://github.com/unclebob/fitnesse/issues/1187#issuecomment-464702014 for rationale.