### PR TITLE
Ignore bin folder (Eclipse Buildship default output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 build
 out
 lib/*

--- a/src/fitnesse/responders/testHistory/HistoryComparer.java
+++ b/src/fitnesse/responders/testHistory/HistoryComparer.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.xml.sax.SAXException;
 
@@ -59,7 +60,7 @@ public class HistoryComparer {
 
   public String findScoreByFirstTableIndexAsStringAsPercent(int firstIndex) {
     double score = findScoreByFirstTableIndex(firstIndex);
-    return String.format("%10.2f", (score / MAX_MATCH_SCORE) * 100);
+    return String.format(Locale.US, "%10.2f", (score / MAX_MATCH_SCORE) * 100);
   }
 
   public boolean allTablesMatch() {


### PR DESCRIPTION
According to
https://discuss.gradle.org/t/eclipse-plugin-did-not-configure-default-output-directory-to-build/7586
it is suggested to leave the output folder as "bin", so that Gradle and
Eclipse don't interfere.