### PR TITLE
Bugfix/1223

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,5 +1,7 @@
 !2 ${FITNESSE_VERSION}
  * Optimized performance of Slim (javascript) expressions ([[1220][https://github.com/unclebob/fitnesse/pull/1220]])
+ * Issues fixed:
+   * Do not set exit code to error when creating a symbolic link from command line ([[1223][https://github.com/unclebob/fitnesse/issues/1223]])
 
 !2 20190428
  * Issues fixed:

--- a/src/fitnesse/FitNesse.java
+++ b/src/fitnesse/FitNesse.java
@@ -64,8 +64,9 @@ public class FitNesse {
     Request request = new MockRequestBuilder(command).noChunk().build();
     FitNesseExpediter expediter = new FitNesseExpediter(new MockSocket(), context, new SerialExecutorService());
     Response response = expediter.createGoodResponse(request);
-    if (response.getStatus() != 200){
-        throw new Exception("error loading page: " + response.getStatus());
+    int responseStatus = response.getStatus();
+    if (responseStatus >= 400 && responseStatus <= 599){
+        throw new Exception("error loading page: " + responseStatus);
     }
     response.withoutHttpHeaders();
     MockResponseSender sender = new MockResponseSender(out);


### PR DESCRIPTION
Only make single command execution throw error if status code is 4xx or 5xx range (client or server error), don't require 200 status. This allows for redirects etc.