### PR TITLE
WhereUsed also finds symbolic links

### DIFF
--- a/src/fitnesse/wiki/SymbolicPage.java
+++ b/src/fitnesse/wiki/SymbolicPage.java
@@ -140,10 +140,13 @@ public class SymbolicPage extends BaseWikitextPage {
   }
 
   @Override
-  @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
   public boolean equals(Object other) {
-    // Wrong! If Other is also a symbolicPage, the comparison is not valid
-    return ((other instanceof SymbolicPage) && realPage.equals(((SymbolicPage) other).realPage)) || realPage.equals(other);
+    if (other instanceof SymbolicPage) {
+      SymbolicPage symbolicOther = (SymbolicPage) other;
+      return getName().equals(symbolicOther.getName()) && getRealPage().equals(symbolicOther.getRealPage());
+    } else {
+      return getRealPage().equals(other);
+    }
   }
 
   @Override

--- a/src/fitnesse/wiki/search/WhereUsedPageFinder.java
+++ b/src/fitnesse/wiki/search/WhereUsedPageFinder.java
@@ -2,18 +2,27 @@ package fitnesse.wiki.search;
 
 import fitnesse.components.TraversalListener;
 import fitnesse.wiki.NoPruningStrategy;
+import fitnesse.wiki.SymbolicPage;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiSourcePage;
 import fitnesse.wiki.WikiWordReference;
-import fitnesse.wikitext.parser.*;
+import fitnesse.wikitext.parser.Alias;
+import fitnesse.wikitext.parser.Parser;
+import fitnesse.wikitext.parser.ParsingPage;
+import fitnesse.wikitext.parser.Symbol;
+import fitnesse.wikitext.parser.SymbolProvider;
+import fitnesse.wikitext.parser.SymbolTreeWalker;
+import fitnesse.wikitext.parser.WikiWord;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class WhereUsedPageFinder implements TraversalListener<WikiPage>, PageFinder, SymbolTreeWalker {
 
-  private WikiPage subjectPage;
-  private TraversalListener<? super WikiPage> observer;
+  private final WikiPage subjectPage;
+  private final TraversalListener<? super WikiPage> observer;
   private WikiPage currentPage;
 
   private List<WikiPage> hits = new ArrayList<>();
@@ -26,13 +35,36 @@ public class WhereUsedPageFinder implements TraversalListener<WikiPage>, PageFin
   @Override
   public void process(WikiPage currentPage) {
     this.currentPage = currentPage;
+
+    checkSymbolicLinks();
+    if (!hits.contains(currentPage)) {
+      checkContent();
+    }
+  }
+
+  private void checkSymbolicLinks() {
+    WikiPageProperty suiteProperty = currentPage.getData().getProperties().getProperty(SymbolicPage.PROPERTY_NAME);
+    if (suiteProperty != null) {
+      Set<String> links = suiteProperty.keySet();
+      for (String link : links) {
+        WikiPage linkTarget = currentPage.getChildPage(link);
+        if (linkTarget instanceof SymbolicPage
+          && ((SymbolicPage) linkTarget).getRealPage().equals(subjectPage)) {
+          addHit();
+          break;
+        }
+      }
+    }
+  }
+
+  private void checkContent() {
     String content = currentPage.getData().getContent();
     Symbol syntaxTree = Parser.make(
-              new ParsingPage(new WikiSourcePage(currentPage)),
-              content,
-              SymbolProvider.refactoringProvider)
-              .parse();
-      syntaxTree.walkPreOrder(this);
+      new ParsingPage(new WikiSourcePage(currentPage)),
+      content,
+      SymbolProvider.refactoringProvider)
+      .parse();
+    syntaxTree.walkPreOrder(this);
   }
 
   @Override
@@ -47,8 +79,7 @@ public class WhereUsedPageFinder implements TraversalListener<WikiPage>, PageFin
     if (node.isType(WikiWord.symbolType)) {
       WikiPage referencedPage = new WikiWordReference(currentPage, node.getContent()).getReferencedPage();
       if (referencedPage != null && referencedPage.equals(subjectPage)) {
-        hits.add(currentPage);
-        observer.process(currentPage);
+        addHit();
       }
     }
     if (node.isType(Alias.symbolType)) {
@@ -58,8 +89,7 @@ public class WhereUsedPageFinder implements TraversalListener<WikiPage>, PageFin
       }
       WikiPage referencedPage = new WikiWordReference(currentPage, linkText).getReferencedPage();
       if (referencedPage != null && referencedPage.equals(subjectPage)) {
-        hits.add(currentPage);
-        observer.process(currentPage);
+        addHit();
       }
     }
     return true;
@@ -68,5 +98,10 @@ public class WhereUsedPageFinder implements TraversalListener<WikiPage>, PageFin
   @Override
   public boolean visitChildren(Symbol node) {
     return true;
+  }
+
+  private void addHit() {
+    hits.add(currentPage);
+    observer.process(currentPage);
   }
 }

--- a/test/fitnesse/wiki/SymbolicPageTest.java
+++ b/test/fitnesse/wiki/SymbolicPageTest.java
@@ -46,45 +46,60 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testCreation() throws Exception {
+  public void testCreation() {
     assertEquals("SymPage", symPage.getName());
   }
 
   @Test
-  public void testLinkage() throws Exception {
+  public void testLinkage() {
     assertSame(pageTwo, symPage.getRealPage());
   }
 
   @Test
-  public void equalsAnotherSymbolicPageWithTheSameRealPage() {
-    assertEquals(symPage, new SymbolicPage("SymPage2", pageTwo, pageOne));
-  }
-  
-  @Test
-  public void doesNotEqualAnotherSymbolicPageWithDifferentRealPage() {
-    WikiPage childPage = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildOne"), "child one");
-    assertNotEquals(symPage, new SymbolicPage("SymPage2", childPage, pageOne));
+  public void doesNotEqualAnotherSymbolicPageWithOtherNameAndTheSameRealPage() {
+    assertNotEquals(symPage, new SymbolicPage("SymPage2", pageTwo, pageOne));
   }
 
   @Test
-  public void doesNotEqualAnotherSymbolicPageWithDifferentExternalRoot() throws Exception {
+  public void equalAnotherSymbolicPageWithTheSameNameAndRealPage() {
+    assertEquals(symPage, new SymbolicPage(symPage.getName(), pageTwo, pageOne));
+  }
+
+  @Test
+  public void equalsItSelf() {
+    assertEquals(symPage, symPage);
+  }
+
+  @Test
+  public void equalsRealPage() {
+    assertEquals(symPage, pageTwo);
+  }
+
+  @Test
+  public void doesNotEqualAnotherSymbolicPageWithDifferentRealPage() {
+    WikiPage childPage = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildOne"), "child one");
+    assertNotEquals(symPage, new SymbolicPage(symPage.getName(), childPage, pageOne));
+  }
+
+  @Test
+  public void doesNotEqualAnotherSymbolicPageWithDifferentExternalRoot() {
     createExternalRoot();
     
     FileUtil.createDir("testDir/ExternalRoot2");
     WikiPage externalRoot2 = new FileSystemPageFactory().makePage(new File("testDir/ExternalRoot2"), "ExternalRoot2", null, new SystemVariableSource());
-    WikiPage symPage2 = new SymbolicPage("SymPage2", externalRoot2, pageOne);
+    WikiPage symPage2 = new SymbolicPage(symPage.getName(), externalRoot2, pageOne);
   
     assertNotEquals(symPage, symPage2);
   }
   
   @Test
-  public void testInternalData() throws Exception {
+  public void testInternalData() {
     PageData data = symPage.getData();
     assertEquals(pageTwoContent, data.getContent());
   }
 
   @Test
-  public void testCommitInternal() throws Exception {
+  public void testCommitInternal() {
     commitNewContent(symPage);
 
     PageData data = pageTwo.getData();
@@ -95,7 +110,7 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testGetChild() throws Exception {
+  public void testGetChild() {
     WikiPage childPage = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildPage"), "child page");
     WikiPage page = symPage.getChildPage("ChildPage");
     assertNotNull(page);
@@ -105,13 +120,13 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void canDetermineIfOriginalPageIsWikiTextPage() throws Exception {
+  public void canDetermineIfOriginalPageIsWikiTextPage() {
     WikiPage symSymPage = new SymbolicPage("SymSymPage", symPage, pageOne);
     assertTrue(SymbolicPage.containsWikitext(symSymPage));
   }
 
   @Test
-  public void canDetermineIfOriginalPageIsNotWikiTextPage() throws Exception {
+  public void canDetermineIfOriginalPageIsNotWikiTextPage() {
     WikiPage wikiPage = mock(WikiPage.class);
     WikiPage symPage = new SymbolicPage("SymPage", wikiPage, pageOne);
     WikiPage symSymPage = new SymbolicPage("SymSymPage", symPage, pageOne);
@@ -119,13 +134,27 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testGetChildren() throws Exception {
+  public void testGetChildren() {
     WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildOne"), "child one");
     WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildTwo"), "child two");
     List<?> children = symPage.getChildren();
     assertEquals(2, children.size());
     assertEquals(SymbolicPage.class, children.get(0).getClass());
     assertEquals(SymbolicPage.class, children.get(1).getClass());
+  }
+
+  @Test
+  public void canCreateMultipleLinksToSamePage() {
+    PageData data = pageOne.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymOne", pageTwoPath);
+    suiteProperty.set("SymTwo", pageTwoPath);
+    pageOne.commit(data);
+
+    PageCrawler pageCrawler = root.getPageCrawler();
+    WikiPage deepPage = pageCrawler.getPage(PathParser.parse(pageOnePath));
+    List<WikiPage> children = deepPage.getChildren();
+    assertEquals(2, children.size());
   }
 
   @Test
@@ -146,7 +175,7 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testCyclicSymbolicLinks() throws Exception {
+  public void testCyclicSymbolicLinks() {
     createCycle();
     PageCrawler pageCrawler = root.getPageCrawler();
 
@@ -196,7 +225,7 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testSymbolicPageUsingExternalDirectory() throws Exception {
+  public void testSymbolicPageUsingExternalDirectory() {
     createExternalRoot();
 
     assertEquals(2, symPage.getChildren().size());
@@ -214,7 +243,7 @@ public class SymbolicPageTest {
     assertEquals("external child", symChild.getData().getContent());
   }
 
-  private void createExternalRoot() throws Exception {
+  private void createExternalRoot() {
     FileUtil.createDir("testDir");
     FileUtil.createDir("testDir/ExternalRoot");
     externalRoot = new FileSystemPageFactory().makePage(new File("testDir/ExternalRoot"), "ExternalRoot", null, new SystemVariableSource());
@@ -226,7 +255,7 @@ public class SymbolicPageTest {
   }
 
   @Test
-  public void testCommittingToExternalRoot() throws Exception {
+  public void testCommittingToExternalRoot() {
     createExternalRoot();
 
     commitNewContent(symPage);
@@ -238,7 +267,7 @@ public class SymbolicPageTest {
     assertEquals("new content", externalRoot.getChildPage("ExternalPageOne").getData().getContent());
   }
 
-  private void commitNewContent(WikiPage wikiPage) throws Exception {
+  private void commitNewContent(WikiPage wikiPage) {
     PageData data = wikiPage.getData();
     data.setContent("new content");
     wikiPage.commit(data);

--- a/test/fitnesse/wiki/search/WhereUsedPageFinderTest.java
+++ b/test/fitnesse/wiki/search/WhereUsedPageFinderTest.java
@@ -1,8 +1,11 @@
 package fitnesse.wiki.search;
 
 import fitnesse.wiki.HitCollector;
+import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
+import fitnesse.wiki.SymbolicPage;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
 import fitnesse.wiki.fs.InMemoryPage;
 import org.junit.Before;
@@ -15,55 +18,57 @@ public class WhereUsedPageFinderTest {
   private WikiPage pageTwo;
   private WikiPage pageThree;
   private WikiPage pageTwoChild;
+  private WikiPage pageTwoChild2;
 
   private HitCollector hits = new HitCollector();
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     root = InMemoryPage.makeRoot("RooT");
     pageOne = WikiPageUtil.addPage(root, PathParser.parse("PageOne"), "this is page one, uncle of PageTwo.ChildPage");
     pageTwo = WikiPageUtil.addPage(root, PathParser.parse("PageTwo"), "I am Page Two my brother is PageOne. I have a >ChildPage. (and SomeMissingPage)");
     pageThree = WikiPageUtil.addPage(root, PathParser.parse("PageThree"), "This is !-PageThree-!, I Have \n!include PageTwo");
     pageTwoChild = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildPage"), "I am Child page, my uncle is .PageOne ");
+    pageTwoChild2 = WikiPageUtil.addPage(pageTwo, PathParser.parse("ChildPage2"), "I am another Child page");
   }
 
   @Test
-  public void testFindReferencingPagesOnSiblingAndChild() throws Exception {
+  public void testFindReferencingPagesOnSiblingAndChild() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageOne, hits);
     whereUsed.search(root);
     hits.assertPagesFound(pageTwo.getName(), pageTwoChild.getName());
   }
 
   @Test
-  public void testFindReferencingPagesOnSibling() throws Exception {
+  public void testFindReferencingPagesOnSibling() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageTwo, hits);
     whereUsed.search(root);
     hits.assertPagesFound(pageThree.getName());
   }
 
   @Test
-  public void testFindReferencingPagesNotReferenced() throws Exception {
+  public void testFindReferencingPagesNotReferenced() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     whereUsed.search(root);
     hits.assertPagesFound();
   }
 
   @Test
-  public void testFindReferencingPagesFromChild() throws Exception {
+  public void testFindReferencingPagesFromChild() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageTwoChild, hits);
     whereUsed.search(root);
     hits.assertPagesFound(pageOne.getName(), pageTwo.getName());
   }
 
   @Test
-  public void testObserving() throws Exception {
+  public void testObserving() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageOne, hits);
     whereUsed.search(root);
     hits.assertPagesFound(pageTwo.getName(), pageTwoChild.getName());
   }
 
   @Test
-  public void testOnlyOneReferencePerPage() throws Exception {
+  public void testOnlyOneReferencePerPage() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     WikiPage newPage = WikiPageUtil.addPage(root, PathParser.parse("NewPage"), "one reference to PageThree.  Two reference to PageThree");
     whereUsed.search(root);
@@ -71,7 +76,7 @@ public class WhereUsedPageFinderTest {
   }
 
   @Test
-  public void testWordsNotFoundInPreprocessedText() throws Exception {
+  public void testWordsNotFoundInPreprocessedText() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     WikiPageUtil.addPage(root, PathParser.parse("NewPage"), "{{{ PageThree }}}");
     whereUsed.search(root);
@@ -79,7 +84,7 @@ public class WhereUsedPageFinderTest {
   }
 
   @Test
-  public void testFindReferencingPagesWithLinksWithAlternateText() throws Exception {
+  public void testFindReferencingPagesWithLinksWithAlternateText() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     WikiPage newPage = WikiPageUtil.addPage(root, PathParser.parse("NewPage"), "I enjoy being a sibling of [[the third page][PageThree]]");
     whereUsed.search(root);
@@ -87,7 +92,7 @@ public class WhereUsedPageFinderTest {
   }
 
   @Test
-  public void pleaseMindPagesWithSuffixAreNotFound() throws Exception {
+  public void pleaseMindPagesWithSuffixAreNotFound() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     WikiPage newPage = WikiPageUtil.addPage(root, PathParser.parse("NewPage"), "I enjoy being a sibling of [[the third page][PageThree?edit]]");
     whereUsed.search(root);
@@ -95,10 +100,71 @@ public class WhereUsedPageFinderTest {
   }
 
   @Test
-  public void testFinderShouldDealWithOtherLinks() throws Exception {
+  public void testFinderShouldDealWithOtherLinks() {
     WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
     WikiPage newPage = WikiPageUtil.addPage(root, PathParser.parse("NewPage"), "I enjoy being a sibling of [[the third page][http://fitnesse.org]]");
     whereUsed.search(root);
     hits.assertPagesFound();
+  }
+
+  @Test
+  public void testFinderShouldFindFullSymbolicLinks() {
+    PageData data = pageOne.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymbThree", "." + pageThree.getFullPath().toString());
+    pageOne.commit(data);
+
+    WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
+    whereUsed.search(root);
+    hits.assertPagesFound(pageOne.getName());
+  }
+
+  @Test
+  public void testFinderShouldFindSibilingSymbolicLinks() {
+    PageData data = pageTwoChild2.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymbThree", pageTwoChild.getName());
+    pageTwoChild2.commit(data);
+
+    WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageTwoChild, hits);
+    whereUsed.search(root);
+    hits.assertPagesFound(pageOne.getName(), pageTwo.getName(), pageTwoChild2.getName());
+  }
+
+  @Test
+  public void testFinderShouldFindUncleSymbolicLinks() {
+    PageData data = pageTwoChild.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymbThree", "<" + pageThree.getFullPath().toString());
+    pageTwoChild.commit(data);
+
+    WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
+    whereUsed.search(root);
+    hits.assertPagesFound(pageTwoChild.getName());
+  }
+
+  @Test
+  public void testFinderCanHandleBrokenLinks() {
+    PageData data = pageTwoChild.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymbThree", "NonExistingPage");
+    pageTwoChild.commit(data);
+
+    WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
+    whereUsed.search(root);
+    hits.assertPagesFound();
+  }
+
+  @Test
+  public void testFinderShouldFindUncleSymbolicLinksOnce() {
+    PageData data = pageTwoChild.getData();
+    WikiPageProperty suiteProperty = data.getProperties().set(SymbolicPage.PROPERTY_NAME);
+    suiteProperty.set("SymbThree", "<" + pageThree.getFullPath().toString());
+    suiteProperty.set("SymbThree2", "<" + pageThree.getFullPath().toString());
+    pageTwoChild.commit(data);
+
+    WhereUsedPageFinder whereUsed = new WhereUsedPageFinder(pageThree, hits);
+    whereUsed.search(root);
+    hits.assertPagesFound(pageTwoChild.getName());
   }
 }


### PR DESCRIPTION
The 'Where Used' functionality currently only finds references to the specified page in the content of other pages. With this PR it also finds symbolic links pointing the specified page.