### PR TITLE
Fix locale-dependent test failure in HistoryComparerTest

### DIFF
--- a/test/fitnesse/responders/testHistory/HistoryComparerTest.java
+++ b/test/fitnesse/responders/testHistory/HistoryComparerTest.java
@@ -103,8 +103,8 @@ public class HistoryComparerTest {
   public void shouldBeAbleToFindMatchScoreByFirstIndexAndReturnAPercentString() throws Exception {
     comparer.matchedTables.add(new HistoryComparer.MatchedPair(1, 2, 1.1));
     comparer.matchedTables.add(new HistoryComparer.MatchedPair(3, 4, 1.0));
-    assertSubString("91.67",comparer.findScoreByFirstTableIndexAsStringAsPercent(1));
-    assertSubString("83.33",comparer.findScoreByFirstTableIndexAsStringAsPercent(3));
+    assertSubString(String.format("%10.2f", 91.67), comparer.findScoreByFirstTableIndexAsStringAsPercent(1));
+    assertSubString(String.format("%10.2f", 83.33), comparer.findScoreByFirstTableIndexAsStringAsPercent(3));
   }
 
   @Test


### PR DESCRIPTION
Otherwise it fails with "java.lang.AssertionError: substring '91.67' not
found in string '     91,67'." using LANG=de_DE.UTF-8