### PR TITLE
Optimize expression evaluator

### DIFF
--- a/src/fitnesse/slim/SlimExpressionEvaluator.java
+++ b/src/fitnesse/slim/SlimExpressionEvaluator.java
@@ -36,7 +36,7 @@ public class SlimExpressionEvaluator {
 
     for (Map.Entry<String, MethodExecutionResult> entry : variables.entrySet()) {
       String key = entry.getKey();
-      if(expr.contains(key)) {
+      if (expr.contains(key)) {
         Object value = entry.getValue().getObject();
         value = convertWikiHashes(mapCnv, value);
         value = convertWikiLists(listCnv, value);

--- a/src/fitnesse/slim/SlimExpressionEvaluator.java
+++ b/src/fitnesse/slim/SlimExpressionEvaluator.java
@@ -30,16 +30,18 @@ public class SlimExpressionEvaluator {
     this.engine = engine;
   }
 
-  public void setContext(Map<String, MethodExecutionResult> variables) {
+  public void setContext(String expr, Map<String, MethodExecutionResult> variables) {
     Converter<Map> mapCnv = ConverterRegistry.getConverterForClass(Map.class);
     Converter<List> listCnv = ConverterRegistry.getConverterForClass(List.class);
 
     for (Map.Entry<String, MethodExecutionResult> entry : variables.entrySet()) {
       String key = entry.getKey();
-      Object value = entry.getValue().getObject();
-      value = convertWikiHashes(mapCnv, value);
-      value = convertWikiLists(listCnv, value);
-      engine.put(key, value);
+      if(expr.contains(key)) {
+        Object value = entry.getValue().getObject();
+        value = convertWikiHashes(mapCnv, value);
+        value = convertWikiLists(listCnv, value);
+        engine.put(key, value);
+      }
     }
   }
 

--- a/src/fitnesse/slim/VariableStore.java
+++ b/src/fitnesse/slim/VariableStore.java
@@ -103,7 +103,7 @@ public class VariableStore {
   }
 
   private Object evaluate(String expr) {
-    SlimExpressionEvaluator evaluator = getEvaluator();
+    SlimExpressionEvaluator evaluator = getEvaluatorForExpression(expr);
 
     Object value = null;
     try {
@@ -114,9 +114,9 @@ public class VariableStore {
     return value;
   }
 
-  protected SlimExpressionEvaluator getEvaluator() {
+  protected SlimExpressionEvaluator getEvaluatorForExpression(String expr) {
     SlimExpressionEvaluator evaluator = new SlimExpressionEvaluator();
-    evaluator.setContext(variables);
+    evaluator.setContext(expr, variables);
     return evaluator;
   }
 }

--- a/src/fitnesse/slim/converters/MapConverter.java
+++ b/src/fitnesse/slim/converters/MapConverter.java
@@ -137,7 +137,7 @@ public class MapConverter implements Converter<Map> {
       try {
         Parser parser = Parser.createParser(possibleTable, null);
         return parser.parse(null);
-      } catch (ParserException e) {
+      } catch (Exception e) {
         return null;
       }
   }

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -221,7 +221,7 @@ public abstract class SlimTable {
       }
       symbols.put(symbol.getKey(), new MethodExecutionResult(symbol.getValue(), Object.class));
     }
-    evaluator.setContext(symbols);
+    evaluator.setContext(expr, symbols);
 
     Object value;
     try {


### PR DESCRIPTION
Add only symbols referenced in the expression to the evaluator's context. This results in up to 40% less consumed time evaluating expressions on pages that have a large amount of slim symbols in their scope.

Also, catch any exception from ParseUtil, as it can trip over localized characters encoded with %'s causing it to throw runtime exceptions that don't need specific handling (if we can't parse the string as html, we treat it as a string)