### PR TITLE
Fix MockitoException on ClosableTestSystemListener

### DIFF
--- a/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
+++ b/test/fitnesse/testrunner/MultipleTestsRunnerTest.java
@@ -88,7 +88,7 @@ public class MultipleTestsRunnerTest {
     }
   }
 
-  static interface ClosableTestSystemListener extends TestSystemListener, Closeable {
+  public interface ClosableTestSystemListener extends TestSystemListener, Closeable {
   }
 
 }


### PR DESCRIPTION
When doing a "clean test" build with gradlew the error was:

org.mockito.exceptions.base.MockitoException:
Mockito cannot mock this class: interface
fitnesse.testrunner.MultipleTestsRunnerTest$ClosableTestSystemListener.

Mockito can only mock non-private & non-final classes.
If you're not sure why you're getting this error, please report to the
mailing list.

[...]

Underlying exception : org.mockito.exceptions.base.MockitoException:
Cannot create mock for interface
fitnesse.testrunner.MultipleTestsRunnerTest$ClosableTestSystemListener

The type is not public and its mock class is loaded by a different class
loader.
This can have multiple reasons:
 - You are mocking a class with additional interfaces of another class
loader
 - Mockito is loaded by a different class loader than the mocked type
(e.g. with OSGi)
 - The thread's context class loader is different than the mock's class
loader
	at fitnesse.testrunner.MultipleTestsRunnerTest.shouldCallCloseOnClosableTestSystemListener(MultipleTestsRunnerTest.java:55)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)

[...]

Caused by: org.mockito.exceptions.base.MockitoException:
Cannot create mock for interface
fitnesse.testrunner.MultipleTestsRunnerTest$ClosableTestSystemListener

The type is not public and its mock class is loaded by a different class
loader.
This can have multiple reasons:
 - You are mocking a class with additional interfaces of another class
loader
 - Mockito is loaded by a different class loader than the mocked type
(e.g. with OSGi)
 - The thread's context class loader is different than the mock's class
loader
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:152)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:365)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:174)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:376)
	... 47 more