### PR TITLE
Fix suites consisting of symbolic pages

### DIFF
--- a/src/fitnesse/wiki/BaseWikiPage.java
+++ b/src/fitnesse/wiki/BaseWikiPage.java
@@ -69,8 +69,12 @@ public abstract class BaseWikiPage implements WikiPage {
     if (!(other instanceof WikiPage))
       return false;
     try {
+      WikiPage otherPage = (WikiPage) other;
+      if (isRoot() && otherPage.isRoot()) {
+        return getName().equals(otherPage.getName());
+      }
       WikiPagePath path1 = getPageCrawler().getFullPath();
-      WikiPagePath path2 = ((WikiPage) other).getPageCrawler().getFullPath();
+      WikiPagePath path2 = otherPage.getPageCrawler().getFullPath();
       return path1.equals(path2);
     } catch (Exception e) {
       return false;

--- a/test/fitnesse/wiki/BaseWikiPageTest.java
+++ b/test/fitnesse/wiki/BaseWikiPageTest.java
@@ -13,6 +13,7 @@ import util.FileUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -52,6 +53,11 @@ public class BaseWikiPageTest {
     checkSymbolicPage(linkingPage.getChildPage("SymLink"));
   }
 
+  @Test
+  public void doesNotEqualAnotherRoot() {
+    WikiPage externalRoot = InMemoryPage.makeRoot("ExternalRoot", fileSystem);
+    assertNotEquals(root, externalRoot);
+  }
 
   @Test
   public void testThatSpecialCharsAreNotEscapedTwice() throws Exception {

--- a/test/fitnesse/wiki/SymbolicPageTest.java
+++ b/test/fitnesse/wiki/SymbolicPageTest.java
@@ -50,6 +50,28 @@ public class SymbolicPageTest {
   }
 
   @Test
+  public void equalsAnotherSymbolicPageWithTheSameRealPage() {
+    assertEquals(symPage, new SymbolicPage("SymPage2", pageTwo, pageOne));
+  }
+  
+  @Test
+  public void doesNotEqualAnotherSymbolicPageWithDifferentRealPage() {
+    WikiPage childPage = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildOne"), "child one");
+    assertNotEquals(symPage, new SymbolicPage("SymPage2", childPage, pageOne));
+  }
+
+  @Test
+  public void doesNotEqualAnotherSymbolicPageWithDifferentExternalRoot() throws Exception {
+    createExternalRoot();
+    
+    FileUtil.createDir("testDir/ExternalRoot2");
+    WikiPage externalRoot2 = new FileSystemPageFactory().makePage(new File("testDir/ExternalRoot2"), "ExternalRoot2", null, new SystemVariableSource());
+    WikiPage symPage2 = new SymbolicPage("SymPage2", externalRoot2, pageOne);
+  
+    assertNotEquals(symPage, symPage2);
+  }
+  
+  @Test
   public void testInternalData() throws Exception {
     PageData data = symPage.getData();
     assertEquals(pageTwoContent, data.getContent());


### PR DESCRIPTION
If using a Suite-page that uses symlinks to link to different external
roots, starting with commit 16bb43e only the contents of the first
symlinked page was displayed in the output of "!contents".

This regression was introduced by fixing #925.