### PR TITLE
script table throws SyntaxError on malformed assignment

### DIFF
--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -21,6 +21,7 @@ public class ScriptTable extends SlimTable {
   public ScriptTable(Table table, String tableId, SlimTestContext context) {
     super(table, tableId, context);
   }
+
   /**
    * Template method to provide the keyword that identifies the table type.
    *
@@ -155,14 +156,14 @@ public class ScriptTable extends SlimTable {
     return assertions;
   }
 
-  protected List<SlimAssertion> actionAndAssign(String symbolName, int row) {
+  protected List<SlimAssertion> actionAndAssign(String symbolName, int row) throws SyntaxError {
     List<SlimAssertion> assertions = new ArrayList<>();
     int lastCol = table.getColumnCountInRow(row) - 1;
     String actionName = getActionNameStartingAt(1, lastCol, row);
     if (!actionName.equals("")) {
       String[] args = getArgumentsStartingAt(1 + 1, lastCol, row, assertions);
       assertions.add(makeAssertion(callAndAssign(symbolName, getTableType() + "Actor", actionName, (Object[]) args),
-              new SymbolAssignmentExpectation(symbolName, 0, row)));
+        new SymbolAssignmentExpectation(symbolName, 0, row)));
 
     }
     return assertions;
@@ -200,7 +201,7 @@ public class ScriptTable extends SlimTable {
     return assertions;
   }
 
-  protected String getScenarioNameFromAlternatingCells(int endingCol, int row) {
+  protected String getScenarioNameFromAlternatingCells(int endingCol, int row) throws SyntaxError {
     return RowHelper.getScenarioNameFromAlternatingCells(table, endingCol, row);
   }
 
@@ -208,49 +209,49 @@ public class ScriptTable extends SlimTable {
     return Collections.emptyList();
   }
 
-  protected List<SlimAssertion> show(int row) {
+  protected List<SlimAssertion> show(int row) throws SyntaxError {
     int lastCol = table.getColumnCountInRow(row) - 1;
     return invokeAction(1, lastCol, row,
-            new ShowActionExpectation(0, row));
+      new ShowActionExpectation(0, row));
   }
 
-  protected List<SlimAssertion> ensure(int row) {
+  protected List<SlimAssertion> ensure(int row) throws SyntaxError {
     int lastCol = table.getColumnCountInRow(row) - 1;
     return invokeAction(1, lastCol, row,
-            new EnsureActionExpectation(0, row));
+      new EnsureActionExpectation(0, row));
   }
 
-  protected List<SlimAssertion> reject(int row) {
+  protected List<SlimAssertion> reject(int row) throws SyntaxError {
     int lastCol = table.getColumnCountInRow(row) - 1;
     return invokeAction(1, lastCol, row,
-            new RejectActionExpectation(0, row));
+      new RejectActionExpectation(0, row));
 
   }
 
-  protected List<SlimAssertion> checkAction(int row) {
+  protected List<SlimAssertion> checkAction(int row) throws SyntaxError {
     int lastColInAction = table.getColumnCountInRow(row) - 1;
     table.getCellContents(lastColInAction, row);
     return invokeAction(1, lastColInAction - 1, row,
-            new ReturnedValueExpectation(lastColInAction, row));
+      new ReturnedValueExpectation(lastColInAction, row));
   }
 
-  protected List<SlimAssertion> checkNotAction(int row) {
+  protected List<SlimAssertion> checkNotAction(int row) throws SyntaxError {
     int lastColInAction = table.getColumnCountInRow(row) - 1;
     table.getCellContents(lastColInAction, row);
     return invokeAction(1, lastColInAction - 1, row,
-            new RejectedValueExpectation(lastColInAction, row));
+      new RejectedValueExpectation(lastColInAction, row));
   }
 
-  protected List<SlimAssertion> invokeAction(int startingCol, int endingCol, int row, SlimExpectation expectation) {
+  protected List<SlimAssertion> invokeAction(int startingCol, int endingCol, int row, SlimExpectation expectation) throws SyntaxError {
     String actionName = getActionNameStartingAt(startingCol, endingCol, row);
     List<SlimAssertion> assertions = new ArrayList<>();
     String[] args = getArgumentsStartingAt(startingCol + 1, endingCol, row, assertions);
     assertions.add(makeAssertion(callFunction(getTableType() + "Actor", actionName, (Object[]) args),
-            expectation));
+      expectation));
     return assertions;
   }
 
-  protected String getActionNameStartingAt(int startingCol, int endingCol, int row) {
+  protected String getActionNameStartingAt(int startingCol, int endingCol, int row) throws SyntaxError {
     return RowHelper.getActionNameStartingAt(table, startingCol, endingCol, row);
   }
 
@@ -259,7 +260,7 @@ public class ScriptTable extends SlimTable {
     ArgumentExtractor extractor = new ArgumentExtractor(startingCol, endingCol, row);
     while (extractor.hasMoreToExtract()) {
       assertions.add(makeAssertion(Instruction.NOOP_INSTRUCTION,
-              new ArgumentExpectation(extractor.argumentColumn, row)));
+        new ArgumentExpectation(extractor.argumentColumn, row)));
       extractor.extractNextArgument();
     }
     return extractor.getArguments();
@@ -297,15 +298,19 @@ public class ScriptTable extends SlimTable {
   public static class RowHelper {
     private static final String SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX = ";";
 
-    public static String getScenarioNameFromAlternatingCells(Table table, int endingCol, int row) {
+    public static String getScenarioNameFromAlternatingCells(Table table, int endingCol, int row) throws SyntaxError {
       String actionName = getActionNameStartingAt(table, 0, endingCol, row);
       String simpleName = actionName.replace(SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX, "");
       return Disgracer.disgraceClassName(simpleName);
     }
 
-    public static String getActionNameStartingAt(Table table, int startingCol, int endingCol, int row) {
+    public static String getActionNameStartingAt(Table table, int startingCol, int endingCol, int row) throws SyntaxError {
       StringBuilder actionName = new StringBuilder();
-      actionName.append(table.getCellContents(startingCol, row));
+      try {
+        actionName.append(table.getCellContents(startingCol, row));
+      } catch (IndexOutOfBoundsException e) {
+        throw new SyntaxError("badly formatted table: Expected an action name to be found at (" + row + "," + startingCol + ")");
+      }
       int actionNameCol = startingCol + 2;
       while (actionNameCol <= endingCol &&
         !invokesSequentialArgumentProcessing(actionName.toString())) {
@@ -381,7 +386,7 @@ public class ScriptTable extends SlimTable {
     @Override
     protected SlimTestResult createEvaluationMessage(String actual, String expected) {
       return (actual != null && actual.equals(BooleanConverter.TRUE)) ?
-              SlimTestResult.pass() : SlimTestResult.fail();
+        SlimTestResult.pass() : SlimTestResult.fail();
     }
   }
 

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -309,7 +309,7 @@ public class ScriptTable extends SlimTable {
       try {
         actionName.append(table.getCellContents(startingCol, row));
       } catch (IndexOutOfBoundsException e) {
-        throw new SyntaxError("badly formatted table: Expected an action name to be found at (" + row + "," + startingCol + ")");
+        throw new SyntaxError("Too few columns in row " + (row + 1) + ". Expected a function in column " + (startingCol + 1) + ".");
       }
       int actionNameCol = startingCol + 2;
       while (actionNameCol <= endingCol &&

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
@@ -173,7 +173,7 @@ public class ScenarioTableExtensionTest {
       }
     }
 
-    private Set<String> findArguments(Pattern pattern) {
+    private Set<String> findArguments(Pattern pattern) throws SyntaxError {
       Set<String> found = new LinkedHashSet<>();
       int rowCount = table.getRowCount();
       for (int row = 0; row < rowCount; row++) {
@@ -191,7 +191,7 @@ public class ScenarioTableExtensionTest {
       return found;
     }
 
-    private ScenarioTable getCalledScenario(int lastCol, int row) {
+    private ScenarioTable getCalledScenario(int lastCol, int row) throws SyntaxError {
       String scenarioName = ScriptTable.RowHelper.getScenarioNameFromAlternatingCells(table, lastCol, row);
       ScenarioTable scenario = getScenarioByName(scenarioName);
       if (scenario == null && lastCol == 0) {

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableExtensionTest.java
@@ -41,7 +41,7 @@ public class ScriptTableExtensionTest {
     protected String getTableType() { return "htmlScriptTable"; }
 
     @Override
-    protected List<SlimAssertion> show(int row) {
+    protected List<SlimAssertion> show(int row) throws SyntaxError {
       int lastCol = table.getColumnCountInRow(row) - 1;
       return invokeAction(1, lastCol, row,
               new ShowHtmlActionExpectation(0, row));

--- a/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScriptTableTest.java
@@ -39,31 +39,49 @@ public class ScriptTableTest {
     }
 
     @Override
-    protected String getTableType() { return "localizedScriptTable"; }
+    protected String getTableType() {
+      return "localizedScriptTable";
+    }
 
     @Override
-    protected String getTableKeyword() { return "localized script"; }
+    protected String getTableKeyword() {
+      return "localized script";
+    }
 
     @Override
-    protected String getStartKeyword() { return "localized start"; }
+    protected String getStartKeyword() {
+      return "localized start";
+    }
 
     @Override
-    protected String getCheckKeyword() { return "localized check"; }
+    protected String getCheckKeyword() {
+      return "localized check";
+    }
 
     @Override
-    protected String getCheckNotKeyword() { return "localized check not"; }
+    protected String getCheckNotKeyword() {
+      return "localized check not";
+    }
 
     @Override
-    protected String getEnsureKeyword() { return "localized ensure"; }
+    protected String getEnsureKeyword() {
+      return "localized ensure";
+    }
 
     @Override
-    protected String getRejectKeyword() { return "localized reject"; }
+    protected String getRejectKeyword() {
+      return "localized reject";
+    }
 
     @Override
-    protected String getNoteKeyword() { return "localized note"; }
+    protected String getNoteKeyword() {
+      return "localized note";
+    }
 
     @Override
-    protected String getShowKeyword() { return "localized show"; }
+    protected String getShowKeyword() {
+      return "localized show";
+    }
 
   }
 
@@ -119,7 +137,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|start|Bob|\n", false);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("scriptTable_id_0", "scriptTableActor", "Bob")
+        new MakeInstruction("scriptTable_id_0", "scriptTableActor", "Bob")
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -129,7 +147,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized start|Bob|\n", true);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "Bob")
+        new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "Bob")
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -139,7 +157,7 @@ public class ScriptTableTest {
     buildInstructionsForWholeTable("|script|Bob|\n", false);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("scriptTable_id_0", "scriptTableActor", "Bob")
+        new MakeInstruction("scriptTable_id_0", "scriptTableActor", "Bob")
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -149,7 +167,7 @@ public class ScriptTableTest {
     buildInstructionsForWholeTable("|localized script|Bob|\n", true);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "Bob")
+        new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "Bob")
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -159,7 +177,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|start|Bob martin|x|y|\n", false);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("scriptTable_id_0", "scriptTableActor", "BobMartin", new Object[]{"x", "y"})
+        new MakeInstruction("scriptTable_id_0", "scriptTableActor", "BobMartin", new Object[]{"x", "y"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -169,7 +187,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized start|Bob martin|x|y|\n", true);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "BobMartin", new Object[]{"x", "y"})
+        new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "BobMartin", new Object[]{"x", "y"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -179,7 +197,7 @@ public class ScriptTableTest {
     buildInstructionsForWholeTable("|script|Bob martin|x|y|\n", false);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("scriptTable_id_0", "scriptTableActor", "BobMartin", new Object[]{"x", "y"})
+        new MakeInstruction("scriptTable_id_0", "scriptTableActor", "BobMartin", new Object[]{"x", "y"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -196,7 +214,7 @@ public class ScriptTableTest {
     buildInstructionsForWholeTable("|localized script|Bob martin|x|y|\n", true);
     List<MakeInstruction> expectedInstructions =
       asList(
-              new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "BobMartin", new Object[]{"x", "y"})
+        new MakeInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "BobMartin", new Object[]{"x", "y"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -206,7 +224,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function")
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function")
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -216,7 +234,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function|arg|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -226,7 +244,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function|arg|trail|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "functionTrail", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "functionTrail", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -236,7 +254,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|eat|3|meals with|12|grams protein|3|grams fat |\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "eatMealsWithGramsProteinGramsFat", new Object[]{"3", "12", "3"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "eatMealsWithGramsProteinGramsFat", new Object[]{"3", "12", "3"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -246,7 +264,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function;|arg0|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg0"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg0"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -256,7 +274,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function;|arg0|arg1|arg2|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg0", "arg1", "arg2"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg0", "arg1", "arg2"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -266,7 +284,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|set name|Marisa|department and title;|QA|Tester|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "setNameDepartmentAndTitle", new Object[]{"Marisa", "QA", "Tester"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "setNameDepartmentAndTitle", new Object[]{"Marisa", "QA", "Tester"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -276,7 +294,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|set name|Marisa|department|QA|title and length of employment;|Tester|2 years|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "setNameDepartmentTitleAndLengthOfEmployment", new Object[]{"Marisa", "QA", "Tester", "2 years"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "setNameDepartmentTitleAndLengthOfEmployment", new Object[]{"Marisa", "QA", "Tester", "2 years"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -286,7 +304,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|check|function|arg|result|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -296,7 +314,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized check|function|arg|result|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -306,7 +324,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|check not|function|arg|result|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -316,7 +334,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized check not|function|arg|result|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -326,7 +344,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|check|function|arg|trail|result|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "functionTrail", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "functionTrail", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -336,7 +354,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized check|function|arg|trail|result|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "functionTrail", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "functionTrail", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -346,7 +364,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|reject|function|arg|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -356,7 +374,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized reject|function|arg|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -366,7 +384,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|ensure|function|arg|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -376,7 +394,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized ensure|function|arg|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -386,7 +404,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|show|function|arg|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -396,7 +414,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|localized show|function|arg|\n", true);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
+        new CallInstruction("localizedScriptTable_id_0", "localizedScriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -406,7 +424,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|$V=|function|arg|\n", false);
     List<CallAndAssignInstruction> expectedInstructions =
       asList(
-              new CallAndAssignInstruction("scriptTable_id_0", "V", "scriptTableActor", "function", new Object[]{"arg"})
+        new CallAndAssignInstruction("scriptTable_id_0", "V", "scriptTableActor", "function", new Object[]{"arg"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -416,7 +434,7 @@ public class ScriptTableTest {
     buildInstructionsFor("|function|$V|\n", false);
     List<CallInstruction> expectedInstructions =
       asList(
-              new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"$V"})
+        new CallInstruction("scriptTable_id_0", "scriptTableActor", "function", new Object[]{"$V"})
       );
     assertEquals(expectedInstructions, instructions());
   }
@@ -459,19 +477,19 @@ public class ScriptTableTest {
   @Test
   public void voidActionHasNoEffectOnColor() throws Exception {
     assertScriptResults("|func|\n",
-            asList(
-                    asList("scriptTable_id_0", VoidConverter.VOID_TAG)
-            ),
-            "[[Script], [func]]", false
+      asList(
+        asList("scriptTable_id_0", VoidConverter.VOID_TAG)
+      ),
+      "[[Script], [func]]", false
     );
   }
 
   @Test
   public void actionReturningNullHasNoEffectOnColor() throws Exception {
     assertScriptResults("|func|\n",
-            asList(
-                    asList("scriptTable_id_0", "null")
-            ),
+      asList(
+        asList("scriptTable_id_0", "null")
+      ),
       "[[Script], [func]]", false
     );
   }
@@ -479,9 +497,9 @@ public class ScriptTableTest {
   @Test
   public void trueActionPasses() throws Exception {
     assertScriptResults("|func|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.TRUE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.TRUE)
+      ),
       "[[Script], [pass(func)]]", false
     );
   }
@@ -489,9 +507,9 @@ public class ScriptTableTest {
   @Test
   public void falseActionFails() throws Exception {
     assertScriptResults("|func|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.FALSE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.FALSE)
+      ),
       "[[Script], [fail(func)]]", false
     );
   }
@@ -499,9 +517,9 @@ public class ScriptTableTest {
   @Test
   public void checkPasses() throws Exception {
     assertScriptResults("|check|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "3")
-            ),
+      asList(
+        asList("scriptTable_id_0", "3")
+      ),
       "[[Script], [check, func, pass(3)]]", false
     );
   }
@@ -509,9 +527,9 @@ public class ScriptTableTest {
   @Test
   public void localizedCheckPasses() throws Exception {
     assertScriptResults("|localized check|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", "3")
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", "3")
+      ),
       "[[localized script], [localized check, func, pass(3)]]", true
     );
   }
@@ -519,9 +537,9 @@ public class ScriptTableTest {
   @Test
   public void checkNotFails() throws Exception {
     assertScriptResults("|check not|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "3")
-            ),
+      asList(
+        asList("scriptTable_id_0", "3")
+      ),
       "[[Script], [check not, func, fail(3)]]", false
     );
   }
@@ -529,9 +547,9 @@ public class ScriptTableTest {
   @Test
   public void localizedCheckNotFails() throws Exception {
     assertScriptResults("|localized check not|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", "3")
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", "3")
+      ),
       "[[localized script], [localized check not, func, fail(3)]]", true
     );
   }
@@ -539,9 +557,9 @@ public class ScriptTableTest {
   @Test
   public void checkFails() throws Exception {
     assertScriptResults("|check|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "4")
-            ),
+      asList(
+        asList("scriptTable_id_0", "4")
+      ),
       "[[Script], [check, func, fail(a=4;e=3)]]", false
     );
   }
@@ -549,9 +567,9 @@ public class ScriptTableTest {
   @Test
   public void localizedCheckFails() throws Exception {
     assertScriptResults("|localized check|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", "4")
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", "4")
+      ),
       "[[localized script], [localized check, func, fail(a=4;e=3)]]", true
     );
   }
@@ -559,9 +577,9 @@ public class ScriptTableTest {
   @Test
   public void checkNotPasses() throws Exception {
     assertScriptResults("|check not|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "4")
-            ),
+      asList(
+        asList("scriptTable_id_0", "4")
+      ),
       "[[Script], [check not, func, pass(a=4;e=3)]]", false
     );
   }
@@ -569,9 +587,9 @@ public class ScriptTableTest {
   @Test
   public void localizedCheckNotPasses() throws Exception {
     assertScriptResults("|localized check not|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", "4")
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", "4")
+      ),
       "[[localized script], [localized check not, func, pass(a=4;e=3)]]", true
     );
   }
@@ -579,9 +597,9 @@ public class ScriptTableTest {
   @Test
   public void ensurePasses() throws Exception {
     assertScriptResults("|ensure|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.TRUE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.TRUE)
+      ),
       "[[Script], [pass(ensure), func, 3]]", false
     );
   }
@@ -589,9 +607,9 @@ public class ScriptTableTest {
   @Test
   public void localizedEnsurePasses() throws Exception {
     assertScriptResults("|localized ensure|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", BooleanConverter.TRUE)
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", BooleanConverter.TRUE)
+      ),
       "[[localized script], [pass(localized ensure), func, 3]]", true
     );
   }
@@ -599,9 +617,9 @@ public class ScriptTableTest {
   @Test
   public void ensureFails() throws Exception {
     assertScriptResults("|ensure|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.FALSE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.FALSE)
+      ),
       "[[Script], [fail(ensure), func, 3]]", false
     );
   }
@@ -609,9 +627,9 @@ public class ScriptTableTest {
   @Test
   public void localizedEnsureFails() throws Exception {
     assertScriptResults("|localized ensure|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", BooleanConverter.FALSE)
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", BooleanConverter.FALSE)
+      ),
       "[[localized script], [fail(localized ensure), func, 3]]", true
     );
   }
@@ -619,9 +637,9 @@ public class ScriptTableTest {
   @Test
   public void rejectPasses() throws Exception {
     assertScriptResults("|reject|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.FALSE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.FALSE)
+      ),
       "[[Script], [pass(reject), func, 3]]", false
     );
   }
@@ -629,9 +647,9 @@ public class ScriptTableTest {
   @Test
   public void localizedRejectPasses() throws Exception {
     assertScriptResults("|localized reject|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", BooleanConverter.FALSE)
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", BooleanConverter.FALSE)
+      ),
       "[[localized script], [pass(localized reject), func, 3]]", true
     );
   }
@@ -639,9 +657,9 @@ public class ScriptTableTest {
   @Test
   public void rejectFails() throws Exception {
     assertScriptResults("|reject|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", BooleanConverter.TRUE)
-            ),
+      asList(
+        asList("scriptTable_id_0", BooleanConverter.TRUE)
+      ),
       "[[Script], [fail(reject), func, 3]]", false
     );
   }
@@ -649,9 +667,9 @@ public class ScriptTableTest {
   @Test
   public void localizedRejectFails() throws Exception {
     assertScriptResults("|localized reject|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", BooleanConverter.TRUE)
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", BooleanConverter.TRUE)
+      ),
       "[[localized script], [fail(localized reject), func, 3]]", true
     );
   }
@@ -659,9 +677,9 @@ public class ScriptTableTest {
   @Test
   public void show() throws Exception {
     assertScriptResults("|show|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "kawabunga")
-            ),
+      asList(
+        asList("scriptTable_id_0", "kawabunga")
+      ),
       "[[Script], [show, func, 3, kawabunga]]", false
     );
   }
@@ -669,10 +687,10 @@ public class ScriptTableTest {
   @Test
   public void showDoesEscapes() throws Exception {
     assertScriptResults("|show|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "1 < 0")
-            ),
-            "[[Script], [show, func, 3, 1 < 0]]", false
+      asList(
+        asList("scriptTable_id_0", "1 < 0")
+      ),
+      "[[Script], [show, func, 3, 1 < 0]]", false
     );
     assertTrue(st.getTable() instanceof HtmlTable);
     String html = ((HtmlTable) st.getTable()).toHtml();
@@ -682,10 +700,10 @@ public class ScriptTableTest {
   @Test
   public void showDoesNotEscapeValidHtml() throws Exception {
     assertScriptResults("|show|func|3|\n",
-            asList(
-                    asList("scriptTable_id_0", "<a href=\"http://myhost/turtle.html\">kawabunga</a>")
-            ),
-            "[[Script], [show, func, 3, <a href=\"http://myhost/turtle.html\">kawabunga</a>]]", false
+      asList(
+        asList("scriptTable_id_0", "<a href=\"http://myhost/turtle.html\">kawabunga</a>")
+      ),
+      "[[Script], [show, func, 3, <a href=\"http://myhost/turtle.html\">kawabunga</a>]]", false
     );
     assertTrue(st.getTable() instanceof HtmlTable);
     String html = ((HtmlTable) st.getTable()).toHtml();
@@ -694,37 +712,37 @@ public class ScriptTableTest {
 
   @Test
   public void sendHtmlInstructionForTable() throws Exception {
-String newLine = System.getProperty("line.separator");
+    String newLine = System.getProperty("line.separator");
     String testPage = "!define BONUSRatingTbl {| RATING_NBR | DESCR2 |\n" +
       "| 1 | Met 100% of goals |\n" +
       "| 2 | Met < 50% of goals |\n" +
-            "}\n" +
-            "| script |\n" +
-            "| show | echo | ${BONUSRatingTbl}|\n";
+      "}\n" +
+      "| script |\n" +
+      "| show | echo | ${BONUSRatingTbl}|\n";
     st = makeScriptTable(testPage, false);
     assertions.addAll(st.getAssertions());
     assertEquals(assertions.toString(), 2, assertions.size());
     assertEquals("Instruction{id='NOOP'}", assertions.get(0).getInstruction().toString());
-    assertEquals("{id='scriptTable_id_0', instruction='call', instanceName='scriptTableActor', methodName='echo', args=[<table>" + newLine+
-            "\t<tr>" + newLine +
-            "\t\t<td>RATING_NBR</td>" + newLine+
-            "\t\t<td>DESCR2</td>" + newLine+
-            "\t</tr>" + newLine+
-            "\t<tr>" + newLine+
-            "\t\t<td>1</td>" + newLine+
-            "\t\t<td>Met 100% of goals</td>" + newLine+
-            "\t</tr>" + newLine+
-            "\t<tr>" + newLine+
-            "\t\t<td>2</td>" + newLine+
-            "\t\t<td>Met &lt; 50% of goals</td>" + newLine+
-            "\t</tr>" + newLine+
-            "</table>]}", assertions.get(1).getInstruction().toString());
+    assertEquals("{id='scriptTable_id_0', instruction='call', instanceName='scriptTableActor', methodName='echo', args=[<table>" + newLine +
+      "\t<tr>" + newLine +
+      "\t\t<td>RATING_NBR</td>" + newLine +
+      "\t\t<td>DESCR2</td>" + newLine +
+      "\t</tr>" + newLine +
+      "\t<tr>" + newLine +
+      "\t\t<td>1</td>" + newLine +
+      "\t\t<td>Met 100% of goals</td>" + newLine +
+      "\t</tr>" + newLine +
+      "\t<tr>" + newLine +
+      "\t\t<td>2</td>" + newLine +
+      "\t\t<td>Met &lt; 50% of goals</td>" + newLine +
+      "\t</tr>" + newLine +
+      "</table>]}", assertions.get(1).getInstruction().toString());
   }
 
   @Test
   public void testPlainTextWhenCellIsNotHtml() throws Exception {
     String testPage = "| script |\n" +
-            "| show | echo | < 50 % |\n";
+      "| show | echo | < 50 % |\n";
     st = makeScriptTable(testPage, false);
     assertions.addAll(st.getAssertions());
     assertEquals(assertions.toString(), 2, assertions.size());
@@ -735,9 +753,9 @@ String newLine = System.getProperty("line.separator");
   @Test
   public void localizedShow() throws Exception {
     assertScriptResults("|localized show|func|3|\n",
-            asList(
-                    asList("localizedScriptTable_id_0", "kawabunga")
-            ),
+      asList(
+        asList("localizedScriptTable_id_0", "kawabunga")
+      ),
       "[[localized script], [localized show, func, 3, kawabunga]]", true
     );
   }
@@ -747,10 +765,10 @@ String newLine = System.getProperty("line.separator");
     assertScriptResults(
       "|$V=|function|\n" +
         "|check|funcion|$V|$V|\n",
-            asList(
-                    asList("scriptTable_id_0", "3"),
-                    asList("scriptTable_id_1", "3")
-            ),
+      asList(
+        asList("scriptTable_id_0", "3"),
+        asList("scriptTable_id_1", "3")
+      ),
       "[[Script], [$V<-[3], function], [check, funcion, $V->[3], pass($V->[3])]]", false
     );
   }
@@ -759,11 +777,11 @@ String newLine = System.getProperty("line.separator");
   public void symbolReplacementAAAAAAAA() throws Exception {
     assertScriptResults(
       "|$V=|function|\n" +
-       "|start|Class|$V|\n",
-            asList(
-                    asList("scriptTable_id_0", "3"),
-                    asList("scriptTable_id_1", "OK")
-            ),
+        "|start|Class|$V|\n",
+      asList(
+        asList("scriptTable_id_0", "3"),
+        asList("scriptTable_id_1", "OK")
+      ),
       "[[Script], [$V<-[3], function], [start, pass(Class), $V->[3]]]", false
     );
   }
@@ -773,12 +791,17 @@ String newLine = System.getProperty("line.separator");
     assertScriptResults(
       "|$V=|function|\n" +
         "|check|funcion|$V $V|$V|\n",
-            asList(
-                    asList("scriptTable_id_0", "3"),
-                    asList("scriptTable_id_1", "3")
-            ),
+      asList(
+        asList("scriptTable_id_0", "3"),
+        asList("scriptTable_id_1", "3")
+      ),
       "[[Script], [$V<-[3], function], [check, funcion, $V->[3] $V->[3], pass($V->[3])]]", false
     );
+  }
+
+  @Test(expected = SyntaxError.class)
+  public void lonelySymbolSetThrowsSyntaxError() throws Exception {
+    buildInstructionsFor("|$V=|", false);
   }
 
 }


### PR DESCRIPTION
The `SyntaxError` exception is propagated up the call chain which requires more changes than expected. This should translate to `Bad Table` message when rendered in FitNesse. 
See #1221 for context of this small PR.