### PR TITLE
Allow slim symbols in scenario arguments to be used in action name

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioArgumentsWithSlimSymboldCaBeUsedInMethodName.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/ScenarioTestSuite/ScenarioArgumentsWithSlimSymboldCaBeUsedInMethodName.wiki
@@ -1,0 +1,18 @@
+---
+Test
+---
+|Library    |
+|eg.Division|
+
+|scenario     |Mydivision _|firstMethod,numerator,secondMethod,denominator,quotient?|
+|@firstMethod |@numerator                                                           |
+|@secondMethod|@denominator                                                         |
+|$quotient=   |quotient                                                             |
+
+|script                                 |
+|$numeratorSetter=  |echo|setNumerator  |
+|$denominatorSetter=|echo|setDenominator|
+
+|Mydivision                                                         |
+|firstMethod     |numerator|secondMethod      |denominator|quotient?|
+|$numeratorSetter|35       |$denominatorSetter|5          |~=7      |

--- a/src/fitnesse/testsystems/TableCell.java
+++ b/src/fitnesse/testsystems/TableCell.java
@@ -1,9 +1,13 @@
 package fitnesse.testsystems;
 
+import java.util.regex.Pattern;
+
 /**
  * This interface can be implemented by Expectation's to provide extra information for reporting.
  */
 public interface TableCell {
+
+  Pattern ALREADY_REPLACED_SYMBOL = Pattern.compile(".*\\$.+<?->?\\[.+].*");
 
   int getCol();
 

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -165,9 +165,9 @@ public class ScenarioTable extends SlimTable {
         for (Map.Entry<String, String> scenarioArgument : scenarioArguments.entrySet()) {
           String arg = scenarioArgument.getKey();
           if (getInputs().contains(arg)) {
-            String argument = scenarioArguments.get(arg);
-            content = StringUtils.replace(content, "@" + arg, replaceSymbols(argument));
-            content = StringUtils.replace(content, "@{" + arg + "}", replaceSymbols(argument));
+            String argument = replaceSymbols(scenarioArguments.get(arg));
+            content = StringUtils.replace(content, "@" + arg, argument);
+            content = StringUtils.replace(content, "@{" + arg + "}", argument);
           } else {
             throw new SyntaxError(String.format("The argument %s is not an input to the scenario.", arg));
           }

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -63,7 +63,7 @@ public class ScenarioTable extends SlimTable {
     return isNameParameterized(firstNameCell);
   }
 
-    protected void getScenarioArguments() {
+  protected void getScenarioArguments() {
     if (parameterized) {
       getArgumentsForParameterizedName();
     } else {
@@ -95,7 +95,7 @@ public class ScenarioTable extends SlimTable {
     String[] arguments = argumentString.split(",");
 
     for (String argument : arguments) {
-        splitInputAndOutputArguments(argument);
+      splitInputAndOutputArguments(argument);
     }
   }
 
@@ -166,8 +166,8 @@ public class ScenarioTable extends SlimTable {
           String arg = scenarioArgument.getKey();
           if (getInputs().contains(arg)) {
             String argument = scenarioArguments.get(arg);
-            content = StringUtils.replace(content, "@" + arg, argument);
-            content = StringUtils.replace(content, "@{" + arg + "}", argument);
+            content = StringUtils.replace(content, "@" + arg, replaceSymbols(argument));
+            content = StringUtils.replace(content, "@{" + arg + "}", replaceSymbols(argument));
           } else {
             throw new SyntaxError(String.format("The argument %s is not an input to the scenario.", arg));
           }
@@ -199,7 +199,7 @@ public class ScenarioTable extends SlimTable {
   }
 
   protected ScriptTable createChild(Class<? extends ScriptTable> parentTableClass, Table newTable, SlimTestContext testContext) throws TableCreationException {
-      return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
+    return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
   }
 
   public List<SlimAssertion> call(String[] args, ScriptTable parentTable, int row) throws TestExecutionException {
@@ -215,7 +215,7 @@ public class ScenarioTable extends SlimTable {
     return parameterized;
   }
 
-///// scriptTable matcher logic:
+  ///// scriptTable matcher logic:
   private void setParameterMatchingPattern() {
     String parameterizedName = null;
     if (parameterized) {
@@ -286,10 +286,10 @@ public class ScenarioTable extends SlimTable {
       SlimTable parent = scriptTable.getParent();
       ExecutionResult testStatus = ((ScenarioTestContext) scriptTable.getTestContext()).getExecutionResult();
       if (outputs.isEmpty() || testStatus != ExecutionResult.PASS){
-    	  // if the scenario has no output parameters
-    	  // or the scenario failed
-    	  // then the whole line should be flagged
-    	  parent.getTable().updateContent(getRow(), new SlimTestResult(testStatus));
+        // if the scenario has no output parameters
+        // or the scenario failed
+        // then the whole line should be flagged
+        parent.getTable().updateContent(getRow(), new SlimTestResult(testStatus));
       }
       return null;
     }

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -63,7 +63,7 @@ public class ScenarioTable extends SlimTable {
     return isNameParameterized(firstNameCell);
   }
 
-  protected void getScenarioArguments() {
+    protected void getScenarioArguments() {
     if (parameterized) {
       getArgumentsForParameterizedName();
     } else {
@@ -95,7 +95,7 @@ public class ScenarioTable extends SlimTable {
     String[] arguments = argumentString.split(",");
 
     for (String argument : arguments) {
-      splitInputAndOutputArguments(argument);
+        splitInputAndOutputArguments(argument);
     }
   }
 
@@ -199,7 +199,7 @@ public class ScenarioTable extends SlimTable {
   }
 
   protected ScriptTable createChild(Class<? extends ScriptTable> parentTableClass, Table newTable, SlimTestContext testContext) throws TableCreationException {
-    return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
+      return SlimTableFactory.createTable(parentTableClass, newTable, id, testContext);
   }
 
   public List<SlimAssertion> call(String[] args, ScriptTable parentTable, int row) throws TestExecutionException {
@@ -215,7 +215,7 @@ public class ScenarioTable extends SlimTable {
     return parameterized;
   }
 
-  ///// scriptTable matcher logic:
+///// scriptTable matcher logic:
   private void setParameterMatchingPattern() {
     String parameterizedName = null;
     if (parameterized) {
@@ -286,10 +286,10 @@ public class ScenarioTable extends SlimTable {
       SlimTable parent = scriptTable.getParent();
       ExecutionResult testStatus = ((ScenarioTestContext) scriptTable.getTestContext()).getExecutionResult();
       if (outputs.isEmpty() || testStatus != ExecutionResult.PASS){
-        // if the scenario has no output parameters
-        // or the scenario failed
-        // then the whole line should be flagged
-        parent.getTable().updateContent(getRow(), new SlimTestResult(testStatus));
+    	  // if the scenario has no output parameters
+    	  // or the scenario failed
+    	  // then the whole line should be flagged
+    	  parent.getTable().updateContent(getRow(), new SlimTestResult(testStatus));
       }
       return null;
     }

--- a/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScenarioTable.java
@@ -159,21 +159,18 @@ public class ScenarioTable extends SlimTable {
 
   public List<SlimAssertion> call(final Map<String, String> scenarioArguments,
                    SlimTable parentTable, int row) throws TestExecutionException {
-    Table newTable = getTable().asTemplate(new Table.CellContentSubstitution() {
-      @Override
-      public String substitute(String content) throws SyntaxError {
-        for (Map.Entry<String, String> scenarioArgument : scenarioArguments.entrySet()) {
-          String arg = scenarioArgument.getKey();
-          if (getInputs().contains(arg)) {
-            String argument = replaceSymbols(scenarioArguments.get(arg));
-            content = StringUtils.replace(content, "@" + arg, argument);
-            content = StringUtils.replace(content, "@{" + arg + "}", argument);
-          } else {
-            throw new SyntaxError(String.format("The argument %s is not an input to the scenario.", arg));
-          }
+    Table newTable = getTable().asTemplate(content -> {
+      for (Map.Entry<String, String> scenarioArgument : scenarioArguments.entrySet()) {
+        String arg = scenarioArgument.getKey();
+        if (getInputs().contains(arg)) {
+          String argument = scenarioArguments.get(arg);
+          content = StringUtils.replace(content, "@" + arg, argument);
+          content = StringUtils.replace(content, "@{" + arg + "}", argument);
+        } else {
+          throw new SyntaxError(String.format("The argument %s is not an input to the scenario.", arg));
         }
-        return content;
       }
+      return content;
     });
     ScenarioTestContext testContext = new ScenarioTestContext(parentTable.getTestContext());
     ScriptTable t = createChild(testContext, parentTable, newTable);

--- a/src/fitnesse/testsystems/slim/tables/ScriptTable.java
+++ b/src/fitnesse/testsystems/slim/tables/ScriptTable.java
@@ -18,6 +18,8 @@ import fitnesse.util.StringUtils;
 
 public class ScriptTable extends SlimTable {
 
+  private final RowHelper rowHelper = new RowHelper();
+
   public ScriptTable(Table table, String tableId, SlimTestContext context) {
     super(table, tableId, context);
   }
@@ -102,6 +104,10 @@ public class ScriptTable extends SlimTable {
    */
   protected String getNoteKeyword() {
     return "note";
+  }
+
+  public RowHelper getRowHelper() {
+    return rowHelper;
   }
 
   @Override
@@ -202,7 +208,7 @@ public class ScriptTable extends SlimTable {
   }
 
   protected String getScenarioNameFromAlternatingCells(int endingCol, int row) throws SyntaxError {
-    return RowHelper.getScenarioNameFromAlternatingCells(table, endingCol, row);
+    return rowHelper.getScenarioNameFromAlternatingCells(table, endingCol, row);
   }
 
   protected List<SlimAssertion> note(int row) {
@@ -252,7 +258,7 @@ public class ScriptTable extends SlimTable {
   }
 
   protected String getActionNameStartingAt(int startingCol, int endingCol, int row) throws SyntaxError {
-    return RowHelper.getActionNameStartingAt(table, startingCol, endingCol, row);
+    return rowHelper.getActionNameStartingAt(table, startingCol, endingCol, row);
   }
 
   // Adds extra assertions to the "assertions" list!
@@ -267,7 +273,7 @@ public class ScriptTable extends SlimTable {
   }
 
   protected boolean invokesSequentialArgumentProcessing(String cellContents) {
-    return RowHelper.invokesSequentialArgumentProcessing(cellContents);
+    return rowHelper.invokesSequentialArgumentProcessing(cellContents);
   }
 
   protected List<SlimAssertion> startActor() {
@@ -295,16 +301,16 @@ public class ScriptTable extends SlimTable {
     return assertions;
   }
 
-  public static class RowHelper {
+  public class RowHelper {
     private static final String SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX = ";";
 
-    public static String getScenarioNameFromAlternatingCells(Table table, int endingCol, int row) throws SyntaxError {
+    public String getScenarioNameFromAlternatingCells(Table table, int endingCol, int row) throws SyntaxError {
       String actionName = getActionNameStartingAt(table, 0, endingCol, row);
       String simpleName = actionName.replace(SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX, "");
       return Disgracer.disgraceClassName(simpleName);
     }
 
-    public static String getActionNameStartingAt(Table table, int startingCol, int endingCol, int row) throws SyntaxError {
+    public String getActionNameStartingAt(Table table, int startingCol, int endingCol, int row) throws SyntaxError {
       StringBuilder actionName = new StringBuilder();
       try {
         actionName.append(table.getCellContents(startingCol, row));
@@ -317,10 +323,10 @@ public class ScriptTable extends SlimTable {
         actionName.append(" ").append(table.getCellContents(actionNameCol, row));
         actionNameCol += 2;
       }
-      return actionName.toString().trim();
+      return replaceSymbols(actionName.toString().trim());
     }
 
-    public static boolean invokesSequentialArgumentProcessing(String cellContents) {
+    public boolean invokesSequentialArgumentProcessing(String cellContents) {
       return cellContents.endsWith(SEQUENTIAL_ARGUMENT_PROCESSING_SUFFIX);
     }
   }

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -269,6 +269,13 @@ public abstract class SlimTable {
         if (testResult.doesCount())
           getTestContext().increment(testResult.getExecutionResult());
       }
+
+      for(int i = 0; i < table.getColumnCountInRow(getRow()); i++) {
+        if(!table.getCellContents(i, getRow()).matches(ALREADY_REPLACED_SYMBOL.pattern())) {
+          table.substitute(i, getRow(), replaceSymbolsWithFullExpansion(table.getCellContents(i, getRow())));
+        }
+
+      }
       return testResult;
     }
 
@@ -354,7 +361,6 @@ public abstract class SlimTable {
 
     @Override
     protected SlimTestResult createEvaluationMessage(String actual, String expected) {
-      table.substitute(getCol(), getRow(), replaceSymbolsWithFullExpansion(expected));
       return SlimTestResult.plain();
     }
   }
@@ -392,7 +398,7 @@ public abstract class SlimTable {
     @Override
     protected SlimTestResult createEvaluationMessage(String actual, String expected) {
       if ("OK".equalsIgnoreCase(actual))
-        return SlimTestResult.ok(replaceSymbolsWithFullExpansion(expected));
+        return SlimTestResult.ok(expected);
       else
         return SlimTestResult.error("Unknown construction message", actual);
     }
@@ -430,13 +436,13 @@ public abstract class SlimTable {
       if (actual == null)
         testResult = SlimTestResult.fail("null", replacedExpected); //todo can't be right message.
       else if (actual.equals(replacedExpected))
-        testResult = SlimTestResult.pass(announceBlank(replaceSymbolsWithFullExpansion(expected)));
+        testResult = SlimTestResult.pass(announceBlank(expected));
       else if (replacedExpected.isEmpty())
         testResult = SlimTestResult.ignore(actual);
       else {
         testResult = new Comparator(replacedExpected, actual, expected).evaluate();
         if (testResult == null)
-          testResult = SlimTestResult.fail(actual, replaceSymbolsWithFullExpansion(expected));
+          testResult = SlimTestResult.fail(actual, expected);
       }
 
       return testResult;
@@ -484,7 +490,7 @@ public abstract class SlimTable {
       return null;
     }
   }
-  
+
   class ReturnedSymbolExpectation extends ReturnedValueExpectation {
     private String symbolName;
     private String assignToName = null;
@@ -652,7 +658,6 @@ public abstract class SlimTable {
     private SlimTestResult rangeMessage(boolean pass) {
       String[] fragments = expected.trim().replaceAll("( )+", " ").split("_");
       String message = String.format("%s%s%s", fragments[0], actual, fragments[1]);
-      message = replaceSymbolsWithFullExpansion(message);
       return pass ? SlimTestResult.pass(message) : SlimTestResult.fail(message);
     }
 
@@ -690,7 +695,6 @@ public abstract class SlimTable {
 
     private SlimTestResult simpleComparisonMessage(boolean pass) {
       String message = String.format("%s%s", actual, expected.trim().replaceAll("( )+", " "));
-      message = replaceSymbolsWithFullExpansion(message);
       return pass ? SlimTestResult.pass(message) : SlimTestResult.fail(message);
 
     }

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableExtensionTest.java
@@ -192,7 +192,8 @@ public class ScenarioTableExtensionTest {
     }
 
     private ScenarioTable getCalledScenario(int lastCol, int row) throws SyntaxError {
-      String scenarioName = ScriptTable.RowHelper.getScenarioNameFromAlternatingCells(table, lastCol, row);
+      ScriptTable scriptTable = new ScriptTable (table, "testTable", getTestContext());
+      String scenarioName = scriptTable.getRowHelper().getScenarioNameFromAlternatingCells(table, lastCol, row);
       ScenarioTable scenario = getScenarioByName(scenarioName);
       if (scenario == null && lastCol == 0) {
         String cellContents = table.getCellContents(0, row);

--- a/test/fitnesse/testsystems/slim/tables/ScenarioTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/ScenarioTableTest.java
@@ -203,4 +203,5 @@ public class ScenarioTableTest {
         assertTrue(inputs.contains("name"));
         assertFalse(st.isParameterized());
     }
+
 }


### PR DESCRIPTION
Scenario arguments can be used to construct action names in a scenario table.
However, if the argument is filled using a slim symbol, this symbol was not expanded before the action name was determined. This PR fixes that omission, so that slim symbols passed to a scenario behave in the same manner as a normal String passed to a scenario.