### PR TITLE
Allow plugins to override default wiki theme

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 ${FITNESSE_VERSION}
+ * Allow plugins to override the default wiki theme (i.e. bootstrap).
 
 !2 20190508
  * Optimized performance of Slim (javascript) expressions ([[1220][https://github.com/unclebob/fitnesse/pull/1220]])

--- a/src/fitnesse/ConfigurationParameter.java
+++ b/src/fitnesse/ConfigurationParameter.java
@@ -41,7 +41,8 @@ public enum ConfigurationParameter {
   VERSIONS_CONTROLLER_DAYS("VersionsController.days"),
   RECENT_CHANGES_CLASS("RecentChanges"),
   CONTEXT_ROOT("ContextRoot"),
-  LOCALHOST_ONLY("LocalhostOnly");
+  LOCALHOST_ONLY("LocalhostOnly"),
+  THEME("Theme");
 
   private static final Logger LOG = Logger.getLogger(ConfigurationParameter.class.getName());
 

--- a/src/fitnesse/ContextConfigurator.java
+++ b/src/fitnesse/ContextConfigurator.java
@@ -18,6 +18,7 @@ import fitnesse.testsystems.slim.tables.SlimTableFactory;
 import fitnesse.util.ClassUtils;
 import fitnesse.wiki.RecentChanges;
 import fitnesse.wiki.RecentChangesWikiPage;
+import fitnesse.wiki.SystemVariableSource;
 import fitnesse.wiki.WikiPageFactory;
 import fitnesse.wiki.WikiPageFactoryRegistry;
 import fitnesse.wiki.fs.FileSystemPageFactory;
@@ -42,6 +43,7 @@ public class ContextConfigurator {
   private static final int DEFAULT_COMMAND_PORT = 9123;
   public static final int DEFAULT_PORT = 80;
   public static final String DEFAULT_CONFIG_FILE = "plugins.properties";
+  public static final String DEFAULT_THEME = "bootstrap";
 
   /** Some properties are stored in typed fields: */
   private WikiPageFactory wikiPageFactory;
@@ -123,6 +125,16 @@ public class ContextConfigurator {
       authenticator = pluginsLoader.makeAuthenticator(get(CREDENTIALS));
     }
 
+    SystemVariableSource variableSource = new SystemVariableSource(properties);
+
+    String theme = variableSource.getProperty(THEME.getKey());
+    if (theme == null) {
+      theme = pluginsLoader.getDefaultTheme();
+      if (theme == null) {
+        theme = DEFAULT_THEME;
+      }
+    }
+
     SlimTableFactory slimTableFactory = new SlimTableFactory();
     CustomComparatorRegistry customComparatorRegistry = new CustomComparatorRegistry();
 
@@ -143,7 +155,9 @@ public class ContextConfigurator {
           testSystemFactory,
           testSystemListener,
           formatterFactory,
-          properties);
+          properties,
+          variableSource,
+          theme);
 
     SymbolProvider symbolProvider = SymbolProvider.wikiParsingProvider;
 

--- a/src/fitnesse/FitNesseContext.java
+++ b/src/fitnesse/FitNesseContext.java
@@ -44,6 +44,7 @@ public class FitNesseContext {
   private final String rootDirectoryName;
   public final String contextRoot;
   public final ResponderFactory responderFactory;
+  public final String theme;
   public final PageFactory pageFactory;
 
   public final SystemVariableSource variableSource;
@@ -59,7 +60,9 @@ public class FitNesseContext {
                             Authenticator authenticator, Logger logger,
                             TestSystemFactory testSystemFactory, TestSystemListener testSystemListener,
                             FormatterFactory formatterFactory,
-                            Properties properties) {
+                            Properties properties,
+                            SystemVariableSource variableSource,
+                            String theme) {
     super();
     this.version = version;
     this.wikiPageFactory = wikiPageFactory;
@@ -75,8 +78,9 @@ public class FitNesseContext {
     this.testSystemListener = testSystemListener;
     this.formatterFactory = formatterFactory;
     this.properties = properties;
+    this.theme = theme;
     responderFactory = new ResponderFactory(getRootPagePath());
-    variableSource = new SystemVariableSource(properties);
+    this.variableSource = variableSource;
     fitNesse = new FitNesse(this);
     pageFactory = new PageFactory(this);
   }

--- a/src/fitnesse/html/template/PageFactory.java
+++ b/src/fitnesse/html/template/PageFactory.java
@@ -3,7 +3,6 @@
 package fitnesse.html.template;
 
 import fitnesse.FitNesseContext;
-import fitnesse.http.Request;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -14,18 +13,13 @@ import java.io.Writer;
 import java.util.Properties;
 
 public class PageFactory {
-  public static final String THEME_PROPERTY = "Theme";
-  public static final String DEFAULT_THEME = "bootstrap";
-
   private final String theme;
   private final String contextRoot;
   private VelocityEngine velocityEngine = null;
 
   public PageFactory(FitNesseContext context) {
-    super();
-    String theme = context.getProperty(THEME_PROPERTY);
-    this.theme = theme != null ? theme : DEFAULT_THEME;
-    this.velocityEngine = newVelocityEngine(context, this.theme);
+    this.theme = context.theme;
+    this.velocityEngine = newVelocityEngine(context.getRootPagePath(), this.theme);
     this.contextRoot = context.contextRoot;
   }
 
@@ -53,7 +47,7 @@ public class PageFactory {
     return getClass().getName();
   }
 
-  private VelocityEngine newVelocityEngine(FitNesseContext context, String theme) {
+  private VelocityEngine newVelocityEngine(String rootPagePath, String theme) {
     Properties properties = new Properties();
     properties.setProperty(VelocityEngine.CHECK_EMPTY_OBJECTS, "false");
     properties.setProperty(VelocityEngine.INPUT_ENCODING, FileUtil.CHARENCODING);
@@ -61,7 +55,7 @@ public class PageFactory {
     properties.setProperty(VelocityEngine.RESOURCE_LOADER, "file,themepath,classpath");
 
     properties.setProperty(VelocityEngine.FILE_RESOURCE_LOADER_PATH,
-        String.format("%s/files/fitnesse/templates", context.getRootPagePath()));
+        String.format("%s/files/fitnesse/templates", rootPagePath));
 
     properties.setProperty("themepath." + VelocityEngine.RESOURCE_LOADER + ".class",
         ClasspathResourceLoader.class.getName());

--- a/src/fitnesse/plugins/PluginFeatureFactory.java
+++ b/src/fitnesse/plugins/PluginFeatureFactory.java
@@ -16,6 +16,8 @@ public interface PluginFeatureFactory {
 
   ContentFilter getContentFilter();
 
+  String getDefaultTheme();
+
   void registerResponders(ResponderFactory responderFactory) throws PluginException;
 
   void registerSymbolTypes(SymbolProvider symbolProvider) throws PluginException;

--- a/src/fitnesse/plugins/PluginFeatureFactory.java
+++ b/src/fitnesse/plugins/PluginFeatureFactory.java
@@ -12,24 +12,37 @@ import fitnesse.wikitext.parser.SymbolProvider;
 
 public interface PluginFeatureFactory {
 
-  Authenticator getAuthenticator();
+  default Authenticator getAuthenticator() {
+    return null;
+  }
 
-  ContentFilter getContentFilter();
+  default ContentFilter getContentFilter() {
+    return null;
+  }
 
-  String getDefaultTheme();
+  default String getDefaultTheme() {
+    return null;
+  }
 
-  void registerResponders(ResponderFactory responderFactory) throws PluginException;
+  default void registerResponders(ResponderFactory responderFactory) throws PluginException {
+  }
 
-  void registerSymbolTypes(SymbolProvider symbolProvider) throws PluginException;
+  default void registerSymbolTypes(SymbolProvider symbolProvider) throws PluginException {
+  }
 
-  void registerWikiPageFactories(WikiPageFactoryRegistry wikiPageFactoryRegistry) throws PluginException;
+  default void registerWikiPageFactories(WikiPageFactoryRegistry wikiPageFactoryRegistry) throws PluginException {
+  }
 
-  void registerFormatters(FormatterRegistry registrar) throws PluginException;
+  default void registerFormatters(FormatterRegistry registrar) throws PluginException {
+  }
 
-  void registerTestSystemFactories(TestSystemFactoryRegistry testSystemFactoryRegistry) throws PluginException;
+  default void registerTestSystemFactories(TestSystemFactoryRegistry testSystemFactoryRegistry) throws PluginException {
+  }
 
-  void registerSlimTables(SlimTableFactory slimTableFactory) throws PluginException;
+  default void registerSlimTables(SlimTableFactory slimTableFactory) throws PluginException {
+  }
 
-  void registerCustomComparators(CustomComparatorRegistry customComparatorRegistry) throws PluginException;
+  default void registerCustomComparators(CustomComparatorRegistry customComparatorRegistry) throws PluginException {
+  }
 
 }

--- a/src/fitnesse/plugins/PluginFeatureFactoryBase.java
+++ b/src/fitnesse/plugins/PluginFeatureFactoryBase.java
@@ -24,6 +24,11 @@ public class PluginFeatureFactoryBase implements PluginFeatureFactory {
   }
 
   @Override
+  public String getDefaultTheme() {
+    return null;
+  }
+
+  @Override
   public void registerResponders(ResponderFactory responderFactory) throws PluginException {
   }
 

--- a/src/fitnesse/plugins/PluginFeatureFactoryBase.java
+++ b/src/fitnesse/plugins/PluginFeatureFactoryBase.java
@@ -1,58 +1,6 @@
 package fitnesse.plugins;
 
-import fitnesse.authentication.Authenticator;
-import fitnesse.reporting.FormatterRegistry;
-import fitnesse.responders.ResponderFactory;
-import fitnesse.responders.editing.ContentFilter;
-import fitnesse.testrunner.TestSystemFactoryRegistry;
-import fitnesse.testsystems.slim.CustomComparatorRegistry;
-import fitnesse.testsystems.slim.tables.SlimTableFactory;
-import fitnesse.wiki.WikiPageFactoryRegistry;
-import fitnesse.wikitext.parser.SymbolProvider;
-
 public class PluginFeatureFactoryBase implements PluginFeatureFactory {
   protected final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(getClass().getName());
 
-  @Override
-  public Authenticator getAuthenticator() {
-    return null;
-  }
-
-  @Override
-  public ContentFilter getContentFilter() {
-    return null;
-  }
-
-  @Override
-  public String getDefaultTheme() {
-    return null;
-  }
-
-  @Override
-  public void registerResponders(ResponderFactory responderFactory) throws PluginException {
-  }
-
-  @Override
-  public void registerSymbolTypes(SymbolProvider symbolProvider) throws PluginException {
-  }
-
-  @Override
-  public void registerWikiPageFactories(WikiPageFactoryRegistry wikiPageFactoryRegistry) throws PluginException {
-  }
-
-  @Override
-  public void registerFormatters(FormatterRegistry registrar) throws PluginException {
-  }
-
-  @Override
-  public void registerTestSystemFactories(TestSystemFactoryRegistry testSystemFactoryRegistry) throws PluginException {
-  }
-
-  @Override
-  public void registerSlimTables(SlimTableFactory slimTableFactory) throws PluginException {
-  }
-
-  @Override
-  public void registerCustomComparators(CustomComparatorRegistry customComparatorRegistry) throws PluginException {
-  }
 }

--- a/src/fitnesse/plugins/PluginsLoader.java
+++ b/src/fitnesse/plugins/PluginsLoader.java
@@ -85,6 +85,17 @@ public class PluginsLoader {
     return authenticator == null ? defaultAuthenticator : authenticator;
   }
 
+  public String getDefaultTheme() {
+    String theme = null;
+    for (PluginFeatureFactory pff : pluginFeatureFactories) {
+      theme = pff.getDefaultTheme();
+      if (theme != null) {
+        break;
+      }
+    }
+    return theme;
+  }
+
   public void loadSymbolTypes(SymbolProvider symbolProvider) throws PluginException {
     for (PluginFeatureFactory pff : pluginFeatureFactories) {
       pff.registerSymbolTypes(symbolProvider);

--- a/test/fitnesse/ContextConfiguratorTest.java
+++ b/test/fitnesse/ContextConfiguratorTest.java
@@ -1,14 +1,24 @@
 package fitnesse;
 
-import java.io.IOException;
-
 import fitnesse.plugins.PluginException;
+import fitnesse.plugins.PluginsLoaderTest;
+import fitnesse.util.ClassUtils;
+import org.junit.After;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ContextConfiguratorTest {
+  private final ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+  @After
+  public void tearDown() {
+    ClassUtils.setClassLoader(null);
+    Thread.currentThread().setContextClassLoader(originalClassLoader);
+  }
 
   @Test
   public void canSetContextRoot() throws IOException, PluginException {
@@ -32,6 +42,50 @@ public class ContextConfiguratorTest {
     String contextRoot = configurator.makeFitNesseContext().contextRoot;
 
     assertThat(contextRoot, is("/fitnesse/"));
+  }
+
+  @Test
+  public void bootstrapIsDefaultTheme() throws IOException, PluginException {
+    String theme = ContextConfigurator
+      .empty()
+      .makeFitNesseContext()
+      .theme;
+
+    assertThat(theme, is("bootstrap"));
+  }
+
+  @Test
+  public void themeCanBeSetViaProperties() throws IOException, PluginException {
+    String theme = ContextConfigurator
+      .empty()
+      .withParameter(ConfigurationParameter.THEME, "othertheme")
+      .makeFitNesseContext()
+      .theme;
+
+    assertThat(theme, is("othertheme"));
+  }
+
+  @Test
+  public void themeCanBeSetByPlugin() throws IOException, PluginException {
+    String theme = ContextConfigurator
+      .empty()
+      .withClassLoader(PluginsLoaderTest.createClassLoaderWithTestPlugin())
+      .makeFitNesseContext()
+      .theme;
+
+    assertThat(theme, is("dummy-theme"));
+  }
+
+  @Test
+  public void themeInPropertiesBeatsOneInPlugin() throws IOException, PluginException {
+    String theme = ContextConfigurator
+      .empty()
+      .withParameter(ConfigurationParameter.THEME, "othertheme")
+      .withClassLoader(PluginsLoaderTest.createClassLoaderWithTestPlugin())
+      .makeFitNesseContext()
+      .theme;
+
+    assertThat(theme, is("othertheme"));
   }
 
 }

--- a/test/fitnesse/html/template/HtmlPageTest.java
+++ b/test/fitnesse/html/template/HtmlPageTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static util.RegexTestCase.assertHasRegexp;
 import static util.RegexTestCase.assertSubString;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
@@ -22,7 +23,7 @@ public class HtmlPageTest {
   @Before
   public void setUp() throws Exception {
     Properties properties = new Properties();
-    properties.setProperty("Theme", "fitnesse_straight");
+    properties.setProperty(ConfigurationParameter.THEME.getKey(), "fitnesse_straight");
     FitNesseContext context = FitNesseUtil.makeTestContext(properties);
     page = new HtmlPage(context.pageFactory.getVelocityEngine(), "skeleton.vm", "fitnesse_theme", "/");
     html = page.html(null);

--- a/test/fitnesse/plugins/DummyPluginFeatureFactory.java
+++ b/test/fitnesse/plugins/DummyPluginFeatureFactory.java
@@ -16,6 +16,11 @@ public class DummyPluginFeatureFactory extends PluginFeatureFactoryBase {
   private TestSystemFactoryRegistry testSystemFactoryRegistry;
 
   @Override
+  public String getDefaultTheme() {
+    return "dummy-theme";
+  }
+
+  @Override
   public void registerSymbolTypes(SymbolProvider symbolProvider) throws PluginException {
     symbolProvider.add(new MonthsFromToday2());
   }

--- a/test/fitnesse/plugins/PluginsLoaderTest.java
+++ b/test/fitnesse/plugins/PluginsLoaderTest.java
@@ -2,12 +2,6 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.plugins;
 
-import java.io.File;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.List;
-import java.util.Properties;
-
 import fitnesse.ConfigurationParameter;
 import fitnesse.authentication.Authenticator;
 import fitnesse.authentication.MultiUserAuthenticator;
@@ -50,7 +44,6 @@ import fitnesse.wikitext.parser.SymbolStream;
 import fitnesse.wikitext.parser.SymbolType;
 import fitnesse.wikitext.parser.Today;
 import fitnesse.wikitext.parser.VariableSource;
-
 import org.htmlparser.nodes.TextNode;
 import org.htmlparser.tags.TableColumn;
 import org.htmlparser.tags.TableRow;
@@ -60,10 +53,25 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class PluginsLoaderTest {
+  private ClassLoader originalClassLoader;
   private Properties testProperties;
   private PluginsLoader loader;
   private ResponderFactory responderFactory;
@@ -83,9 +91,8 @@ public class PluginsLoaderTest {
     testSlimTableFactory = new SlimTableFactory();
     testCustomComparatorsRegistry = new CustomComparatorRegistry();
 
-    URL pluginLoaderTestDirectory = new File("plugin-loader-test").toURI().toURL();
-
-    classLoader = new URLClassLoader(new URL[] { pluginLoaderTestDirectory }, ClassLoader.getSystemClassLoader());
+    originalClassLoader = Thread.currentThread().getContextClassLoader();
+    classLoader = createClassLoaderWithTestPlugin();
     ClassUtils.setClassLoader(classLoader);
 
     testTestSystemFactory = new MultipleTestSystemFactory(testSlimTableFactory, testCustomComparatorsRegistry, classLoader);
@@ -98,6 +105,7 @@ public class PluginsLoaderTest {
   @After
   public void tearDown() {
     ClassUtils.setClassLoader(null);
+    Thread.currentThread().setContextClassLoader(originalClassLoader);
   }
 
   @Test
@@ -318,6 +326,12 @@ public class PluginsLoaderTest {
     tableRow.setChildren(new NodeList(tableColumn));
     tableTag.setChildren(new NodeList(tableRow));
     return new HtmlTable(tableTag);
+  }
+
+  public static URLClassLoader createClassLoaderWithTestPlugin() throws MalformedURLException {
+    URL pluginLoaderTestDirectory = new File("plugin-loader-test").toURI().toURL();
+
+    return new URLClassLoader(new URL[] { pluginLoaderTestDirectory }, ClassLoader.getSystemClassLoader());
   }
 
   public static class TestContentFilter implements ContentFilter {

--- a/test/fitnesse/plugins/PluginsLoaderTest.java
+++ b/test/fitnesse/plugins/PluginsLoaderTest.java
@@ -223,6 +223,23 @@ public class PluginsLoaderTest {
   }
 
   @Test
+  public void noDefaultTheme() throws PluginException {
+    classLoader = new URLClassLoader(new URL[0], ClassLoader.getSystemClassLoader());
+    ClassUtils.setClassLoader(classLoader);
+
+    loader = new PluginsLoader(new ComponentFactory(testProperties), classLoader);
+
+    String theme = loader.getDefaultTheme();
+    assertNull(theme);
+  }
+
+  @Test
+  public void testDefaultThemeFromPlugin() {
+    String theme = loader.getDefaultTheme();
+    assertEquals("dummy-theme", theme);
+  }
+
+  @Test
   public void testWikiPageFactoryCreation() throws Exception {
     testProperties.setProperty(ConfigurationParameter.WIKI_PAGE_FACTORIES.getKey(), FooWikiPageFactory.class.getName());
 

--- a/test/fitnesseMain/FitNesseMainTest.java
+++ b/test/fitnesseMain/FitNesseMainTest.java
@@ -156,15 +156,16 @@ public class FitNesseMainTest {
   @Test
   public void systemPropertiesTakePrecedenceOverConfiguredProperties() throws Exception {
     final String configFileName = "systemPropertiesTakePrecedenceOverConfiguredProperties.properties";
-    FileUtil.createFile(configFileName, "Theme=example");
+    String themeKey = ConfigurationParameter.THEME.getKey();
+    FileUtil.createFile(configFileName, themeKey + "=example");
 
-    System.setProperty("Theme", "othertheme");
+    System.setProperty(themeKey, "othertheme");
     try {
       // Checked via logging:
       String output = runFitnesseMainWith("-o", "-c", "/root", "-f", configFileName);
       assertThat(output, containsString("othertheme"));
     } finally {
-      System.getProperties().remove("Theme");
+      System.getProperties().remove(themeKey);
       FileUtil.deleteFile(configFileName);
     }
   }


### PR DESCRIPTION
By default FitNesse uses the 'bootstrap' theme, but this can be overridden using a `Theme` property in either: `plugins.properties`,  an environment variable  or system property.

In this PR a .jar plugin placed in the `plugins` directory can define an alternative theme, instead of bootstrap, to be used when no explicit theme is configured. This can be achieved by implementing the new method `getDefaultTheme()` in its `PluginFeatureFactory`.

