### PR TITLE
Ignore bin folder (Eclipse Buildship default output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 build
 out
 lib/*


### PR DESCRIPTION
According to
https://discuss.gradle.org/t/eclipse-plugin-did-not-configure-default-output-directory-to-build/7586
it is suggested to leave the output folder as "bin", so that Gradle and
Eclipse don't interfere.