### PR TITLE
Make test ordering more logical

### DIFF
--- a/src/fitnesse/testrunner/PagesByTestSystem.java
+++ b/src/fitnesse/testrunner/PagesByTestSystem.java
@@ -1,5 +1,8 @@
 package fitnesse.testrunner;
 
+import fitnesse.testsystems.TestPage;
+import fitnesse.wiki.WikiPage;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -7,9 +10,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import fitnesse.testsystems.TestPage;
-import fitnesse.wiki.WikiPage;
 
 /**
  * Organize pages by test system in an appropriate order.
@@ -50,7 +50,7 @@ public class PagesByTestSystem {
     Map<WikiPageIdentity, List<TestPage>> orderedPagesByTestSystem = new HashMap<>(pagesByTestSystem.size());
 
     if (!pagesByTestSystem.isEmpty()) {
-      PageListSetUpTearDownSurrounder surrounder = new PageListSetUpTearDownSurrounder(root);
+      PageListSetUpTearDownSurrounder surrounder = new PageListSetUpTearDownSurrounder();
 
       for (Map.Entry<WikiPageIdentity, List<WikiPage>> pages : pagesByTestSystem.entrySet())
         orderedPagesByTestSystem.put(pages.getKey(), asTestPages(surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(pages.getValue())));

--- a/test/fitnesse/testrunner/PageListSetUpTearDownSurrounderTest.java
+++ b/test/fitnesse/testrunner/PageListSetUpTearDownSurrounderTest.java
@@ -1,14 +1,21 @@
 package fitnesse.testrunner;
 
-import fitnesse.wiki.*;
-import static org.junit.Assert.assertEquals;
-
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import static fitnesse.wiki.PageData.SUITE_SETUP_NAME;
+import static fitnesse.wiki.PageData.SUITE_TEARDOWN_NAME;
+import static org.junit.Assert.assertEquals;
 
 public class PageListSetUpTearDownSurrounderTest {
   private WikiPage root;
@@ -22,18 +29,18 @@ public class PageListSetUpTearDownSurrounderTest {
     root = InMemoryPage.makeRoot("RooT");
     PageData data = root.getData();
     root.commit(data);
-    suite = WikiPageUtil.addPage(root, PathParser.parse("SuitePageName"), "The is the test suite\n");
-    testPage = WikiPageUtil.addPage(suite, PathParser.parse("TestPage"), "My test and has some content");
-    surrounder = new PageListSetUpTearDownSurrounder(root);
+    suite = addChildPage(root, "SuitePageName", "The is the test suite\n");
+    testPage = addChildPage(suite, "TestPage", "My test and has some content");
+    surrounder = new PageListSetUpTearDownSurrounder();
   }
 
   @Test
-  public void testPagesForTestSystemAreSurroundedByRespectiveSuiteSetupAndTeardown() throws Exception {
-    WikiPage slimPage = WikiPageUtil.addPage(testPage, PathParser.parse("SlimPageTest"), "");
-    WikiPage setUp = WikiPageUtil.addPage(root, PathParser.parse("SuiteSetUp"), "");
-    WikiPage tearDown = WikiPageUtil.addPage(root, PathParser.parse("SuiteTearDown"), "");
-    WikiPage setUp2 = WikiPageUtil.addPage(slimPage, PathParser.parse("SuiteSetUp"), "");
-    WikiPage tearDown2 = WikiPageUtil.addPage(slimPage, PathParser.parse("SuiteTearDown"), "");
+  public void testPagesForTestSystemAreSurroundedByRespectiveSuiteSetupAndTeardown() {
+    WikiPage slimPage = addChildPage(testPage, "SlimPageTest");
+    WikiPage setUp = addChildPage(root, SUITE_SETUP_NAME);
+    WikiPage tearDown = addChildPage(root, SUITE_TEARDOWN_NAME);
+    WikiPage setUp2 = addChildPage(slimPage, SUITE_SETUP_NAME);
+    WikiPage tearDown2 = addChildPage(slimPage, SUITE_TEARDOWN_NAME);
 
     List<WikiPage> testPages = surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(makeTestPageList());
 
@@ -42,17 +49,10 @@ public class PageListSetUpTearDownSurrounderTest {
     assertPageIsBetween(testPage, setUp, tearDown, testPages);
   }
 
-    private ArrayList<WikiPage> makeTestPageList() throws Exception {
-        SuiteContentsFinder finder = new SuiteContentsFinder(suite, null, root);
-        ArrayList<WikiPage> testPages = new ArrayList<>();
-        for (WikiPage page : finder.getAllPagesToRunForThisSuite()) testPages.add(page);
-        return testPages;
-    }
-
   @Test
-  public void testSetUpAndTearDown() throws Exception {
-    WikiPage setUp = WikiPageUtil.addPage(root, PathParser.parse("SuiteSetUp"), "suite set up");
-    WikiPage tearDown = WikiPageUtil.addPage(root, PathParser.parse("SuiteTearDown"), "suite tear down");
+  public void testSetUpAndTearDown() {
+    WikiPage setUp = addChildPage(root, SUITE_SETUP_NAME, "suite set up");
+    WikiPage tearDown = addChildPage(root, SUITE_TEARDOWN_NAME, "suite tear down");
 
     List<WikiPage> testPages = surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(makeTestPageList());
     assertEquals(3, testPages.size());
@@ -61,10 +61,76 @@ public class PageListSetUpTearDownSurrounderTest {
     assertEquals(tearDown, testPages.get(2));
   }
 
-  private void assertPageIsBetween(WikiPage curr, WikiPage prev, WikiPage next,
-          List<WikiPage> pages) {
+  @Test
+  public void testSuiteOrderingDoesNotDependOnPresenceOfSuiteSetup() {
+    addChildPage(root, SUITE_SETUP_NAME);
+    addChildPage(root, SUITE_TEARDOWN_NAME);
+    addChildPage(suite, "AtoplevelTest");
+    WikiPage slimSuite1 = addChildPage(suite, "SlimPage1Suite");
+    addChildPage(slimSuite1, "SlimPage1Test");
+    addChildPage(slimSuite1, SUITE_TEARDOWN_NAME);
+    WikiPage slimSuite2 = addChildPage(suite, "SlimPage2Suite");
+    addChildPage(slimSuite2, "SlimPage2Test");
+
+    List<WikiPage> noNestedSetUpPages = surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(makeTestPageList());
+    List<String> testPagePaths1 = getNormalPagePaths(noNestedSetUpPages);
+
+    addChildPage(slimSuite2, SUITE_SETUP_NAME);
+    List<WikiPage> nestedSetUpPages = surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(makeTestPageList());
+    List<String> testPagePaths2 = getNormalPagePaths(nestedSetUpPages);
+
+    assertEquals(testPagePaths1, testPagePaths2);
+  }
+
+  @Test
+  public void testSetUpAndTearDownExecutedOnlyOnce() {
+    addChildPage(root, SUITE_SETUP_NAME);
+    addChildPage(root, SUITE_TEARDOWN_NAME);
+    WikiPage slimSuite1 = addChildPage(suite, "SlimPage1Suite");
+    addChildPage(slimSuite1, "SlimPage1Test");
+    addChildPage(slimSuite1, SUITE_TEARDOWN_NAME);
+    WikiPage slimSuite2 = addChildPage(suite, "SlimPage2Suite");
+    addChildPage(slimSuite2, "SlimPage2Test");
+    WikiPage slimSuite3 = addChildPage(suite, "SlimPage3Suite");
+    addChildPage(slimSuite3, "SlimPage3Test");
+    addChildPage(slimSuite2, SUITE_SETUP_NAME);
+
+    List<WikiPage> pages = surrounder.surroundGroupsOfTestPagesWithRespectiveSetUpAndTearDowns(makeTestPageList());
+    List<String> paths = getPagePaths(pages);
+    Set<String> uniquePaths = new HashSet<>(paths);
+    assertEquals(uniquePaths.size(), paths.size());
+  }
+
+  private List<WikiPage> makeTestPageList() {
+    SuiteContentsFinder finder = new SuiteContentsFinder(suite, null, root);
+    return finder.getAllPagesToRunForThisSuite();
+  }
+
+  private List<String> getNormalPagePaths(List<WikiPage> pages) {
+    List<String> paths = getPagePaths(pages);
+    paths.removeIf(p -> p.endsWith(SUITE_SETUP_NAME) || p.endsWith(SUITE_TEARDOWN_NAME));
+    return paths;
+  }
+
+  private List<String> getPagePaths(List<WikiPage> pages) {
+    List<String> list = new ArrayList<>(pages.size());
+    for (WikiPage page : pages) {
+      list.add(page.getFullPath().toString());
+    }
+    return list;
+  }
+
+  private void assertPageIsBetween(WikiPage curr, WikiPage prev, WikiPage next, List<WikiPage> pages) {
     int currIndex = pages.indexOf(curr);
     assertEquals(prev, pages.get(currIndex - 1));
     assertEquals(next, pages.get(currIndex + 1));
+  }
+
+  private WikiPage addChildPage(WikiPage suite, String childName) {
+    return addChildPage(suite, childName, "");
+  }
+
+  private WikiPage addChildPage(WikiPage suite, String childName, String s) {
+    return WikiPageUtil.addPage(suite, PathParser.parse(childName), s);
   }
 }


### PR DESCRIPTION
This PR addresses #1229 and ensure each SuiteSetUp and -TearDown is only executed once per run.

Test ordering no longer depends on the presence (or absence) of SuiteSetUp pages. The test ordering is fixed (alphabetically on full page path) and each SuiteSetUp and SuiteTearDown is added into the mix at the appropriate point. (setups just before the first test in their suite and teardown just after the last in their suite)