### PR TITLE
Add new feature: suite partitioning

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 ${FITNESSE_VERSION}
+ * New feature to split a suite of tests in partitions, which could be used to split test execution across multiple workers, without having the change the content or structure of the test pages.
 
 !2 20200205
  * Added ability to customize HTML generated for Slim tables, using 'symbol decorators' ([[1255][https://github.com/unclebob/fitnesse/pull/1255]]).

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder.wiki
@@ -1,0 +1,11 @@
+---
+Suite
+---
+
+The partition preview responder can show how the 'Suite Responder' will split a suite in sub-suites when using the !style_code(partitionIndex) and !style_code(partitionCount) parameters.
+
+When you execute a suite page indicating that you want to partition the suite (i.e. split it in parts) and only run one partition, !-FitNesse-! should only run that partition.
+
+The partition preview responder shows which pages go in which partition, and how the tests will be ordered in the test system.
+
+!contents -R2 -g -p -f -h

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder.wiki
@@ -7,5 +7,6 @@ The partition preview responder can show how the 'Suite Responder' will split a 
 When you execute a suite page indicating that you want to partition the suite (i.e. split it in parts) and only run one partition, !-FitNesse-! should only run that partition.
 
 The partition preview responder shows which pages go in which partition, and how the tests will be ordered in the test system.
+It can either provide its output in HTML (the default) or as tab separated. Tab separated format can be requested by supplying the !style_code(format) parameter with value !style_code(tsv).
 
 !contents -R2 -g -p -f -h

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreview.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreview.wiki
@@ -1,0 +1,51 @@
+---
+Test
+---
+
+In this test we create a suite of 4 pages, which is partitioned in 3 parts. We expect our 4 pages to be split in one partition of 2 tests and two of 1 test (i.e. a 2-1-1 division).
+
+----
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder                  |
+|line  |!-!define TEST_SYSTEM {slim}-!|
+|page  |!-SuitePage.TestPage4-!       |
+
+|Response Requester.                                      |
+|uri                                               |valid?|
+|!-SuitePage?responder=partition&partitionCount=3-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+The suite should report all !-TestPages-! in tab-separate format.
+
+|Response Examiner.                                         |
+|type    |pattern                                  |matches?|
+|headers |Content-Type: text/tab-separated-values  |true    |
+|contents|!-Page\tPartition\tTest System\tOrder\n-!|true    |
+|contents|!-SuitePage\.TestPage1\t0\tfit\t0\n-!    |true    |
+|contents|!-SuitePage\.TestPage2\t0\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.TestPage3\t1\tfit\t0\n-!    |true    |
+|contents|!-SuitePage\.TestPage4\t2\tslim\t0\n-!   |true    |
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreview.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreview.wiki
@@ -30,9 +30,9 @@ Create two sub pages
 |line  |!-!define TEST_SYSTEM {slim}-!|
 |page  |!-SuitePage.TestPage4-!       |
 
-|Response Requester.                                      |
-|uri                                               |valid?|
-|!-SuitePage?responder=partition&partitionCount=3-!|true  |
+|Response Requester.                                                 |
+|uri                                                          |valid?|
+|!-SuitePage?responder=partition&format=tsv&partitionCount=3-!|true  |
 
 |Response Examiner.|
 |contents?         |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewBasedOnFile.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewBasedOnFile.wiki
@@ -1,0 +1,81 @@
+---
+Test
+---
+
+This test shows that the partitioner can work with a file containing the division of the suite, instead of calculating from scratch.
+The file is specified by the !style_code(partitionIndexFile) parameter and should be placed in the files section.
+
+The file may contain extra tests, they are ignored.
+Tests not listed in the file are split across all partitions and put ''before'' the tests listed in the file.
+
+---
+
+!define TEST_SYSTEM {slim}
+
+Create the file section
+|file section|setup|
+
+Add some files
+|file section file adder                                                                                                                                                                                     |
+|path         |type|content                                                                                                                                                                           |valid?|
+|partition.txt|file|!-Page	Partition	Test System	Order
+SuitePage.TestPage1	2	fit	99
+SuitePage.TestPage2	2	fit	0
+SuitePage.TestPage3	1	fit	0
+SuitePage.TestPage4	0	fit	0
+SuitePage.TestPage5	0	fit	1
+-!|true  |
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder                  |
+|line  |!-!define TEST_SYSTEM {slim}-!|
+|page  |!-SuitePage.TestPage4-!       |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage6-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage7-!                    |
+
+|Response Requester.                                                                       |
+|uri                                                                                |valid?|
+|!-SuitePage?responder=partition&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+The suite should report all !-TestPages-! in tab-separate format.
+
+|Response Examiner.                                         |
+|type    |pattern                                  |matches?|
+|headers |Content-Type: text/tab-separated-values  |true    |
+|contents|!-Page\tPartition\tTest System\tOrder\n-!|true    |
+|contents|!-SuitePage\.TestPage1\t2\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.TestPage2\t2\tfit\t0\n-!    |true    |
+|contents|!-SuitePage\.TestPage3\t1\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.TestPage4\t0\tslim\t1\n-!   |true    |
+|contents|!-SuitePage\.TestPage6\t0\tfit\t0\n-!    |true    |
+|contents|!-SuitePage\.TestPage7\t1\tfit\t0\n-!    |true    |
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewBasedOnFile.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewBasedOnFile.wiki
@@ -58,9 +58,9 @@ Create two sub pages
 |line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
 |page  |!-SuitePage.TestPage7-!                    |
 
-|Response Requester.                                                                       |
-|uri                                                                                |valid?|
-|!-SuitePage?responder=partition&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
+|Response Requester.                                                                                  |
+|uri                                                                                           |valid?|
+|!-SuitePage?responder=partition&format=tsv&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
 
 |Response Examiner.|
 |contents?         |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewIncludesSuiteSetUp.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewIncludesSuiteSetUp.wiki
@@ -1,0 +1,86 @@
+---
+Test
+---
+
+!-SuiteSetUp-! and !-SuiteTearDown-! pages are also added to the list of test pages.
+
+---
+
+!define TEST_SYSTEM {slim}
+
+Create the file section
+|file section|setup|
+
+Add some files
+|file section file adder                                                                                                                                                                                     |
+|path         |type|content                                                                                                                                                                           |valid?|
+|partition.txt|file|!-Page	Partition	Test System	Order
+SuitePage.TestPage1	2	fit	1
+SuitePage.TestPage2	2	fit	0
+SuitePage.TestPage3	1	fit	99
+SuitePage.TestPage4	0	fit	0
+SuitePage.TestPage5	0	fit	1
+-!|true  |
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder            |
+|line  |!--!                    |
+|page  |!-SuitePage.SuiteSetUp-!|
+
+|script|Page Builder               |
+|line  |!--!                       |
+|page  |!-SuitePage.SuiteTearDown-!|
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder           |
+|line  |!--!                   |
+|page  |!-SuitePage.TestPage4-!|
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage6-!                    |
+
+|Response Requester.                                                                       |
+|uri                                                                                |valid?|
+|!-SuitePage?responder=partition&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+The suite should report all !-TestPages-! in tab-separate format.
+
+|Response Examiner.                                         |
+|type    |pattern                                  |matches?|
+|headers |Content-Type: text/tab-separated-values  |true    |
+|contents|!-Page\tPartition\tTest System\tOrder\n-!|true    |
+|contents|!-SuitePage\.TestPage1\t2\tfit\t2\n-!    |true    |
+|contents|!-SuitePage\.TestPage2\t2\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.TestPage3\t1\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.TestPage4\t0\tfit\t2\n-!    |true    |
+|contents|!-SuitePage\.TestPage6\t0\tfit\t1\n-!    |true    |
+|contents|!-SuitePage\.SuiteSetUp\t0\tfit\t0\n-!   |true    |
+|contents|!-SuitePage\.SuiteTearDown\t0\tfit\t3\n-!|true    |
+|contents|!-SuitePage\.SuiteSetUp\t1\tfit\t0\n-!   |true    |
+|contents|!-SuitePage\.SuiteTearDown\t1\tfit\t2\n-!|true    |
+|contents|!-SuitePage\.SuiteSetUp\t2\tfit\t0\n-!   |true    |
+|contents|!-SuitePage\.SuiteTearDown\t2\tfit\t3\n-!|true    |
+

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewIncludesSuiteSetUp.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/PartitionPreviewResponder/PartitionPreviewIncludesSuiteSetUp.wiki
@@ -58,9 +58,9 @@ Create two sub pages
 |line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
 |page  |!-SuitePage.TestPage6-!                    |
 
-|Response Requester.                                                                       |
-|uri                                                                                |valid?|
-|!-SuitePage?responder=partition&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
+|Response Requester.                                                                                  |
+|uri                                                                                           |valid?|
+|!-SuitePage?responder=partition&format=tsv&partitionCount=3&partitionIndexFile=partition.txt-!|true  |
 
 |Response Examiner.|
 |contents?         |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuitePartition.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuitePartition.wiki
@@ -1,0 +1,136 @@
+---
+Test
+---
+
+When you execute a suite page indicating that you want to partition the suite (i.e. split it in parts) and only run one partition, !-FitNesse-! should only run that partition.
+
+In this test we create a suite of 4 pages, which is partitioned in 3 parts. We expect our 4 pages to be split in one partition of 2 tests and two of 1 test (i.e. a 2-1-1 division).
+
+The parameters !style_code(partitionIndex) and !style_code(partitionCount) configure which sub-list to run.
+
+----
+
+!2 Run the 1st partition
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage4-!                    |
+
+Now run the suite page, indicating that you want to split in 3 parts and run the first.
+So when we run the first partition only the first 2 pages should be executed.
+
+|Response Requester.                                                   |
+|uri                                                            |valid?|
+|!-SuitePage?responder=suite&partitionCount=3&partitionIndex=0-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+The suite should report the TestPages and should show no errors.
+
+|Response Examiner.                    |
+|type    |pattern             |matches?|
+|contents|!-TestPage1-!       |true    |
+|contents|!-TestPage2-!       |true    |
+|contents|!-TestPage3-!       |false   |
+|contents|!-TestPage4-!       |false   |
+|contents|Test Pages:.*2 right|true    |
+
+The error log page should not have any errors
+
+|Response Requester.              |
+|uri                       |valid?|
+|!-SuitePage?executionLog-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+|Response Examiner.                  |
+|type    |pattern           |matches?|
+|contents|Exit code.*0.*Time|true    |
+
+---
+
+Perform the test again, now running the second partition. Now only one page (page three) should be run.
+
+!2 Run the 2nd partition
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage4-!                    |
+
+Now run the suite page, indicating that you want to split in 3 parts and run the 2nd.
+
+|Response Requester.                                                   |
+|uri                                                            |valid?|
+|!-SuitePage?responder=suite&partitionCount=3&partitionIndex=1-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+The suite should report the TestPages and should show no errors.
+
+|Response Examiner.                    |
+|type    |pattern             |matches?|
+|contents|!-TestPage1-!       |false   |
+|contents|!-TestPage2-!       |false   |
+|contents|!-TestPage3-!       |true    |
+|contents|!-TestPage4-!       |false   |
+|contents|Test Pages:.*1 right|true    |
+
+The error log page should not have any errors
+
+|Response Requester.              |
+|uri                       |valid?|
+|!-SuitePage?executionLog-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+|Response Examiner.                  |
+|type    |pattern           |matches?|
+|contents|Exit code.*0.*Time|true    |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuitePartitionBasedOnFile.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteResponderTests/SuiteTestResponders/SuiteResponder/TestSuitePartitionBasedOnFile.wiki
@@ -1,0 +1,92 @@
+---
+Test
+---
+
+This test shows that the suite responder can work with a file containing the division of the suite, instead of calculating from scratch.
+The file is specified by the !style_code(partitionIndexFile) parameter, in addition to !style_code(partitionIndex) and !style_code(partitionCount) parameters, and should be placed in the files section.
+
+The file may contain extra tests, they are ignored.
+Tests not listed in the file are split across all partitions and put ''before'' the tests listed in the file.
+
+---
+
+!define TEST_SYSTEM {slim}
+
+Create the file section
+|file section|setup|
+
+Add some files
+|file section file adder                                                                                                                                                                                     |
+|path         |type|content                                                                                                                                                                           |valid?|
+|partition.tsv|file|!-Page	Partition	Test System	Order
+SuitePage.TestPage1	2	fit	99
+SuitePage.TestPage2	2	fit	0
+SuitePage.TestPage3	0	fit	0
+SuitePage.TestPage4	1	fit	0
+SuitePage.TestPage5	1	fit	1
+-!|true  |
+
+Create a Suite page
+
+|script|Page Builder |
+|line  |${SUT_PATH}  |
+|page  |!-SuitePage-!|
+
+Create two sub pages
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage1-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage2-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage3-!                    |
+
+|script|Page Builder                  |
+|line  |!-!define TEST_SYSTEM {slim}-!|
+|page  |!-SuitePage.TestPage4-!       |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage6-!                    |
+
+|script|Page Builder                               |
+|line  |!-|!-fitnesse.testutil.PassFixture-!-!!-|-!|
+|page  |!-SuitePage.TestPage7-!                    |
+
+|Response Requester.                                                                                    |
+|uri                                                                                             |valid?|
+|!-SuitePage?responder=suite&partitionCount=3&partitionIndex=0&partitionIndexFile=partition.tsv-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+
+|Response Examiner.                    |
+|type    |pattern             |matches?|
+|contents|!-TestPage1-!       |false   |
+|contents|!-TestPage2-!       |false   |
+|contents|!-TestPage3-!       |true    |
+|contents|!-TestPage4-!       |false   |
+|contents|!-TestPage6-!       |true    |
+|contents|!-TestPage7-!       |false   |
+|contents|Test Pages:.*2 right|true    |
+
+The error log page should not have any errors
+
+|Response Requester.              |
+|uri                       |valid?|
+|!-SuitePage?executionLog-!|true  |
+
+|Response Examiner.|
+|contents?         |
+|                  |
+
+|Response Examiner.                  |
+|type    |pattern           |matches?|
+|contents|Exit code.*0.*Time|true    |

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
@@ -5,7 +5,7 @@ Suites can be partitioned, that is split into multiple parts, for instance to ru
 
 There are multiple ways to select certain parts of a suite. SubWikiSuites and TagsAndFilters both allow suites to be split, but these are static. And if the goal is only to improve a test suite's execution time, it could be considered improper use of these mechanisms as they are intended to define functional aspects of tests.
 A purpose-build mechanism to partition a suite is also available. When running a suite one can provide a !style_code(partitionCount) and !style_code(partitionIndex) parameter (zero-based) to indicate in how many parts the suite should be split, and which part to run now.
-An example usage of this mechanism is a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partionIndex=0-!). This would partion the suite in two, executing the first.
+An example usage of this mechanism is a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partitionIndex=0-!). This would partition the suite in two, executing the first.
 
 So one can start multiple runs for the same suite, all using the same partition count, but a different partition index.
 By starting 'partition count' runs all tests are run, without the need to manually define and maintain exactly which tests should go in which partition, even when tests are added and removed from the suite.
@@ -20,7 +20,7 @@ So one could for instance do !style_code(!-http://&lt;host>:&lt;port>/&lt;suite 
 One can also supply a file containing a partitioning in the format created by the partition preview responder when running a suite. This file can list the desired partitioning for all known test pages. Any other pages found in the suite will be spread evenly across all partitions.
 The filename for such a file must be supplied to the suite responder using the !style_code(partitionIndexFile) parameter. The file will be looked up inside the wiki's [[files section][.FitNesse.UserGuide.FitNesseWiki.FilesSection]].
 
-So for example a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partionIndex=1&partitionIndexFile=partitions.tsv-!). This would partion the tests in the suite in two groups using the division described in a file called !style_code(partitions.tsv) in the files section, executing the second group.
+So for example a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partitionIndex=1&partitionIndexFile=partitions.tsv-!). This would partition the tests in the suite in two groups using the division described in a file called !style_code(partitions.tsv) in the files section, executing the second group.
 The file's content could look something like this (where whitespace between columns should be tab characters):
 {{{
 Page	Partition	Test System	Order

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
@@ -1,0 +1,42 @@
+!2 Suite Partitioning
+
+Suites can be partitioned, that is split into multiple parts, for instance to run each partition in parallel. By running the parts in parallel the total execution time can be reduced.
+!-FitNesse-! is not thread-safe so each partition's run should be executed by a separate Java process. But this can be a very effective way to speed up the time needed for testing when tests do not interfere which each other. In CI/CD servers one can spread test execution across multiple workers and get very quick tests results, even when test sizes grow.
+
+There are multiple ways to select certain parts of a suite. SubWikiSuites and TagsAndFilters both allow suites to be split, but these are static. And if the goal is only to improve a test suite's execution time, it could be considered improper use of these mechanisms as they are intended to define functional aspects of tests.
+A purpose-build mechanism to partition a suite is also available. When running a suite one can provide a !style_code(partitionCount) and !style_code(partitionIndex) parameter (zero-based) to indicate in how many parts the suite should be split, and which part to run now.
+An example usage of this mechanism is a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partionIndex=0-!). This would partion the suite in two, executing the first.
+
+So one can start multiple runs for the same suite, all using the same partition count, but a different partition index.
+By starting 'partition count' runs all tests are run, without the need to manually define and maintain exactly which tests should go in which partition, even when tests are added and removed from the suite.
+
+!3 Partition Preview
+
+A specific partition responder is available which will list the partitions (and test order in them) that will be created for a specific suite and partition count. It will list all test pages in a tab-separated text format indicating in which partition the test will be placed and what its order in the partition will be.
+So one could for instance do !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?partition&partitionCount=5-!) to so see how that suite would be divided in 5 partitions.
+
+!3 Partition Index File
+
+One can also supply a file containing a partitioning in the format created by the partition preview responder when running a suite. This file can list the desired partitioning for all known test pages. Any other pages found in the suite will be spread evenly across all partitions.
+The filename for such a file must be supplied to the suite responder using the !style_code(partitionIndexFile) parameter. The file will be looked up inside the wiki's [[files section][.FitNesse.UserGuide.FitNesseWiki.FilesSection]].
+
+So for example a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partionIndex=1&partitionIndexFile=partitions.tsv-!). This would partion the tests in the suite in two groups using the division described in a file called !style_code(partitions.tsv) in the files section, executing the second group.
+The file's content could look something like this (where whitespace between columns should be tab characters):
+{{{
+Page	Partition	Test System	Order
+FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation	0	slim	0
+FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations	1	slim	0
+FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations	1	slim	1
+}}}
+
+!3 Partitioning Algorithm
+
+The standard partitioning algorithm tries to make partitions with the same number of tests. It will, for instance, for a partition count of 4:
+ * split a suite of 100 tests into 4 partitions of 25 elements and
+ * a suite of 102 elements would be split into 2 partitions of 26 elements and 2 of 25.
+
+Plugins can tailor this behaviour by registering a custom 'test run factory'. For instance when historic run times of tests are known a plugin could use this information to create partitions with an equal expected run time.
+
+!3 Usage via !-FitNesseRunner-!
+
+When [[running tests from jUnit][.FitNesse.UserGuide.WritingAcceptanceTests.RunningFromJunit]] using the !style_code(!-FitNesseRunner-!) one can use this feature by applying the !style_code(@Partition), and possibly the !style_code(!-@PartitionFile-!), annotation to the test class.

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
@@ -12,12 +12,14 @@ By starting 'partition count' runs all tests are run, without the need to manual
 
 !3 Partition Preview
 
-A specific partition responder is available which will list the partitions (and test order in them) that will be created for a specific suite and partition count. It will list all test pages in a tab-separated text format indicating in which partition the test will be placed and what its order in the partition will be.
+A specific partition responder is available which will list the partitions (and test order in them) that will be created for a specific suite and partition count. It will list all test pages in HTML (or tab-separated text) format indicating in which partition the test will be placed and what its order in the partition will be.
 So one could for instance do !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?partition&partitionCount=5-!) to so see how that suite would be divided in 5 partitions.
+
+Tab separated format can be requested by supplying the !style_code(format) parameter with value !style_code(tsv), e.g. !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?partition&format=tsv&partitionCount=5-!).
 
 !3 Partition Index File
 
-One can also supply a file containing a partitioning in the format created by the partition preview responder when running a suite. This file can list the desired partitioning for all known test pages. Any other pages found in the suite will be spread evenly across all partitions.
+One can also supply a file containing a partitioning in the tab-separated format created by the partition preview responder when running a suite. This file can list the desired partitioning for all known test pages. Any other pages found in the suite will be spread evenly across all partitions.
 The filename for such a file must be supplied to the suite responder using the !style_code(partitionIndexFile) parameter. The file will be looked up inside the wiki's [[files section][.FitNesse.UserGuide.FitNesseWiki.FilesSection]].
 
 So for example a call to !style_code(!-http://&lt;host>:&lt;port>/&lt;suite path>?suite&partitionCount=2&partitionIndex=1&partitionIndexFile=partitions.tsv-!). This would partition the tests in the suite in two groups using the division described in a file called !style_code(partitions.tsv) in the files section, executing the second group.

--- a/src/fitnesse/ConfigurationParameter.java
+++ b/src/fitnesse/ConfigurationParameter.java
@@ -1,5 +1,7 @@
 package fitnesse;
 
+import util.FileUtil;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -7,8 +9,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import util.FileUtil;
 
 /**
  * Parameters used to configure FitNesse.

--- a/src/fitnesse/FitNesseContext.java
+++ b/src/fitnesse/FitNesseContext.java
@@ -7,6 +7,7 @@ import fitnesse.components.Logger;
 import fitnesse.html.template.PageFactory;
 import fitnesse.reporting.FormatterFactory;
 import fitnesse.responders.ResponderFactory;
+import fitnesse.testrunner.run.FileBasedTestRunFactory;
 import fitnesse.testrunner.run.TestRunFactoryRegistry;
 import fitnesse.testsystems.TestSystemFactory;
 import fitnesse.testsystems.TestSystemListener;
@@ -86,6 +87,7 @@ public class FitNesseContext {
     fitNesse = new FitNesse(this);
     pageFactory = new PageFactory(this);
     testRunFactoryRegistry = new TestRunFactoryRegistry(this);
+    testRunFactoryRegistry.addFactory(new FileBasedTestRunFactory(this));
   }
 
   public WikiPage getRootPage() {

--- a/src/fitnesse/fixtures/FileSectionFileAdder.java
+++ b/src/fitnesse/fixtures/FileSectionFileAdder.java
@@ -3,10 +3,12 @@
 package fitnesse.fixtures;
 
 import java.io.File;
+import java.io.FileWriter;
 
 public class FileSectionFileAdder {
   private String path;
   private String type;
+  private String content = "";
 
   public boolean valid() throws Exception {
     File file;
@@ -15,7 +17,10 @@ public class FileSectionFileAdder {
       file.mkdir();
     } else {
       file = new File(FileSection.getFileSection(), path);
-      file.createNewFile();
+      try (FileWriter fw = new FileWriter(file)) {
+        fw.append(content);
+      }
+      content = "";
     }
     return file.exists();
   }
@@ -26,5 +31,9 @@ public class FileSectionFileAdder {
 
   public void setType(String type) {
     this.type = type;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
   }
 }

--- a/src/fitnesse/http/Response.java
+++ b/src/fitnesse/http/Response.java
@@ -2,6 +2,8 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.http;
 
+import util.FileUtil;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
@@ -11,19 +13,18 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 
-import util.FileUtil;
-
 public abstract class Response {
   public enum Format {
     XML("text/xml"),
     HTML("text/html; charset=" + FileUtil.CHARENCODING),
     TEXT("text/text"),
+    TSV("text/tab-separated-values"),
     JSON("application/json"),
     JUNIT("text/junit");
 
     private final String contentType;
 
-    private Format(String contentType) {
+    Format(String contentType) {
       this.contentType = contentType;
     }
 
@@ -59,6 +60,8 @@ public abstract class Response {
       format = Format.JUNIT;
     } else if ("text".equalsIgnoreCase(formatString)) {
       format = Format.TEXT;
+    } else if ("tsv".equalsIgnoreCase(formatString)) {
+      format = Format.TSV;
     } else {
       format = Format.HTML;
     }
@@ -80,6 +83,10 @@ public abstract class Response {
 
   public boolean isTextFormat() {
     return Format.TEXT.contentType.equals(contentType);
+  }
+
+  public boolean isTabSeparatedFormat() {
+    return Format.TSV.contentType.equals(contentType);
   }
 
   public boolean isJunitFormat() {

--- a/src/fitnesse/resources/templates/partitionPreview.vm
+++ b/src/fitnesse/resources/templates/partitionPreview.vm
@@ -1,0 +1,27 @@
+<h1>Partitioning preview</h1>
+<div>
+ <a class="button" href="?partition&partitionCount=$partitionCount">Download TSV partitionfile</a><br />&nbsp;
+</div>
+<table>
+ <thead>
+  <tr>
+   <th>Page</th>
+   <th>Partition</th>
+   <th>Test System</th>
+   <th>Order</th>
+  </tr>
+ </thead>
+ <tbody>
+  #foreach($page in $partitioning.getPages())
+  <tr>
+   #foreach($position in $partitioning.getPositions($page))
+   <td>$page</td>
+   #foreach($dimension in $position.getGroup())
+   <td>$partitioning.formatDimension($dimension)</td>
+   #end
+   <td>$position.getPositionInGroup()</td>
+   #end
+  </tr>
+  #end
+ </tbody>
+</table>

--- a/src/fitnesse/resources/templates/partitionPreview.vm
+++ b/src/fitnesse/resources/templates/partitionPreview.vm
@@ -1,6 +1,21 @@
 <h1>Partitioning preview</h1>
 <div>
- <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount">Download TSV partitionfile</a><br/>&nbsp;
+ <table>
+  <tbody>
+  <tr>
+   <td>
+    <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount" title="partition preview in tab-separated format">Download TSV file</a>
+   </td>
+   <td>
+    <p class="note">
+     Partition index file in tab-separated format (TSV) can be supplied to suite responder to fix partitioning used.
+     See <a href="FitNesse.UserGuide.WritingAcceptanceTests.TestSuites.SuitePartitioning#PartitionIndexFile">SuitePartitioning
+     in the user guide</a> for more details.
+    </p>
+   </td>
+  </tr>
+  </tbody>
+ </table>
 </div>
 <table>
  <thead>
@@ -16,7 +31,7 @@
   #foreach($page in $pagePositions.getPages())
   <tr>
    #foreach($position in $pagePositions.getPositions($page))
-    <td>$page</td>
+    <td style="overflow-y: auto; max-width: 60em;">$page</td>
     #foreach($dimension in $position.getGroup())
      <td>$pagePositions.formatDimension($dimension)</td>
     #end

--- a/src/fitnesse/resources/templates/partitionPreview.vm
+++ b/src/fitnesse/resources/templates/partitionPreview.vm
@@ -4,7 +4,8 @@
   <tbody>
   <tr>
    <td>
-    <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount" title="partition preview in tab-separated format">Download TSV file</a>
+    <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount"
+       title="partition preview in tab-separated format">Download TSV file</a>
    </td>
    <td>
     <p class="note">
@@ -29,15 +30,15 @@
  </thead>
  <tbody>
   #foreach($page in $pagePositions.getPages())
-  <tr>
    #foreach($position in $pagePositions.getPositions($page))
+   <tr>
     <td style="overflow-y: auto; max-width: 60em;">$page</td>
     #foreach($dimension in $position.getGroup())
      <td>$pagePositions.formatDimension($dimension)</td>
     #end
     <td>$position.getPositionInGroup()</td>
+   </tr>
    #end
-  </tr>
   #end
  </tbody>
 </table>

--- a/src/fitnesse/resources/templates/partitionPreview.vm
+++ b/src/fitnesse/resources/templates/partitionPreview.vm
@@ -1,9 +1,9 @@
 <h1>Partitioning preview</h1>
 <div>
- <table>
+ <table style="table-layout: fixed; width: 100%;">
   <tbody>
   <tr>
-   <td>
+   <td style="width: 11em;">
     <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount"
        title="partition preview in tab-separated format">Download TSV file</a>
    </td>
@@ -18,21 +18,21 @@
   </tbody>
  </table>
 </div>
-<table>
+<table style="table-layout: fixed; width: 100%;">
  <thead>
  <tr>
   <th>Page</th>
   #foreach($groupName in $pagePositions.getGroupNames())
-   <th>$groupName</th>
+   <th style="width: 5em;">$groupName</th>
   #end
-  <th>Order</th>
+  <th style="width: 4em;">Order</th>
  </tr>
  </thead>
  <tbody>
   #foreach($page in $pagePositions.getPages())
    #foreach($position in $pagePositions.getPositions($page))
    <tr>
-    <td style="overflow-y: auto; max-width: 60em;">$page</td>
+    <td style="overflow-y: auto;">$page</td>
     #foreach($dimension in $position.getGroup())
      <td>$pagePositions.formatDimension($dimension)</td>
     #end

--- a/src/fitnesse/resources/templates/partitionPreview.vm
+++ b/src/fitnesse/resources/templates/partitionPreview.vm
@@ -1,25 +1,26 @@
 <h1>Partitioning preview</h1>
 <div>
- <a class="button" href="?partition&partitionCount=$partitionCount">Download TSV partitionfile</a><br />&nbsp;
+ <a class="button" href="?partition&format=tsv&partitionCount=$partitionCount">Download TSV partitionfile</a><br/>&nbsp;
 </div>
 <table>
  <thead>
-  <tr>
-   <th>Page</th>
-   <th>Partition</th>
-   <th>Test System</th>
-   <th>Order</th>
-  </tr>
+ <tr>
+  <th>Page</th>
+  #foreach($groupName in $pagePositions.getGroupNames())
+   <th>$groupName</th>
+  #end
+  <th>Order</th>
+ </tr>
  </thead>
  <tbody>
-  #foreach($page in $partitioning.getPages())
+  #foreach($page in $pagePositions.getPages())
   <tr>
-   #foreach($position in $partitioning.getPositions($page))
-   <td>$page</td>
-   #foreach($dimension in $position.getGroup())
-   <td>$partitioning.formatDimension($dimension)</td>
-   #end
-   <td>$position.getPositionInGroup()</td>
+   #foreach($position in $pagePositions.getPositions($page))
+    <td>$page</td>
+    #foreach($dimension in $position.getGroup())
+     <td>$pagePositions.formatDimension($dimension)</td>
+    #end
+    <td>$position.getPositionInGroup()</td>
    #end
   </tr>
   #end

--- a/src/fitnesse/responders/ResponderFactory.java
+++ b/src/fitnesse/responders/ResponderFactory.java
@@ -23,6 +23,7 @@ import fitnesse.responders.refactoring.MovePageResponder;
 import fitnesse.responders.refactoring.RefactorPageResponder;
 import fitnesse.responders.refactoring.RenamePageResponder;
 import fitnesse.responders.refactoring.SearchReplaceResponder;
+import fitnesse.responders.run.PartitionPreviewResponder;
 import fitnesse.responders.run.StopTestResponder;
 import fitnesse.responders.run.SuiteResponder;
 import fitnesse.responders.run.TestResponder;
@@ -70,6 +71,7 @@ public class ResponderFactory {
     addResponder("stoptest", StopTestResponder.class);
     addResponder("test", TestResponder.class);
     addResponder("suite", SuiteResponder.class);
+    addResponder("partition", PartitionPreviewResponder.class);
     addResponder("proxy", SerializedPageResponder.class);
     addResponder("versions", VersionSelectionResponder.class);
     addResponder("viewVersion", VersionResponder.class);

--- a/src/fitnesse/responders/run/PartitionPreviewResponder.java
+++ b/src/fitnesse/responders/run/PartitionPreviewResponder.java
@@ -1,0 +1,48 @@
+package fitnesse.responders.run;
+
+import fitnesse.FitNesseContext;
+import fitnesse.http.Request;
+import fitnesse.http.Response;
+import fitnesse.responders.ChunkingResponder;
+import fitnesse.testrunner.SuiteContentsFinder;
+import fitnesse.testrunner.SuiteFilter;
+import fitnesse.testrunner.run.PagePositions;
+import fitnesse.wiki.WikiPage;
+
+import java.io.Writer;
+import java.util.List;
+
+/**
+ * Responder to display the tests that would be executed, in which order, for a given suite.
+ */
+public class PartitionPreviewResponder extends ChunkingResponder {
+
+  @Override
+  public Response makeResponse(FitNesseContext context, Request request) throws Exception {
+    Response response = super.makeResponse(context, request);
+    response.setContentType("text/tab-separated-values");
+    return response;
+  }
+
+  @Override
+  protected void doSending() throws Exception {
+    PagePositions pages = getPagesToRun();
+    try {
+      Writer writer = response.getWriter();
+      pages.appendTo(writer, "\t");
+    } finally {
+      response.close();
+    }
+  }
+
+  protected PagePositions getPagesToRun() {
+    SuiteFilter filter = SuiteResponder.createSuiteFilter(request, page.getFullPath().toString());
+    SuiteContentsFinder suiteTestFinder = new SuiteContentsFinder(page, filter, root);
+    List<WikiPage> allPages = suiteTestFinder.getAllPagesToRunForThisSuite();
+    return applyPartition(allPages);
+  }
+
+  protected PagePositions applyPartition(List<WikiPage> pages) {
+    return context.testRunFactoryRegistry.findPagePositions(pages);
+  }
+}

--- a/src/fitnesse/responders/run/PartitionPreviewResponder.java
+++ b/src/fitnesse/responders/run/PartitionPreviewResponder.java
@@ -1,16 +1,22 @@
 package fitnesse.responders.run;
 
 import fitnesse.FitNesseContext;
+import fitnesse.html.template.HtmlPage;
+import fitnesse.html.template.PageTitle;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.responders.ChunkingResponder;
 import fitnesse.testrunner.SuiteContentsFinder;
 import fitnesse.testrunner.SuiteFilter;
 import fitnesse.testrunner.run.PagePositions;
+import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Responder to display the tests that would be executed, in which order, for a given suite.
@@ -20,7 +26,11 @@ public class PartitionPreviewResponder extends ChunkingResponder {
   @Override
   public Response makeResponse(FitNesseContext context, Request request) throws Exception {
     Response response = super.makeResponse(context, request);
-    response.setContentType("text/tab-separated-values");
+    if (request.hasInput("html")) {
+      response.setContentType("text/html");
+    } else {
+      response.setContentType("text/tab-separated-values");
+    }
     return response;
   }
 
@@ -28,8 +38,12 @@ public class PartitionPreviewResponder extends ChunkingResponder {
   protected void doSending() throws Exception {
     PagePositions pages = getPagesToRun();
     try {
-      Writer writer = response.getWriter();
-      pages.appendTo(writer, "\t");
+      if (request.hasInput("html")) {
+        makePartitionPreviewHtmlResponse().render(response.getWriter(), request);
+      } else {
+        Writer writer = response.getWriter();
+        pages.appendTo(writer, "\t");
+      }
     } finally {
       response.close();
     }
@@ -44,5 +58,27 @@ public class PartitionPreviewResponder extends ChunkingResponder {
 
   protected PagePositions applyPartition(List<WikiPage> pages) {
     return context.testRunFactoryRegistry.findPagePositions(pages);
+  }
+
+  private HtmlPage makePartitionPreviewHtmlResponse() throws UnsupportedEncodingException {
+    HtmlPage page = context.pageFactory.newPage();
+    page.setTitle("Partitioning preview");
+    page.setPageTitle(new PageTitle(PathParser.parse(request.getResource())));
+    page.setNavTemplate("viewNav");
+    page.put("partitionCount", getPartitionCount());
+    page.put("partitioning", getPagesToRun());
+    page.setMainTemplate("partitionPreview");
+
+    return page;
+  }
+
+  private int getPartitionCount() {
+    String qs = request.getQueryString();
+    Pattern partitionCountPattern = Pattern.compile("partitionCount=([0-9]+)");
+    Matcher matcher = partitionCountPattern.matcher(qs);
+    if (matcher.find()) {
+      return Integer.parseInt(matcher.group(1));
+    }
+    return 0;
   }
 }

--- a/src/fitnesse/testrunner/MultipleTestsRunner.java
+++ b/src/fitnesse/testrunner/MultipleTestsRunner.java
@@ -111,10 +111,7 @@ public class MultipleTestsRunner implements Stoppable {
 
         @Override
         public String getTestSystem() {
-          String testSystemName = getVariable(WikiPageIdentity.TEST_SYSTEM);
-          if (testSystemName == null)
-            return "fit";
-          return testSystemName;
+          return identity.testSystem();
         }
 
         @Override

--- a/src/fitnesse/testrunner/WikiPageIdentity.java
+++ b/src/fitnesse/testrunner/WikiPageIdentity.java
@@ -7,10 +7,16 @@ public class WikiPageIdentity {
   public static final String COMMAND_PATTERN = "COMMAND_PATTERN";
   public static final String TEST_RUNNER = "TEST_RUNNER";
   public static final String TEST_SYSTEM = "TEST_SYSTEM";
-  private WikiPage page;
+  private final WikiPage page;
+  private final String testSystem;
+  private final String testRunner;
+  private final String commandPattern;
 
   public WikiPageIdentity(WikiPage page) {
     this.page = page;
+    testSystem = getTestSystem();
+    testRunner = getTestRunner();
+    commandPattern = getCommandPattern();
   }
 
   public String getVariable(String name) {
@@ -18,20 +24,32 @@ public class WikiPageIdentity {
   }
 
   public String testSystem() {
+    return testSystem;
+  }
+
+  private String testRunner() {
+    return testRunner;
+  }
+
+  private String commandPattern() {
+    return commandPattern;
+  }
+
+  private String getTestSystem() {
     String testSystemName = getVariable(TEST_SYSTEM);
     if (testSystemName == null)
       return "fit";
     return testSystemName;
   }
 
-  private String testRunner() {
+  private String getTestRunner() {
     String program = getVariable(TEST_RUNNER);
     if (program == null)
       program = "";
     return program;
   }
 
-  private String commandPattern() {
+  private String getCommandPattern() {
     String testRunner = getVariable(COMMAND_PATTERN);
     if (testRunner == null)
       testRunner = "";

--- a/src/fitnesse/testrunner/run/FileBasedTestRunFactory.java
+++ b/src/fitnesse/testrunner/run/FileBasedTestRunFactory.java
@@ -1,0 +1,87 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.FitNesseContext;
+import fitnesse.util.partitioner.ListPartitioner;
+import fitnesse.wiki.WikiPage;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Partitions test pages based on the file in the files section,
+ * indicated with the partitionIndexFile context parameter.
+ */
+public class FileBasedTestRunFactory extends PartitioningTestRunFactory {
+  public static final String PARTITION_FILE_ARG = "partitionIndexFile";
+  private final FitNesseContext context;
+  private Function<File, ListPartitioner<WikiPage>> partitionFunctionFactory;
+
+  public FileBasedTestRunFactory(FitNesseContext context) {
+    this.context = context;
+    partitionFunctionFactory = this::createPartitioner;
+    setPartitioner(p -> new PageListPartitionerImpl(getPartitionFunction(p)));
+  }
+
+  @Override
+  public boolean canRun(List<WikiPage> pages) {
+    boolean canRun = super.canRun(pages) && !pages.isEmpty();
+    if (canRun) {
+      canRun = getFile(pages)
+        .map(f -> {
+          if (!f.canRead()) throw new IllegalArgumentException("Unable to read: " + f.getAbsolutePath());
+          return true;
+        })
+        .orElse(false);
+    }
+    return canRun;
+  }
+
+  protected Optional<File> getFile(List<WikiPage> pages) {
+    return Optional.ofNullable(getFilename(pages)).map(this::getPartitionFile);
+  }
+
+  protected ListPartitioner<WikiPage> getPartitionFunction(List<WikiPage> pages) {
+    return getFile(pages)
+      .map(partitionFunctionFactory)
+      .orElseThrow(() -> new IllegalStateException("Unable to read file, which was present earlier: " + getFilename(pages)));
+  }
+
+  protected File getPartitionFile(String paramValue) {
+    return new File(new File(context.getRootPagePath(), "files"), paramValue);
+  }
+
+  protected String getFilename(List<WikiPage> pages) {
+    return pages.get(0).getVariable(PARTITION_FILE_ARG);
+  }
+
+  protected ListPartitioner<WikiPage> createPartitioner(File f) {
+    PagePositions pagePositions = readPositionMap(f, "\t");
+    return new PagePositionsBasedWikiPagePartitioner(pagePositions);
+  }
+
+  protected PagePositions readPositionMap(File file, String separator) {
+    try (FileReader f = new FileReader(file);
+         BufferedReader b = new BufferedReader(f)) {
+      return PagePositions.parseFrom(b, separator);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to load: " + file.getAbsolutePath(), e);
+    }
+  }
+
+  public Function<File, ListPartitioner<WikiPage>> getPartitionFunctionFactory() {
+    return partitionFunctionFactory;
+  }
+
+  public void setPartitionFunctionFactory(Function<File, ListPartitioner<WikiPage>> partitionFunctionFactory) {
+    this.partitionFunctionFactory = partitionFunctionFactory;
+  }
+
+  public FitNesseContext getContext() {
+    return context;
+  }
+}

--- a/src/fitnesse/testrunner/run/PageListPartitioner.java
+++ b/src/fitnesse/testrunner/run/PageListPartitioner.java
@@ -1,0 +1,37 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.wiki.WikiPage;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Split a test run into a number of partitions, test runs or suites.
+ * All partitions combined contain all tests of the full test run.
+ * Splitting a run like this allows a suite to be cut into a number of smaller separate suites,
+ * that could for instance be run in parallel to reduce test time.
+ */
+public interface PageListPartitioner {
+
+  /**
+   * Creates requested partition.
+   *
+   * @param factory function to create PagesByTestSystem
+   * @param pages pages to be executed.
+   * @param partitionCount number of partitions that will be created will be larger than 1.
+   * @param partitionIndex partition to return.
+   * @return pages to include in run.
+   */
+  PagesByTestSystem partition(Function<List<WikiPage>, ? extends PagesByTestSystem> factory, List<WikiPage> pages, int partitionCount, int partitionIndex);
+
+  /**
+   * List indices per page (including suite set ups and tear downs).
+   * SuiteSetUp or SuiteTearDown can appear in multiple partitions, therefore a list of indices is returned.
+   *
+   * @param factory function to create PagesByTestSystem
+   * @param pages pages to be executed.
+   * @param partitionCount number of partitions to create
+   * @return page -> partition and index within that partition, for each partition to include page in.
+   */
+  PagePositions findPagePositions(Function<List<WikiPage>, ? extends PagesByTestSystem> factory, List<WikiPage> pages, int partitionCount);
+}

--- a/src/fitnesse/testrunner/run/PageListPartitioner.java
+++ b/src/fitnesse/testrunner/run/PageListPartitioner.java
@@ -31,7 +31,7 @@ public interface PageListPartitioner {
    * @param factory function to create PagesByTestSystem
    * @param pages pages to be executed.
    * @param partitionCount number of partitions to create
-   * @return page -> partition and index within that partition, for each partition to include page in.
+   * @return page to partition and index within that partition, for each partition to include page in.
    */
   PagePositions findPagePositions(Function<List<WikiPage>, ? extends PagesByTestSystem> factory, List<WikiPage> pages, int partitionCount);
 }

--- a/src/fitnesse/testrunner/run/PageListPartitionerImpl.java
+++ b/src/fitnesse/testrunner/run/PageListPartitionerImpl.java
@@ -1,0 +1,142 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import fitnesse.util.partitioner.ListPartitioner;
+import fitnesse.wiki.WikiPage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Splits the lists of pages into partitions, using the same ordering as the PagesByTestSystem will.
+ */
+public class PageListPartitionerImpl implements PageListPartitioner {
+  public static final String PARTITION_HEADER = "Partition";
+  private ListPartitioner<WikiPage> partitionFunction;
+
+  /**
+   * Creates new, but does not yet initialize the partition function.
+   * DO NOT forget to call setPartitionFunction() before actually using it!
+   */
+  public PageListPartitionerImpl() {
+  }
+
+  public PageListPartitionerImpl(ListPartitioner<WikiPage> partitionFunction) {
+    this.partitionFunction = partitionFunction;
+  }
+
+  @Override
+  public PagesByTestSystem partition(Function<List<WikiPage>, ? extends PagesByTestSystem> factory, List<WikiPage> pages, int partitionCount, int partitionIndex) {
+    List<List<WikiPage>> partitionedTests = getPartitionsWithOnlyTests(partitionCount, factory.apply(pages));
+    List<WikiPage> selectedPartition = partitionedTests.get(partitionIndex);
+    return factory.apply(selectedPartition);
+  }
+
+  @Override
+  public PagePositions findPagePositions(
+    Function<List<WikiPage>, ? extends PagesByTestSystem> factory,
+    List<WikiPage> pages,
+    int partitionCount) {
+    List<List<WikiPage>> partitionedTests;
+    if (partitionCount > 1) {
+      partitionedTests = getPartitionsWithOnlyTests(partitionCount, factory.apply(pages));
+    } else {
+      partitionedTests = Collections.singletonList(pages);
+    }
+    List<List<WikiPage>> partitions = getPartitionsIncludingSetUpAndTearDown(factory, partitionedTests);
+    return getIndicesPerPage(pages, partitions);
+  }
+
+  protected List<List<WikiPage>> getPartitionsWithOnlyTests(int partitionCount, PagesByTestSystem pagesByTestSystem) {
+    List<WikiPage> orderedPages = getOrderedTestWikiPages(pagesByTestSystem);
+    return partitionFunction.split(orderedPages, partitionCount);
+  }
+
+  protected List<WikiPage> getOrderedTestWikiPages(PagesByTestSystem pagesByTestSystem) {
+    List<WikiPage> orderedPages = orderPagesByTestSystem(pagesByTestSystem);
+    orderedPages.removeIf(WikiPage::isSuiteSetupOrTearDown);
+    return orderedPages;
+  }
+
+  protected List<List<WikiPage>> getPartitionsIncludingSetUpAndTearDown(
+    Function<List<WikiPage>, ? extends PagesByTestSystem> factory,
+    List<List<WikiPage>> partitionedTests) {
+
+    return partitionedTests
+      .stream()
+      .map(factory)
+      .map(this::orderPagesByTestSystem)
+      .collect(Collectors.toList());
+  }
+
+  protected PagePositions getIndicesPerPage(List<WikiPage> allPages, List<List<WikiPage>> partitions) {
+    PagePositions allPositions = createPagePositions(partitions);
+    return orderResults(allPages, allPositions);
+  }
+
+  protected PagePositions createPagePositions(List<List<WikiPage>> partitions) {
+    PagePositions result = new PagePositions();
+    result.getGroupNames().addAll(asList(PARTITION_HEADER, "Test System"));
+
+    for (int partitionIndex = 0; partitionIndex < partitions.size(); partitionIndex++) {
+      List<WikiPage> partition = partitions.get(partitionIndex);
+      for (int indexInPartition = 0; indexInPartition < partition.size(); indexInPartition++) {
+        WikiPage page = partition.get(indexInPartition);
+        WikiPageIdentity identity = new WikiPageIdentity(page);
+        result.addPosition(page.getFullPath().toString(), asList(partitionIndex, identity), indexInPartition);
+      }
+    }
+    return result;
+  }
+
+  protected PagePositions orderResults(List<WikiPage> inputPages, PagePositions allPositions) {
+    PagePositions result = copySelectedKeys(inputPages, allPositions);
+
+    for (String pageName : allPositions.getPages()) {
+      if (!result.hasPositions(pageName)) {
+        // page not present in input, but we did calculate one (or more) positions
+        // (probably SuiteSetUp and -TearDown pages) these are added to result as well
+        result.getPositions(pageName).addAll(allPositions.getPositions(pageName));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Creates page positions for keys to keep, where they are listed in original order
+   * @param keysToKeep defines positions for which pages are needed and in which order they should be listed
+   * @param allPositions all known page positions
+   * @return subset of allPositions where pages are filtered and ordered according to keysToKeep
+   */
+  protected PagePositions copySelectedKeys(List<WikiPage> keysToKeep, PagePositions allPositions) {
+    PagePositions results = new PagePositions();
+    results.getGroupNames().addAll(allPositions.getGroupNames());
+    for (WikiPage page : keysToKeep) {
+      String pageName = page.getFullPath().toString();
+      results.getPositions(pageName).addAll(allPositions.getPositions(pageName));
+    }
+    return results;
+  }
+
+  protected List<WikiPage> orderPagesByTestSystem(PagesByTestSystem pagesByTestSystem) {
+    List<WikiPage> orderedPages = new ArrayList<>(pagesByTestSystem.getSourcePages().size());
+    for (WikiPageIdentity identity : pagesByTestSystem.identities()) {
+      List<WikiPage> pages = pagesByTestSystem.wikiPagesForIdentity(identity);
+      orderedPages.addAll(pages);
+    }
+    return orderedPages;
+  }
+
+  public ListPartitioner<WikiPage> getPartitionFunction() {
+    return partitionFunction;
+  }
+
+  public void setPartitionFunction(ListPartitioner<WikiPage> partitionFunction) {
+    this.partitionFunction = partitionFunction;
+  }
+}

--- a/src/fitnesse/testrunner/run/PagePosition.java
+++ b/src/fitnesse/testrunner/run/PagePosition.java
@@ -1,0 +1,39 @@
+package fitnesse.testrunner.run;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PagePosition {
+  private final List<Object> group;
+  private final int positionInGroup;
+
+  public PagePosition(int positionInGroup, Object... group) {
+    this(Arrays.asList(group), positionInGroup);
+  }
+
+  public PagePosition(List<Object> group, int positionInGroup) {
+    this.group = group;
+    this.positionInGroup = positionInGroup;
+  }
+
+  public List<Object> getGroup() {
+    return group;
+  }
+
+  public Integer getGroupIntValue(int index) {
+    Object partO = getGroup().get(index);
+    if (partO instanceof String) {
+      partO = Integer.valueOf((String) partO);
+    }
+    return (Integer) partO;
+  }
+
+  public int getPositionInGroup() {
+    return positionInGroup;
+  }
+
+  @Override
+  public String toString() {
+    return group + ": " + positionInGroup;
+  }
+}

--- a/src/fitnesse/testrunner/run/PagePositions.java
+++ b/src/fitnesse/testrunner/run/PagePositions.java
@@ -156,7 +156,7 @@ public class PagePositions {
     }
   }
 
-  protected String formatDimension(Object dimension) {
+  public String formatDimension(Object dimension) {
     if (dimension instanceof WikiPageIdentity) {
       return ((WikiPageIdentity) dimension).testSystem();
     } else {

--- a/src/fitnesse/testrunner/run/PagePositions.java
+++ b/src/fitnesse/testrunner/run/PagePositions.java
@@ -1,0 +1,166 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import org.apache.velocity.util.StringBuilderWriter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Describes the order in which pages will be executed in a test run.
+ */
+public class PagePositions {
+  public static final String PAGE_HEADER = "Page";
+  public static final String ORDER_HEADER = "Order";
+
+  private final Map<List<Object>, List<Object>> groupCache = new HashMap<>();
+  private String lineSep = "\n";
+  private List<String> groupNames = new ArrayList<>();
+  private Map<String, List<PagePosition>> positions = new LinkedHashMap<>();
+
+  public List<String> getGroupNames() {
+    return groupNames;
+  }
+
+  public Integer getGroupIndex(String name) {
+    return groupNames.indexOf(name);
+  }
+
+  public List<String> getPages() {
+    return new ArrayList<>(positions.keySet());
+  }
+
+  public List<PagePosition> getPositions(String page) {
+    return positions.computeIfAbsent(page, p -> new LinkedList<>());
+  }
+
+  public boolean hasPositions(String page) {
+    return positions.containsKey(page);
+  }
+
+  public void addPosition(String page, List<Object> group, int positionInGroup) {
+    // re-use group objects if same elements are used to define group
+    List<Object> groupFromCache = groupCache.computeIfAbsent(group, g -> group);
+    getPositions(page).add(new PagePosition(groupFromCache, positionInGroup));
+  }
+
+  public Comparator<String> createByPositionInGroupComparator() {
+    Map<String, Integer> testOrdering = new HashMap<>();
+    for (String page : getPages()) {
+      for (PagePosition pos : getPositions(page)) {
+        testOrdering.put(page, pos.getPositionInGroup());
+      }
+    }
+    return (page1, page2) -> {
+      int pos1 = testOrdering.getOrDefault(page1, -1);
+      int pos2 = testOrdering.getOrDefault(page2, -1);
+      return pos1 == pos2 ? page1.compareTo(page2) : pos1 - pos2;
+    };
+  }
+
+  public void appendTo(Writer writer, String groupSep) throws IOException {
+    appendHeader(writer, groupSep);
+    for (Map.Entry<String, List<PagePosition>> entry : positions.entrySet()) {
+      appendIndices(writer, entry.getKey(), entry.getValue(), groupSep);
+    }
+    writer.flush();
+  }
+
+  public static PagePositions parseFrom(Reader reader, String groupSep) throws IOException {
+    BufferedReader b = new BufferedReader(reader);
+    PagePositions positions = new PagePositions();
+    positions.parseHeader(b, groupSep);
+    positions.parseRows(b, groupSep);
+    return positions;
+  }
+
+  protected void parseHeader(BufferedReader reader, String groupSep) throws IOException {
+    splitNextLine(reader, groupSep)
+      .map(parts -> {
+        int count = parts.length;
+        if (count < 3) throw new IllegalArgumentException("Expected at least 2 columns, got: " + count);
+        groupNames.clear();
+        for (int i = 1; i < count - 1; i++) {
+          groupNames.add(parts[i]);
+        }
+        return groupNames;
+      }).
+      orElseThrow(() -> new IllegalArgumentException("No header line"));
+  }
+
+  protected void parseRows(BufferedReader reader, String groupSep) throws IOException {
+    while(true) {
+      Optional<String[]> linePresent = splitNextLine(reader, groupSep);
+      if (!linePresent.isPresent()) {
+        break;
+      }
+      String[] parts = linePresent.get();
+      int count = parts.length;
+      if (count < 3) throw new IllegalArgumentException("Expected at least 2 columns, got: " + count);
+      Integer pos = Integer.valueOf(parts[count - 1]);
+      List<Object> group = asList((Object[])Arrays.copyOfRange(parts, 1, count - 1));
+      addPosition(parts[0], group, pos);
+    }
+  }
+
+  protected Optional<String[]> splitNextLine(BufferedReader reader, String groupSep) throws IOException {
+    return Optional.ofNullable(reader.readLine()).map(l -> l.split(groupSep));
+  }
+
+  @Override
+  public String toString() {
+    try {
+      Writer writer = new StringBuilderWriter();
+      appendTo(writer, "\t");
+      return writer.toString();
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to write data", e);
+    }
+  }
+
+  protected void appendHeader(Writer writer, String groupSep) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    sb.append(PAGE_HEADER).append(groupSep);
+    sb.append(String.join(groupSep, groupNames));
+    sb.append(groupSep);
+    sb.append(ORDER_HEADER);
+    sb.append(lineSep);
+    writer.append(sb.toString());
+  }
+
+  protected void appendIndices(Writer writer, String page, List<PagePosition> indices, String groupSep) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    for (PagePosition index : indices) {
+      sb.append(page)
+        .append(groupSep);
+      for (Object dimension : index.getGroup()) {
+        String dimensionStr = formatDimension(dimension);
+        sb.append(dimensionStr).append(groupSep);
+      }
+      sb.append(index.getPositionInGroup()).append(lineSep);
+      writer.append(sb.toString());
+      sb.setLength(0);
+    }
+  }
+
+  protected String formatDimension(Object dimension) {
+    if (dimension instanceof WikiPageIdentity) {
+      return ((WikiPageIdentity) dimension).testSystem();
+    } else {
+      return String.valueOf(dimension);
+    }
+  }
+}

--- a/src/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitioner.java
+++ b/src/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitioner.java
@@ -1,0 +1,87 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.util.partitioner.EqualLengthListPartitioner;
+import fitnesse.util.partitioner.ListPartitioner;
+import fitnesse.util.partitioner.MapBasedListPartitioner;
+import fitnesse.wiki.WikiPage;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Partitions pages based on provided PagePositions.
+ */
+public class PagePositionsBasedWikiPagePartitioner implements ListPartitioner<WikiPage> {
+  private ListPartitioner<WikiPage> partitioner;
+  private Comparator<WikiPage> pageComparator;
+
+  public PagePositionsBasedWikiPagePartitioner(PagePositions pagePositions) {
+    if (pagePositions != null) {
+      setPagePositions(pagePositions);
+    }
+  }
+
+  public void setPagePositions(PagePositions pagePositions) {
+    pageComparator = createComparator(pagePositions);
+    partitioner = createPartitioner(pagePositions);
+  }
+
+  @Override
+  public List<List<WikiPage>> split(List<WikiPage> source, int partitionCount) {
+    List<WikiPage> pages = source;
+    if (pageComparator != null) {
+      // by ordering the input according to the positions within each partition BEFORE partitioning the
+      // resulting partitions will have the ordering prescribed by the page positions
+      pages = new ArrayList<>(source);
+      pages.sort(pageComparator);
+    }
+    return partitioner.split(pages, partitionCount);
+  }
+
+  protected Comparator<WikiPage> createComparator(PagePositions pagePositions) {
+    Comparator<String> comp = pagePositions.createByPositionInGroupComparator();
+    return (page1, page2) -> {
+      String path1 = page1.getFullPath().toString();
+      String path2 = page2.getFullPath().toString();
+      return comp.compare(path1, path2);
+    };
+  }
+
+  protected ListPartitioner<WikiPage> createPartitioner(PagePositions pagePositions) {
+    Map<String, Integer> positionMap = loadPartitionFile(pagePositions);
+    return createPartitioner(positionMap);
+  }
+
+  protected ListPartitioner<WikiPage> createPartitioner(Map<String, Integer> positionMap) {
+    return new MapBasedListPartitioner<>(wp -> wp.getFullPath().toString(), positionMap, this::handleUnknownPages);
+  }
+
+  protected List<List<WikiPage>> handleUnknownPages(
+    List<List<WikiPage>> partitionsFromFile,
+    List<WikiPage> pagesNotPresent) {
+    return new EqualLengthListPartitioner<WikiPage>().split(pagesNotPresent, partitionsFromFile.size());
+  }
+
+  protected Map<String, Integer> loadPartitionFile(PagePositions pagePositions) {
+    int part = pagePositions.getGroupIndex(PageListPartitionerImpl.PARTITION_HEADER);
+    if (part < 0) {
+      throw new IllegalArgumentException("No " + PageListPartitionerImpl.PARTITION_HEADER + " column found");
+    }
+    return extractPartitionMap(pagePositions, part);
+  }
+
+  protected Map<String, Integer> extractPartitionMap(PagePositions pagePositions, int partGroupIndex) {
+    Map<String, Integer> indices = new HashMap<>();
+    for (String page : pagePositions.getPages()) {
+      List<PagePosition> positions = pagePositions.getPositions(page);
+      for (PagePosition position : positions) {
+        Integer partValue = position.getGroupIntValue(partGroupIndex);
+        indices.put(page, partValue);
+      }
+    }
+    return indices;
+  }
+}

--- a/src/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitioner.java
+++ b/src/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitioner.java
@@ -43,11 +43,7 @@ public class PagePositionsBasedWikiPagePartitioner implements ListPartitioner<Wi
 
   protected Comparator<WikiPage> createComparator(PagePositions pagePositions) {
     Comparator<String> comp = pagePositions.createByPositionInGroupComparator();
-    return (page1, page2) -> {
-      String path1 = page1.getFullPath().toString();
-      String path2 = page2.getFullPath().toString();
-      return comp.compare(path1, path2);
-    };
+    return Comparator.comparing(p -> p.getFullPath().toString(), comp);
   }
 
   protected ListPartitioner<WikiPage> createPartitioner(PagePositions pagePositions) {

--- a/src/fitnesse/testrunner/run/PartitioningTestRunFactory.java
+++ b/src/fitnesse/testrunner/run/PartitioningTestRunFactory.java
@@ -1,0 +1,103 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.util.partitioner.EqualLengthListPartitioner;
+import fitnesse.wiki.WikiPage;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class PartitioningTestRunFactory implements TestRunFactory {
+  public static final String PARTITION_COUNT_ARG = "partitionCount";
+  public static final String PARTITION_INDEX_ARG = "partitionIndex";
+
+  private Function<List<WikiPage>, ? extends PagesByTestSystem> factory;
+  private Function<List<WikiPage>, PageListPartitioner> partitioner;
+
+  public PartitioningTestRunFactory() {
+    this(PagesByTestSystem::new,
+      pages -> new PageListPartitionerImpl(new EqualLengthListPartitioner<>()));
+  }
+
+  public PartitioningTestRunFactory(Function<List<WikiPage>, ? extends PagesByTestSystem> factory,
+                                    Function<List<WikiPage>, PageListPartitioner> partitioner) {
+    this.factory = factory;
+    this.partitioner = partitioner;
+  }
+
+  @Override
+  public boolean canRun(List<WikiPage> pages) {
+    return true;
+  }
+
+  public TestRun createRun(List<WikiPage> pages) {
+    PagesByTestSystem pagesByTestSystem = getPagesByTestSystem(pages);
+    return createRun(pagesByTestSystem);
+  }
+
+  public PagePositions findPagePositions(List<WikiPage> pages) {
+    if (pages.isEmpty()) {
+      return new PagePositions();
+    }
+    WikiPage page = pages.get(0);
+    PageListPartitioner pageListPartitioner = partitioner.apply(pages);
+    int partitionCount = getPartitionCount(page);
+    return pageListPartitioner.findPagePositions(factory, pages, partitionCount);
+  }
+
+  protected PagesByTestSystem getPagesByTestSystem(List<WikiPage> pages) {
+    if (pages.isEmpty()) {
+      return factory.apply(pages);
+    }
+    WikiPage page = pages.get(0);
+    PageListPartitioner pageListPartitioner = partitioner.apply(pages);
+    int partitionCount = getPartitionCount(page);
+    if (partitionCount == 1) {
+      return factory.apply(pages);
+    } else {
+      int partitionIndex = getPartitionIndex(page);
+      if (partitionIndex >= partitionCount) {
+        throw new IllegalArgumentException(PARTITION_COUNT_ARG + " must be larger than " + PARTITION_INDEX_ARG);
+      }
+      return pageListPartitioner.partition(factory, pages, partitionCount, partitionIndex);
+    }
+  }
+
+  protected TestRun createRun(PagesByTestSystem pagesByTestSystem) {
+    return new PerTestSystemTestRun(pagesByTestSystem);
+  }
+
+  protected int getPartitionCount(WikiPage page) {
+    int partitionCount = 1;
+    String partitionCountStr = page.getVariable(PARTITION_COUNT_ARG);
+    if (StringUtils.isNotEmpty(partitionCountStr)) {
+      partitionCount = Integer.parseInt(partitionCountStr);
+    }
+    return partitionCount;
+  }
+
+  protected int getPartitionIndex(WikiPage page) {
+    int partitionIndex = 0;
+    String partitionIndexStr = page.getVariable(PARTITION_INDEX_ARG);
+    if (StringUtils.isNotEmpty(partitionIndexStr)) {
+      partitionIndex = Integer.parseInt(partitionIndexStr);
+    }
+    return partitionIndex;
+  }
+
+  public Function<List<WikiPage>, ? extends PagesByTestSystem> getFactory() {
+    return factory;
+  }
+
+  public void setFactory(Function<List<WikiPage>, ? extends PagesByTestSystem> factory) {
+    this.factory = factory;
+  }
+
+  public Function<List<WikiPage>, PageListPartitioner> getPartitioner() {
+    return partitioner;
+  }
+
+  public void setPartitioner(Function<List<WikiPage>, PageListPartitioner> partitioner) {
+    this.partitioner = partitioner;
+  }
+}

--- a/src/fitnesse/testrunner/run/PositionMapBasedWikiPagePartitioner.java
+++ b/src/fitnesse/testrunner/run/PositionMapBasedWikiPagePartitioner.java
@@ -1,0 +1,43 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.util.partitioner.EqualLengthListPartitioner;
+import fitnesse.util.partitioner.ListPartitioner;
+import fitnesse.util.partitioner.MapBasedListPartitioner;
+import fitnesse.wiki.WikiPage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Partitions pages based on provided map with partition indices.
+ */
+public class PositionMapBasedWikiPagePartitioner implements ListPartitioner<WikiPage> {
+  private Map<String, Integer> partitionMap;
+
+  @Override
+  public List<List<WikiPage>> split(List<WikiPage> source, int partitionCount) {
+    return createPartitioner(partitionMap).split(source, partitionCount);
+  }
+
+  protected String getFullPath(WikiPage wikiPage) {
+    return wikiPage.getFullPath().toString();
+  }
+
+  protected List<List<WikiPage>> handleUnknownPages(
+    List<List<WikiPage>> partitionsFromFile,
+    List<WikiPage> pagesNotPresent) {
+    return new EqualLengthListPartitioner<WikiPage>().split(pagesNotPresent, partitionsFromFile.size());
+  }
+
+  protected ListPartitioner<WikiPage> createPartitioner(Map<String, Integer> partitionMap) {
+    return new MapBasedListPartitioner<>(this::getFullPath, partitionMap, this::handleUnknownPages);
+  }
+
+  public void setPartitionMap(Map<String, Integer> partitionMap) {
+    this.partitionMap = partitionMap;
+  }
+
+  public Map<String, Integer> getPartitionMap() {
+    return partitionMap;
+  }
+}

--- a/src/fitnesse/testrunner/run/TestRunFactory.java
+++ b/src/fitnesse/testrunner/run/TestRunFactory.java
@@ -8,4 +8,6 @@ public interface TestRunFactory {
   boolean canRun(List<WikiPage> pages);
 
   TestRun createRun(List<WikiPage> pages);
+
+  PagePositions findPagePositions(List<WikiPage> pages);
 }

--- a/src/fitnesse/testrunner/run/TestRunFactoryRegistry.java
+++ b/src/fitnesse/testrunner/run/TestRunFactoryRegistry.java
@@ -7,18 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TestRunFactoryRegistry {
-  public final static TestRunFactory DEFAULT =
-    new TestRunFactory() {
-      @Override
-      public boolean canRun(List<WikiPage> pages) {
-        return true;
-      }
-
-      @Override
-      public TestRun createRun(List<WikiPage> pages) {
-        return new PerTestSystemTestRun(pages);
-      }
-    };
+  public final static TestRunFactory DEFAULT = new PartitioningTestRunFactory();
 
   private final List<TestRunFactory> testRunFactories = new ArrayList<>();
   private final FitNesseContext context;
@@ -33,6 +22,10 @@ public class TestRunFactoryRegistry {
 
   public TestRun createRun(List<WikiPage> pages) {
     return getFactory(pages).createRun(pages);
+  }
+
+  public PagePositions findPagePositions(List<WikiPage> pages) {
+    return getFactory(pages).findPagePositions(pages);
   }
 
   public TestRunFactory getFactory(List<WikiPage> pages) {

--- a/src/fitnesse/util/partitioner/EqualLengthListPartitioner.java
+++ b/src/fitnesse/util/partitioner/EqualLengthListPartitioner.java
@@ -1,0 +1,44 @@
+package fitnesse.util.partitioner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits a list into 'near equal' length sublists.
+ * Near equal means the difference in length between any two sublists is at most one.
+ * If a split into sublists of exactly the same length is possible this is created.
+ */
+public class EqualLengthListPartitioner<T> implements ListPartitioner<T> {
+
+  /**
+   * Splits a list into 'near equal' length sublists.
+   * @param source list to split
+   * @param partitionCount number of sublists desired
+   * @return list of partitionCount sublists of source
+   */
+  @Override
+  public List<List<T>> split(List<T> source, int partitionCount) {
+    int sourceSize = source.size();
+    int smallerPartitionSize = sourceSize / partitionCount;
+    int largerPartitionSize = smallerPartitionSize + 1;
+
+    int fullPartitions = sourceSize % partitionCount;
+    if (fullPartitions == 0) {
+      fullPartitions = partitionCount;
+      largerPartitionSize = smallerPartitionSize;
+    }
+
+    List<List<T>> result = new ArrayList<>(partitionCount);
+    int index = 0;
+    for (int i = 0; i < partitionCount; i++) {
+      int partitionSize = i < fullPartitions ? largerPartitionSize : smallerPartitionSize;
+      int end = index + partitionSize;
+
+      List<T> partition = source.subList(index, end);
+      result.add(partition);
+
+      index = end;
+    }
+    return result;
+  }
+}

--- a/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
@@ -1,0 +1,81 @@
+package fitnesse.util.partitioner;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Splits a list into sublists based on two functions.
+ * One will give positions where a preference for a sublist is known beforehand, the o
+ * @param <T> list element type
+ */
+public class FunctionBasedListPartitioner<T> implements ListPartitioner<T> {
+  private final Function<T, Optional<Integer>> positionFunction;
+  private final BiFunction<List<List<T>>, List<T>, List<List<T>>> notFoundFunction;
+
+  /**
+   * Creates new.
+   * @param positionFunction indicates sublist index for an element if it can be determined on its own
+   * @param notFoundFunction partitions the elements for which the positionFunction did not give an index,
+   *                         it gets the partitions created based on the positionFunctions and the elements
+   *                         not yet placed in a partition.
+   */
+  public FunctionBasedListPartitioner(Function<T, Optional<Integer>> positionFunction,
+                                      BiFunction<List<List<T>>, List<T>, List<List<T>>> notFoundFunction) {
+    this.positionFunction = positionFunction;
+    this.notFoundFunction = notFoundFunction;
+  }
+
+  @Override
+  public List<List<T>> split(List<T> source, int partitionCount) {
+    List<List<T>> result = new ArrayList<>(partitionCount);
+    for (int j = 0; j < partitionCount; j++) {
+      result.add(new LinkedList<>());
+    }
+    List<T> notFound = addUsingPositionFunction(source, result);
+    if (!notFound.isEmpty()) {
+      List<List<T>> extraItems = notFoundFunction.apply(result, notFound);
+      if (partitionCount < extraItems.size()) {
+        throw new IllegalArgumentException("Extra items use too many partitions: " + extraItems.size());
+      }
+      result = combinePlacedAndNotFound(result, extraItems);
+    }
+    return result;
+  }
+
+  protected List<T> addUsingPositionFunction(List<T> source, List<List<T>> result) {
+    int partitionCount = result.size();
+    List<T> notFound = new ArrayList<>();
+    for (T item : source) {
+      Optional<Integer> pos = positionFunction.apply(item);
+      if (pos.isPresent()) {
+        int index = pos.get();
+        if (index >= 0 && index < partitionCount) {
+          result.get(index).add(item);
+        } else {
+          notFound.add(item);
+        }
+      } else {
+        notFound.add(item);
+      }
+    }
+    return notFound;
+  }
+
+  protected List<List<T>> combinePlacedAndNotFound(List<List<T>> partitions, List<List<T>> extraItems) {
+    List<List<T>> result = new ArrayList<>(partitions.size());
+    for (List<T> placed : partitions) {
+      List<T> endPartition = new ArrayList<>(placed);
+      result.add(endPartition);
+    }
+
+    for (int i = 0; i < extraItems.size(); i++) {
+      List<T> extras = extraItems.get(i);
+      result.get(i).addAll(0, extras);
+    }
+    return result;
+  }
+}

--- a/src/fitnesse/util/partitioner/ListPartitioner.java
+++ b/src/fitnesse/util/partitioner/ListPartitioner.java
@@ -1,0 +1,16 @@
+package fitnesse.util.partitioner;
+
+import java.util.List;
+
+/**
+ * Splits a list into a number of partitions (i.e. sub-lists).
+ */
+public interface ListPartitioner<T> {
+  /**
+   * Splits source.
+   * @param source list to split.
+   * @param partitionCount number of partitions to create.
+   * @return list of partitionCount lists each containing zero or more of source's elements.
+   */
+  List<List<T>> split(List<T> source, int partitionCount);
+}

--- a/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
@@ -1,0 +1,41 @@
+package fitnesse.util.partitioner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Partitions list based on map indicating known positions for elenents.
+ * @param <T> list element type
+ */
+public class MapBasedListPartitioner<T> extends FunctionBasedListPartitioner<T> {
+  private final Map<String, Integer> positionMap;
+
+  public MapBasedListPartitioner(Function<T, String> keyFunction, Map<String, Integer> positionMap) {
+    this(keyFunction, positionMap, (parts, nf) -> new EqualLengthListPartitioner<T>().split(nf, parts.size()));
+  }
+
+  public MapBasedListPartitioner(Function<T, String> keyFunction, Map<String, Integer> positionMap,
+                                 BiFunction<List<List<T>>, List<T>, List<List<T>>> notFoundFunction) {
+    super(
+      t -> {
+        String key = keyFunction.apply(t);
+        Integer value = positionMap.get(key);
+        return Optional.ofNullable(value);
+      },
+      notFoundFunction);
+    this.positionMap = positionMap;
+  }
+
+  @Override
+  protected List<T> addUsingPositionFunction(List<T> source, List<List<T>> result) {
+    if (positionMap.isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      return super.addUsingPositionFunction(source, result);
+    }
+  }
+}

--- a/test/fitnesse/responders/run/SuiteResponderTest.java
+++ b/test/fitnesse/responders/run/SuiteResponderTest.java
@@ -297,6 +297,25 @@ public class SuiteResponderTest {
     assertHasRegexp("#TestThree", results);
   }
 
+  @Test
+  public void canRunPartition0() throws Exception {
+    addTestPagesWithSuiteProperty();
+    request.setQueryString("suiteFilter=smoke,foo&partitionCount=2&partitionIndex=0");
+    String results = runSuite();
+    assertDoesntHaveRegexp("#TestOne", results);
+    assertDoesntHaveRegexp("#TestTwo", results);
+    assertHasRegexp("#TestThree", results);
+  }
+
+  @Test
+  public void canRunPartition1() throws Exception {
+    addTestPagesWithSuiteProperty();
+    request.setQueryString("suiteFilter=smoke,foo&partitionCount=2&partitionIndex=1");
+    String results = runSuite();
+    assertDoesntHaveRegexp("#TestOne", results);
+    assertHasRegexp("#TestTwo", results);
+    assertDoesntHaveRegexp("#TestThree", results);
+  }
 
   @Test
   public void excludeSuiteQuery() throws Exception {

--- a/test/fitnesse/testrunner/run/PageListPartitionerImplTest.java
+++ b/test/fitnesse/testrunner/run/PageListPartitionerImplTest.java
@@ -1,0 +1,118 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import fitnesse.util.partitioner.EqualLengthListPartitioner;
+import fitnesse.util.partitioner.ListPartitioner;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PageListPartitionerImplTest extends PageListTestBase {
+  private final PageListPartitionerImpl partitioner = new PageListPartitionerImpl(new EqualLengthListPartitioner<>());
+
+  @Test
+  public void emptyListIsNoProblem() {
+    List<WikiPage> list = Collections.emptyList();
+
+    PagesByTestSystem part0 = partitioner.partition(PagesByTestSystem::new, list, 2, 0);
+    assertEquals(0, part0.totalTestsToRun());
+    PagesByTestSystem part1 = partitioner.partition(PagesByTestSystem::new, list, 2, 1);
+    assertEquals(0, part1.totalTestsToRun());
+  }
+
+  @Test
+  public void partitions() {
+    List<WikiPage> list = createDummyPageList();
+
+    PagesByTestSystem part0 = partitioner.partition(PagesByTestSystem::new, list, 3, 0);
+    assertEquals(2, part0.totalTestsToRun());
+    assertEquals(list.get(0), part0.getSourcePages().get(0));
+    assertEquals(list.get(1), part0.getSourcePages().get(1));
+
+    PagesByTestSystem part1 = partitioner.partition(PagesByTestSystem::new, list, 3, 1);
+    assertEquals(1, part1.totalTestsToRun());
+    assertEquals(list.get(2), part1.getSourcePages().get(0));
+
+    PagesByTestSystem part2 = partitioner.partition(PagesByTestSystem::new, list, 3, 2);
+    assertEquals(1, part2.totalTestsToRun());
+    assertEquals(list.get(3), part2.getSourcePages().get(0));
+  }
+  @Test
+  public void findPagePositions() {
+    List<WikiPage> list = createDummyPageList();
+
+    PagePositions positions = partitioner.findPagePositions(PagesByTestSystem::new, list, 3);
+    assertEquals(asList("Partition", "Test System"), positions.getGroupNames());
+    assertEquals(4, positions.getPages().size());
+
+    List<String> pages = positions.getPages();
+    for (int i = 0; i < list.size(); i++) {
+      String pagename = pages.get(i);
+      assertEquals(list.get(i).getFullPath().toString(), pagename);
+      List<PagePosition> pagePosList = positions.getPositions(pagename);
+      assertEquals(1, pagePosList.size());
+      PagePosition pagePosition = pagePosList.get(0);
+      assertEquals(2, pagePosition.getGroup().size());
+      assertTrue(pagePosition.getGroup().get(1) instanceof WikiPageIdentity);
+    }
+    assertEquals(0, getPartitionFor(positions, pages.get(0)));
+    assertEquals(0, getPartitionFor(positions, pages.get(1)));
+    assertEquals(1, getPartitionFor(positions, pages.get(2)));
+    assertEquals(2, getPartitionFor(positions, pages.get(3)));
+  }
+
+  @Test
+  public void testCustomPartitioner() {
+    List<WikiPage> list = createDummyPageList();
+    Map<WikiPage, Integer> positionInput = new HashMap<>();
+    positionInput.put(list.get(0), 2);
+    positionInput.put(list.get(1), 1);
+    positionInput.put(list.get(2), 0);
+    positionInput.put(list.get(3), 2);
+
+    ListPartitioner<WikiPage> customFunction = (l, i) -> {
+      List<List<WikiPage>> result = new ArrayList<>(i);
+      for (int j = 0; j < i; j++) {
+        result.add(new ArrayList<>());
+      }
+      for (WikiPage page : l) {
+        Integer pos = positionInput.get(page);
+        result.get(pos).add(page);
+      }
+      return result;
+    };
+    PageListPartitioner customPart = new PageListPartitionerImpl(customFunction);
+    PagePositions positions = customPart.findPagePositions(PagesByTestSystem::new, list, 3);
+    assertEquals(4, positions.getPages().size());
+
+    List<String> pages = positions.getPages();
+    assertEquals(2, getPartitionFor(positions, pages.get(0)));
+    assertEquals(1, getPartitionFor(positions, pages.get(1)));
+    assertEquals(0, getPartitionFor(positions, pages.get(2)));
+    assertEquals(2, getPartitionFor(positions, pages.get(3)));
+
+  }
+
+  private Object getPartitionFor(PagePositions posList, String pagename) {
+    return posList.getPositions(pagename).get(0).getGroup().get(0);
+  }
+
+  private List<WikiPage> createDummyPageList() {
+    WikiPageDummy parent = new WikiPageDummy("parent", "p", null);
+    return asList(
+      new WikiPageDummy("A", "B", parent),
+      new WikiPageDummy("a", "b", parent),
+      new WikiPageDummy("C", "D", parent),
+      new WikiPageDummy("c", "d", parent));
+  }
+}

--- a/test/fitnesse/testrunner/run/PageListSetUpTearDownTestBase.java
+++ b/test/fitnesse/testrunner/run/PageListSetUpTearDownTestBase.java
@@ -1,34 +1,15 @@
 package fitnesse.testrunner.run;
 
-import fitnesse.testrunner.SuiteContentsFinder;
-import fitnesse.wiki.PageData;
-import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPageUtil;
-import fitnesse.wiki.fs.InMemoryPage;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static fitnesse.wiki.PageData.SUITE_SETUP_NAME;
 import static fitnesse.wiki.PageData.SUITE_TEARDOWN_NAME;
 import static org.junit.Assert.assertEquals;
 
-public abstract class PageListSetUpTearDownTestBase {
-  protected WikiPage root;
-  protected WikiPage suite;
-  protected WikiPage testPage;
-
-  @Before
-  public void setUp() throws Exception {
-    root = InMemoryPage.makeRoot("RooT");
-    PageData data = root.getData();
-    root.commit(data);
-    suite = addChildPage(root, "SuitePageName", "The is the test suite\n");
-    testPage = addChildPage(suite, "TestPage", "My test and has some content");
-  }
+public abstract class PageListSetUpTearDownTestBase extends PageListTestBase {
 
   @Test
   public void testSetUpAndTearDown() {
@@ -43,25 +24,4 @@ public abstract class PageListSetUpTearDownTestBase {
   }
 
   protected abstract List<WikiPage> addSuiteSetUpsAndTearDowns(List<WikiPage> pages);
-
-  protected List<WikiPage> makeTestPageList() {
-    SuiteContentsFinder finder = new SuiteContentsFinder(suite, null, root);
-    return finder.getAllPagesToRunForThisSuite();
-  }
-
-  protected List<String> getPagePaths(List<WikiPage> pages) {
-    List<String> list = new ArrayList<>(pages.size());
-    for (WikiPage page : pages) {
-      list.add(page.getFullPath().toString());
-    }
-    return list;
-  }
-
-  protected WikiPage addChildPage(WikiPage suite, String childName) {
-    return addChildPage(suite, childName, "");
-  }
-
-  protected WikiPage addChildPage(WikiPage suite, String childName, String s) {
-    return WikiPageUtil.addPage(suite, PathParser.parse(childName), s);
-  }
 }

--- a/test/fitnesse/testrunner/run/PageListTestBase.java
+++ b/test/fitnesse/testrunner/run/PageListTestBase.java
@@ -1,0 +1,61 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.SuiteContentsFinder;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageUtil;
+import fitnesse.wiki.fs.InMemoryPage;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class PageListTestBase {
+  private String suiteContent;
+
+  protected Map<String, String> customProperties = new HashMap<>();
+  protected WikiPage root;
+  protected WikiPage suite;
+  protected WikiPage testPage;
+
+  public PageListTestBase() {
+    this("The is the test suite\n");
+  }
+
+  public PageListTestBase(String suiteContent) {
+    this.suiteContent = suiteContent;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    root = InMemoryPage.makeRoot("RooT", customProperties);
+    PageData data = root.getData();
+    root.commit(data);
+    suite = addChildPage(root, "SuitePageName", suiteContent);
+    testPage = addChildPage(suite, "TestPage", "My test and has some content");
+  }
+
+  protected List<WikiPage> makeTestPageList() {
+    SuiteContentsFinder finder = new SuiteContentsFinder(suite, null, root);
+    return finder.getAllPagesToRunForThisSuite();
+  }
+
+  protected List<String> getPagePaths(List<WikiPage> pages) {
+    List<String> list = new ArrayList<>(pages.size());
+    for (WikiPage page : pages) {
+      list.add(page.getFullPath().toString());
+    }
+    return list;
+  }
+
+  protected WikiPage addChildPage(WikiPage suite, String childName) {
+    return addChildPage(suite, childName, "");
+  }
+
+  protected WikiPage addChildPage(WikiPage suite, String childName, String s) {
+    return WikiPageUtil.addPage(suite, PathParser.parse(childName), s);
+  }
+}

--- a/test/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitionerTest.java
+++ b/test/fitnesse/testrunner/run/PagePositionsBasedWikiPagePartitionerTest.java
@@ -1,0 +1,34 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.wiki.WikiPage;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PagePositionsBasedWikiPagePartitionerTest extends PageListTestBase {
+
+  @Test
+  public void testComparatorKnownPages() {
+    addChildPage(suite, "Test2");
+    addChildPage(suite, "Test3");
+    List<WikiPage> pageList = makeTestPageList();
+
+    int listSize = pageList.size();
+    int max = listSize;
+    PagePositions pagePositions = new PagePositions();
+    for (WikiPage page : pageList) {
+      String path = page.getFullPath().toString();
+      pagePositions.getPositions(path).add(new PagePosition(--max,"slim"));
+    }
+
+    List<WikiPage> copiedList = new ArrayList<>(pageList);
+    copiedList.sort(new PagePositionsBasedWikiPagePartitioner(null).createComparator(pagePositions));
+
+    for (int i = 0; i < listSize; i++) {
+      assertEquals("Element: " + i, pageList.get(i), copiedList.get(listSize - 1 - i));
+    }
+  }
+}

--- a/test/fitnesse/testrunner/run/PagePositionsTest.java
+++ b/test/fitnesse/testrunner/run/PagePositionsTest.java
@@ -1,0 +1,73 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageDummy;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class PagePositionsTest {
+  private static final String CONTENT =
+    "Page\tPartition\tTest System\tOrder\n" +
+      "FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation\t4\tslim\t0\n" +
+      "FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations\t1\tslim\t1\n" +
+      "FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations\t1\tslim\t0\n";
+
+  @Test
+  public void roundTrip() throws IOException {
+    try (BufferedReader r = new BufferedReader(new StringReader(CONTENT))) {
+      PagePositions pagePositions = PagePositions.parseFrom(r, "\t");
+
+      String written = pagePositions.toString();
+
+      assertEquals(CONTENT, written);
+
+      assertEquals(asList("Partition", "Test System"), pagePositions.getGroupNames());
+      assertEquals(Integer.valueOf(1), pagePositions.getGroupIndex("Test System"));
+
+      assertEquals(
+        asList("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation",
+          "FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations",
+          "FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations"),
+        pagePositions.getPages());
+    }
+  }
+
+  @Test
+  public void testFormatWikiPageIdentity() {
+    WikiPage p = new WikiPageDummy("a", "a", null);
+
+    PagePositions poss = new PagePositions();
+    WikiPageIdentity identity = new WikiPageIdentity(p);
+    assertEquals("fit", poss.formatDimension(identity));
+    assertEquals("1", poss.formatDimension(1));
+    assertEquals("b", poss.formatDimension("b"));
+    assertEquals("null", poss.formatDimension(null));
+  }
+
+  @Test
+  public void createByPositionInGroupComparator() throws IOException {
+    try (BufferedReader r = new BufferedReader(new StringReader(CONTENT))) {
+      PagePositions pagePositions = PagePositions.parseFrom(r, "\t");
+      Comparator<String> comparator = pagePositions.createByPositionInGroupComparator();
+
+      List<String> pageNames = new ArrayList<>(pagePositions.getPages());
+      pageNames.add("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.Uknown");
+      pageNames.sort(comparator);
+
+      assertEquals(0, pageNames.indexOf("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.Uknown"));
+      assertEquals(1, pageNames.indexOf("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation"));
+      assertEquals(2, pageNames.indexOf("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations"));
+      assertEquals(3, pageNames.indexOf("FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations"));
+    }
+  }
+}

--- a/test/fitnesse/testrunner/run/PartitioningTestRunFactoryTest.java
+++ b/test/fitnesse/testrunner/run/PartitioningTestRunFactoryTest.java
@@ -1,0 +1,208 @@
+package fitnesse.testrunner.run;
+
+import fitnesse.testrunner.WikiPageIdentity;
+import fitnesse.util.partitioner.EqualLengthListPartitioner;
+import fitnesse.wiki.WikiPage;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static fitnesse.wiki.PageData.SUITE_SETUP_NAME;
+import static fitnesse.wiki.PageData.SUITE_TEARDOWN_NAME;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PartitioningTestRunFactoryTest extends PageListTestBase {
+  private List<List<WikiPage>> pagesProvidedToConstr = new ArrayList<>();
+  private List<List<WikiPage>> pagesProvidedToPartitioner = new ArrayList<>();
+  private Function<List<WikiPage>, ? extends PagesByTestSystem> constr = pages -> {
+    pagesProvidedToConstr.add(pages);
+    return new PagesByTestSystem(pages);
+  };
+  private Function<List<WikiPage>, PageListPartitioner> partitioner = pages -> {
+    pagesProvidedToPartitioner.add(pages);
+    return new PageListPartitionerImpl(new EqualLengthListPartitioner<>());
+  };
+  private PartitioningTestRunFactory partitioningTestRunFactory = new PartitioningTestRunFactory(constr, partitioner);
+
+  @Test
+  public void testCanDealWithEmptyList() {
+    assertTrue(partitioningTestRunFactory.canRun(emptyList()));
+
+    assertNotNull(partitioningTestRunFactory.createRun(emptyList()));
+
+    assertEquals(singletonList(emptyList()), pagesProvidedToConstr);
+    assertEquals(emptyList(), pagesProvidedToPartitioner);
+
+    assertEquals(emptyList(), partitioningTestRunFactory.findPagePositions(emptyList()).getPages());
+  }
+
+  @Test
+  public void testNoPartitionCountPages() {
+    List<WikiPage> pageList = addTestPages();
+    PagesByTestSystem pages = partitioningTestRunFactory.getPagesByTestSystem(pageList);
+
+    List<String> paths = getPagePaths(pages.getSourcePages());
+    assertEquals(
+      "[SuitePageName.SlimPage1Suite.SlimPage1Test, " +
+        "SuitePageName.SlimPage2Suite.SlimPage2Test, " +
+        "SuitePageName.SlimPage3Suite.SlimPage3Test, SuitePageName.TestPage]",
+      paths.toString());
+
+    assertEquals(singletonList(pageList), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testPartitionedPages0() {
+    customProperties.put(PartitioningTestRunFactory.PARTITION_COUNT_ARG, "2");
+    customProperties.put(PartitioningTestRunFactory.PARTITION_INDEX_ARG, "0");
+    List<WikiPage> pageList = addTestPages();
+    PagesByTestSystem pages = partitioningTestRunFactory.getPagesByTestSystem(pageList);
+
+    List<String> paths = getPagePaths(pages.getSourcePages());
+    assertEquals(
+      "[SuitePageName.SlimPage1Suite.SlimPage1Test, SuitePageName.SlimPage2Suite.SlimPage2Test]",
+      paths.toString());
+
+    assertEquals(asList(pageList, pageList.subList(0, 2)), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testPartitionedPages1() {
+    customProperties.put(PartitioningTestRunFactory.PARTITION_COUNT_ARG, "2");
+    customProperties.put(PartitioningTestRunFactory.PARTITION_INDEX_ARG, "1");
+    List<WikiPage> pageList = addTestPages();
+    PagesByTestSystem pages = partitioningTestRunFactory.getPagesByTestSystem(pageList);
+
+    List<String> paths = getPagePaths(pages.getSourcePages());
+    assertEquals(
+      "[SuitePageName.SlimPage3Suite.SlimPage3Test, SuitePageName.TestPage]",
+      paths.toString());
+
+    assertEquals(asList(pageList, pageList.subList(2, 4)), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testPartitionedPages2() {
+    customProperties.put(PartitioningTestRunFactory.PARTITION_COUNT_ARG, "3");
+    customProperties.put(PartitioningTestRunFactory.PARTITION_INDEX_ARG, "1");
+    List<WikiPage> pageList = addTestPages();
+    PagesByTestSystem pages = partitioningTestRunFactory.getPagesByTestSystem(pageList);
+
+    List<String> paths = getPagePaths(pages.getSourcePages());
+    assertEquals(
+      "[SuitePageName.SlimPage3Suite.SlimPage3Test]",
+      paths.toString());
+
+    assertEquals(asList(pageList, pageList.subList(2, 3)), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testPartitionedPages4() {
+    customProperties.put(PartitioningTestRunFactory.PARTITION_COUNT_ARG, "3");
+    customProperties.put(PartitioningTestRunFactory.PARTITION_INDEX_ARG, "2");
+    List<WikiPage> pageList = addTestPages();
+    PagesByTestSystem pages = partitioningTestRunFactory.getPagesByTestSystem(pageList);
+
+    List<String> paths = getPagePaths(pages.getSourcePages());
+    assertEquals(
+      "[SuitePageName.TestPage]",
+      paths.toString());
+
+    assertEquals(asList(pageList, pageList.subList(3, 4)), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testNoPartitionFindPages() {
+    List<WikiPage> pageList = addTestPages();
+    PagePositions pagePositions = partitioningTestRunFactory.findPagePositions(pageList);
+    List<String> pages = pagePositions.getPages();
+    assertEquals(8, pages.size());
+    assertEquals("[SuitePageName.SlimPage1Suite.SlimPage1Test, " +
+        "SuitePageName.SlimPage2Suite.SlimPage2Test, " +
+        "SuitePageName.SlimPage3Suite.SlimPage3Test, " +
+        "SuitePageName.TestPage, SuiteSetUp, " +
+        "SuitePageName.SlimPage1Suite.SuiteTearDown, " +
+        "SuitePageName.SlimPage2Suite.SuiteSetUp, " +
+        "SuiteTearDown]",
+      pages.toString());
+
+    assertEquals(singletonList(pageList), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+  }
+
+  @Test
+  public void testPartitionedFindPages() {
+    customProperties.put(PartitioningTestRunFactory.PARTITION_COUNT_ARG, "2");
+    List<WikiPage> pageList = addTestPages();
+    PagePositions pagePositions = partitioningTestRunFactory.findPagePositions(pageList);
+    List<String> pages = pagePositions.getPages();
+    assertEquals(8, pages.size());
+
+    assertEquals("[SuitePageName.SlimPage1Suite.SlimPage1Test, " +
+        "SuitePageName.SlimPage2Suite.SlimPage2Test, " +
+        "SuitePageName.SlimPage3Suite.SlimPage3Test, " +
+        "SuitePageName.TestPage, " +
+        "SuiteSetUp, " +
+        "SuitePageName.SlimPage1Suite.SuiteTearDown, " +
+        "SuitePageName.SlimPage2Suite.SuiteSetUp, " +
+        "SuiteTearDown]",
+      pages.toString());
+
+    assertEquals(asList(pageList, pageList.subList(0, 2), pageList.subList(2, 4)), pagesProvidedToConstr);
+    assertEquals(singletonList(pageList), pagesProvidedToPartitioner);
+
+    String lastTearDown = pages.get(5);
+    assertEquals("SuitePageName.SlimPage1Suite.SuiteTearDown", lastTearDown);
+    List<PagePosition> lastTPos = pagePositions.getPositions(lastTearDown);
+    assertEquals(1, lastTPos.size());
+    PagePosition tdPagePosition = lastTPos.get(0);
+    assertEquals(2, tdPagePosition.getPositionInGroup());
+    assertEquals(2, tdPagePosition.getGroup().size());
+    assertEquals(0, tdPagePosition.getGroup().get(0));
+    assertEquals(WikiPageIdentity.class, tdPagePosition.getGroup().get(1).getClass());
+
+    String lastSetUp = pages.get(4);
+    assertEquals("SuiteSetUp", lastSetUp);
+    List<PagePosition> lastPos = pagePositions.getPositions(lastSetUp);
+    assertEquals(2, lastPos.size());
+    PagePosition setupPagePosition1 = lastPos.get(0);
+    assertEquals(0, setupPagePosition1.getPositionInGroup());
+    assertEquals(2, setupPagePosition1.getGroup().size());
+    assertEquals(0, setupPagePosition1.getGroup().get(0));
+    assertEquals(WikiPageIdentity.class, setupPagePosition1.getGroup().get(1).getClass());
+    PagePosition setupPagePosition2 = lastPos.get(1);
+    assertEquals(0, setupPagePosition2.getPositionInGroup());
+    assertEquals(2, setupPagePosition2.getGroup().size());
+    assertEquals(1, setupPagePosition2.getGroup().get(0));
+    assertEquals(WikiPageIdentity.class, setupPagePosition2.getGroup().get(1).getClass());
+  }
+
+  private List<WikiPage> addTestPages() {
+    addChildPage(root, SUITE_SETUP_NAME);
+    addChildPage(root, SUITE_TEARDOWN_NAME);
+    WikiPage slimSuite1 = addChildPage(suite, "SlimPage1Suite");
+    addChildPage(slimSuite1, "SlimPage1Test");
+    addChildPage(slimSuite1, SUITE_TEARDOWN_NAME);
+    WikiPage slimSuite2 = addChildPage(suite, "SlimPage2Suite");
+    addChildPage(slimSuite2, "SlimPage2Test");
+    WikiPage slimSuite3 = addChildPage(suite, "SlimPage3Suite");
+    addChildPage(slimSuite3, "SlimPage3Test");
+    addChildPage(slimSuite2, SUITE_SETUP_NAME);
+
+    return makeTestPageList();
+  }
+
+
+}

--- a/test/fitnesse/testrunner/run/TestRunFactoryRegistryTest.java
+++ b/test/fitnesse/testrunner/run/TestRunFactoryRegistryTest.java
@@ -63,6 +63,11 @@ public class TestRunFactoryRegistryTest {
       public TestRun createRun(List<WikiPage> pages) {
         return provider.apply(pages).get();
       }
+
+      @Override
+      public PagePositions findPagePositions(List<WikiPage> pages) {
+        return null;
+      }
     };
     registry.addFactory(factory);
   }

--- a/test/fitnesse/util/partitioner/EqualLengthListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/EqualLengthListPartitionerTest.java
@@ -1,0 +1,50 @@
+package fitnesse.util.partitioner;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class EqualLengthListPartitionerTest {
+  private final EqualLengthListPartitioner<String> partitioner = new EqualLengthListPartitioner<>();
+
+  @Test
+  public void partitionEmpty() {
+    assertEquals(Collections.emptyList(), getPartition(Collections.emptyList(), 2, 0));
+    assertEquals(Collections.emptyList(), getPartition(Collections.emptyList(), 2, 1));
+  }
+
+  @Test
+  public void partitionExact() {
+    List<String> list = asList("a", "b", "c", "d");
+    assertEquals(Collections.singletonList("a"), getPartition(list, 4, 0));
+    assertEquals(Collections.singletonList("b"), getPartition(list, 4, 1));
+    assertEquals(Collections.singletonList("c"), getPartition(list, 4, 2));
+    assertEquals(Collections.singletonList("d"), getPartition(list, 4, 3));
+
+    assertEquals(list, getPartition(list, 1, 0));
+
+    assertEquals(asList("a", "b"), getPartition(list, 2, 0));
+    assertEquals(asList("c", "d"), getPartition(list, 2, 1));
+  }
+
+  @Test
+  public void partitionPartial() {
+    List<String> list = asList("a", "b", "c", "d");
+    assertEquals(asList("a", "b"), getPartition(list, 3, 0));
+    assertEquals(Collections.singletonList("c"), getPartition(list, 3, 1));
+    assertEquals(Collections.singletonList("d"), getPartition(list, 3, 2));
+
+    List<String> list2 = asList("a", "b", "c", "d", "e");
+    assertEquals(asList("a", "b"), getPartition(list2, 3, 0));
+    assertEquals(asList("c", "d"), getPartition(list2, 3, 1));
+    assertEquals(Collections.singletonList("e"), getPartition(list2, 3, 2));
+  }
+
+  private List<String> getPartition(List<String> source, int partitionCount, int index) {
+    return partitioner.split(source, partitionCount).get(index);
+  }
+}

--- a/test/fitnesse/util/partitioner/FunctionBasedListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/FunctionBasedListPartitionerTest.java
@@ -1,0 +1,88 @@
+package fitnesse.util.partitioner;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class FunctionBasedListPartitionerTest {
+  private Map<String, Integer> positions = new LinkedHashMap<>();
+  private List<List<String>> notFoundArgs = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+    positions.put("a", 2);
+    positions.put("b", 0);
+    positions.put("c", 3);
+    positions.put("0", 1);
+    positions.put("e", 4);
+    positions.put("6", 5);
+  }
+
+  @Test
+  public void testAllPlaced() {
+    List<String> list = new ArrayList<>(positions.keySet());
+    Function<String, Optional<Integer>> f = s -> Optional.ofNullable(positions.get(s));
+
+    FunctionBasedListPartitioner<String> partitioner =
+      new FunctionBasedListPartitioner<>(f, (parts, nf) -> {
+        notFoundArgs.add(nf);
+        return new ArrayList<>(parts.size());
+      });
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(6, parts.size());
+
+    for (List<String> part : parts) {
+      assertEquals(1, part.size());
+    }
+    assertEquals("b", parts.get(0).get(0));
+    assertEquals("0", parts.get(1).get(0));
+    assertEquals("a", parts.get(2).get(0));
+    assertEquals("c", parts.get(3).get(0));
+    assertEquals("e", parts.get(4).get(0));
+    assertEquals("6", parts.get(5).get(0));
+
+    assertEquals(Collections.emptyList(), notFoundArgs);
+  }
+
+  @Test
+  public void testNotAllPlaced() {
+    List<String> list = new ArrayList<>(positions.keySet());
+    list.add(1, "nf1");
+    list.add(3, "nf2");
+    list.add("nf3");
+    list.add("nf4");
+    list.add("nf5");
+    list.add("nf6");
+    list.add("nf7");
+    Function<String, Optional<Integer>> f = s -> Optional.ofNullable(positions.get(s));
+
+    FunctionBasedListPartitioner<String> partitioner =
+      new FunctionBasedListPartitioner<>(f, (parts, nf) -> {
+        notFoundArgs.add(nf);
+        return new EqualLengthListPartitioner<String>().split(nf, parts.size());
+      });
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(Collections.singletonList(asList("nf1", "nf2", "nf3", "nf4", "nf5", "nf6", "nf7")), notFoundArgs);
+    assertEquals(
+      asList(
+        asList("nf1", "nf2", "b"),
+        asList("nf3", "0"),
+        asList("nf4", "a"),
+        asList("nf5", "c"),
+        asList("nf6", "e"),
+        asList("nf7", "6")),
+      parts);
+  }
+}

--- a/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
@@ -1,0 +1,120 @@
+package fitnesse.util.partitioner;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
+import static org.junit.Assert.assertEquals;
+
+public class MapBasedListPartitionerTest {
+  private Map<String, Integer> positions = new LinkedHashMap<>();
+  private List<List<String>> notFoundArgs = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    positions.put("a", 2);
+    positions.put("b", 0);
+    positions.put("c", 3);
+    positions.put("0", 1);
+    positions.put("e", 4);
+    positions.put("6", 5);
+  }
+
+  @Test
+  public void testAllPlaced() {
+    List<String> list = new ArrayList<>(positions.keySet());
+
+    MapBasedListPartitioner<String> partitioner =
+      new MapBasedListPartitioner<>(identity(), positions, (parts, nf) -> {
+        notFoundArgs.add(nf);
+        return new ArrayList<>(parts.size());
+      });
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(6, parts.size());
+
+    for (List<String> part : parts) {
+      assertEquals(1, part.size());
+    }
+    assertEquals("b", parts.get(0).get(0));
+    assertEquals("0", parts.get(1).get(0));
+    assertEquals("a", parts.get(2).get(0));
+    assertEquals("c", parts.get(3).get(0));
+    assertEquals("e", parts.get(4).get(0));
+    assertEquals("6", parts.get(5).get(0));
+
+    assertEquals(Collections.emptyList(), notFoundArgs);
+  }
+
+  @Test
+  public void testNotAllPlacedDefault() {
+    List<String> list = new ArrayList<>(positions.keySet());
+    list.add(1, "nf1");
+    list.add(3, "nf2");
+    list.add("nf3");
+    list.add("nf4");
+    list.add("nf5");
+    list.add("nf6");
+    list.add("nf7");
+
+    MapBasedListPartitioner<String> partitioner =
+      new MapBasedListPartitioner<>(identity(), positions);
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(
+      asList(
+        asList("nf1", "nf2", "b"),
+        asList("nf3", "0"),
+        asList("nf4", "a"),
+        asList("nf5", "c"),
+        asList("nf6", "e"),
+        asList("nf7", "6")),
+      parts);
+  }
+
+  @Test
+  public void testNotAllPlaced() {
+    List<String> list = new ArrayList<>(positions.keySet());
+    list.add(1, "nf8");
+    list.add(3, "nf2");
+    list.add("nf3");
+    list.add("nf4");
+    list.add("nf5");
+    list.add("nf6");
+    list.add("nf7");
+
+    MapBasedListPartitioner<String> partitioner =
+      new MapBasedListPartitioner<>(identity(), positions, (parts, nf) -> {
+        notFoundArgs.add(nf);
+        return new ArrayList<>(parts.size());
+      });
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(6, parts.size());
+    assertEquals(Collections.singletonList(asList("nf8", "nf2", "nf3", "nf4", "nf5", "nf6", "nf7")), notFoundArgs);
+  }
+
+  @Test
+  public void testCanDealWithBadIndex() {
+    positions.put("bad", 8);
+    positions.put("otherBad", -1);
+    List<String> list = new ArrayList<>(positions.keySet());
+
+    MapBasedListPartitioner<String> partitioner =
+      new MapBasedListPartitioner<>(identity(), positions, (parts, nf) -> {
+        notFoundArgs.add(nf);
+        return new ArrayList<>(parts.size());
+      });
+
+    List<List<String>> parts = partitioner.split(list, 6);
+    assertEquals(6, parts.size());
+    assertEquals(Collections.singletonList(asList("bad", "otherBad")), notFoundArgs);
+  }
+}


### PR DESCRIPTION
With this PR FitNesse's suite responder (and the jUnit `FitNesseRunner`) gets a new feature: suite partitioning. 
Partitioning allows the set of tests in a suite to be split into multiple sub-sets (all tests are present in exactly one sub-set). The idea for making such a split is that a test execution on a CI/CD server can be sped up if its parts are done in parallel on multiple workers. The suite partitioning feature allows the suite to be split without requiring specific alterations on the tests themselves (e.g. no need to add tags or group tests in sub-wikis). And the split will remain 'balanced' (i.e. all partitions have approximately the same size) even when tests are added and removed from the suite.

Besides just running a certain partition from a suite there is also a new responder (partition) which provides insight into how tests would be partitioned, and ordered within a suite. This responder can also be useful when not splitting a suite (i.e. number of partitions is 1) to understand how a suite will be run. It lists all tests in a suite all the suite set ups and tear downs that will be added to the suite and the order in which they will be executed (taking into account which test systems they use), without actually running all tests.

This PR introduces a basic partition algorithm based on the number of tests, but it also allows plugins to define more advanced/elaborate mechanisms.





Below is the documentation added to FitNesse's user guide: 

-----

Suites can be partitioned, that is split into multiple parts, for instance to run each partition in parallel. By running the parts in parallel the total execution time can be reduced.
FitNesse is not thread-safe so each partition's run should be executed by a separate Java process. But this can be a very effective way to speed up the time needed for testing when tests do not interfere which each other. In CI/CD servers one can spread test execution across multiple workers and get very quick tests results, even when test sizes grow.

 There are multiple ways to select certain parts of a suite. SubWikiSuites and TagsAndFilters both allow suites to be split, but these are static. And if the goal is only to improve a test suite's execution time, it could be considered improper use of these mechanisms as they are intended to define functional aspects of tests.
A purpose-build mechanism to partition a suite is also available. When running a suite one can provide a `partitionCount` and `partitionIndex` parameter (zero-based) to indicate in how many parts the suite should be split, and which part to run now.
An example usage of this mechanism is a call to `http://<host>:<port>/<suite path>?suite&partitionCount=2&partitionIndex=0`. This would partition the suite in two, executing the first.

 So one can start multiple runs for the same suite, all using the same partition count, but a different partition index.
By starting 'partition count' runs all tests are run, without the need to manually define and maintain exactly which tests should go in which partition, even when tests are added and removed from the suite.

 **Partition Preview**

A specific partition responder is available which will list the partitions (and test order in them) that will be created for a specific suite and partition count. It will list all test pages in HTML (or tab-separated text) format indicating in which partition the test will be placed and what its order in the partition will be.
So one could for instance do `http://<host>:<port>/<suite path>?partition&partitionCount=5` to so see how that suite would be divided in 5 partitions.

Tab separated format can be requested by supplying the `format` parameter with value `tsv`, e.g. `http://<host>:<port>/<suite path>?partition&partitionCount=5&format=tsv`.

 **Partition Index File**

One can also supply a file containing a partitioning in the tab-separated format created by the partition preview responder when running a suite. This file can list the desired partitioning for all known test pages. Any other pages found in the suite will be spread evenly across all partitions.
The filename for such a file must be supplied to the suite responder using the `partitionIndexFile` parameter. The file will be looked up inside the wiki's files section.

 So for example a call to `http://<host>:<port>/<suite path>?suite&partitionCount=2&partitionIndex=1&partitionIndexFile=partitions.tsv`. This would partition the tests in the suite in two groups using the division described in a file called `partitions.tsv` in the files section, executing the second group.
The file's content could look something like this (where whitespace between columns should be tab characters):
```
Page	Partition	Test System	Order
FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation	0	slim	0
FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations	1	slim	0
FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations	1	slim	1
```

 **Partitioning Algorithm**

 The standard partitioning algorithm tries to make partitions with the same number of tests. It will, for instance, for a partition count of 4:
 * split a suite of 100 tests into 4 partitions of 25 elements and
 * a suite of 102 elements would be split into 2 partitions of 26 elements and 2 of 25.

 Plugins can tailor this behaviour by registering a custom 'test run factory'. For instance when historic run times of tests are known a plugin could use this information to create partitions with an equal expected run time.

**Usage via FitNesseRunner**

 When running tests from jUnit using the `FitNesseRunner` one can use this feature by applying the `@Partition`, and possibly the `@PartitionFile`, annotation to the test class.