### PR TITLE
Fix locale-dependent failure in ErrorSituationsDuringSlimServerStartup

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestSystemSlimSuite/ErrorSituationsDuringSlimServerStartup/A_TimeoutAsSlimHeaderNotReceived/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/TestSystemSlimSuite/ErrorSituationsDuringSlimServerStartup/A_TimeoutAsSlimHeaderNotReceived/content.txt
@@ -15,9 +15,9 @@ After slim.timeout seconds we should abort and stop the test.
 !define SLIM_PORT (-!${FITNESSE_PORT}!-)
 !define SLIM_FLAGS (-v)
 -! |
-|check         |request page    |TestPage?test                   |200          |
-|ensure        |content contains|Timeout while reading slim header from client.|
-|show collapsed|content                                                        |
-|check         |request page    |TestPage?executionLog           |200          |
-|ensure        |content contains|Address already in use                        |
-|show collapsed|content                                                        |
+|check         |request page    |TestPage?test                             |200                     |
+|ensure        |content contains|Timeout while reading slim header from client.                     |
+|show collapsed|content                                                                             |
+|check         |request page    |TestPage?executionLog                     |200                     |
+|ensure        |content matches |!-Address already in use|java.net.BindException.* \(Bind failed\)-!|
+|show collapsed|content                                                                             |


### PR DESCRIPTION
The test fails because the exception message is localized. For example
when running with LANG=de_DE.UTF-8 the message is:

java.net.BindException: Die Adresse wird bereits verwendet (Bind failed)
        at java.net.PlainSocketImpl.socketBind(Native Method)

(which is German for "Address already in use")

It seems that there is no way to get the non-localized message:
https://stackoverflow.com/questions/17159357/is-there-a-way-to-force-exception-message-to-be-english-for-java-1-7