### PR TITLE
Issue 1280

### DIFF
--- a/src/fitnesse/wikitext/parser/Parser.java
+++ b/src/fitnesse/wikitext/parser/Parser.java
@@ -58,7 +58,7 @@ public class Parser {
         return scanner.peek(size, new ParseSpecification().provider(specification));
     }
 
-    public List<Symbol> peek(SymbolType[] types) {
+    public List<Symbol> peek(SymbolType... types) {
         List<Symbol> lookAhead = scanner.peek(types.length, new ParseSpecification().provider(specification));
         if (lookAhead.size() != types.length) return emptySymbols;
         for (int i = 0; i < lookAhead.size(); i++) {

--- a/src/fitnesse/wikitext/parser/Table.java
+++ b/src/fitnesse/wikitext/parser/Table.java
@@ -73,8 +73,10 @@ public class Table extends SymbolType implements Rule, Translation {
     // row can also be inside a define. In that case the final '|' is not followed by a newline
     // but by the define's close brace ('}'), possibly preceded by whitespace
     if ("|".equals(currentContent)) {
-      return !parser.peek(SymbolType.CloseBrace).isEmpty()
-        || !parser.peek(SymbolType.Whitespace, SymbolType.CloseBrace).isEmpty();
+      return !parser.peek(SymbolType.CloseBrace, SymbolType.Newline).isEmpty()
+        || !parser.peek(SymbolType.CloseBrace, SymbolType.Whitespace, SymbolType.Newline).isEmpty()
+        || !parser.peek(SymbolType.Whitespace, SymbolType.CloseBrace, SymbolType.Newline).isEmpty()
+        || !parser.peek(SymbolType.Whitespace, SymbolType.CloseBrace, SymbolType.Whitespace, SymbolType.Newline).isEmpty();
     }
     return false;
   }

--- a/test/fitnesse/wikitext/parser/DefineTest.java
+++ b/test/fitnesse/wikitext/parser/DefineTest.java
@@ -57,11 +57,50 @@ public class DefineTest {
 
   @Test
   public void definesTwoTables() {
+    checkMultipleTables("", 2);
+  }
+
+  @Test
+  public void definesManyTablesCurlyOnEndOfLine() {
+    checkMultipleTables("", 15);
+  }
+
+  @Test
+  public void definesManyTablesCurlyOnEndOfLineSpaceBefore() {
+    checkMultipleTables(" ", 15);
+  }
+
+  @Test
+  public void definesManyTablesCurlyOnEndOfLineSpacesBefore() {
+    checkMultipleTables("   ", 15);
+  }
+
+  @Test
+  public void definesManyTablesCurlyAtStartOfLine() {
+    checkMultipleTables("\n", 15);
+  }
+
+  private void checkMultipleTables(String postfix, int count) {
     WikiPage pageOne = new TestRoot().makePage("PageOne");
-    ParserTestHelper.assertTranslatesTo(pageOne,
-      "!define x {|a|b|c|}\n!define y {|d|e|f|}",
-      MakeDefinition("x=|a|b|c|") + HtmlElement.endl + "<br/>"
-        + MakeDefinition("y=|d|e|f|") + HtmlElement.endl);
+    StringBuilder sb = new StringBuilder();
+    StringBuilder sb2 = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      if (i > 0) {
+        sb.append("\n");
+        sb2.append("<br/>");
+      }
+      sb.append(createTableDefine("x", i, postfix));
+      sb2.append(MakeDefinition(createExpectedDefinition("x", i, postfix)));
+      sb2.append(HtmlElement.endl);
+    }
+    ParserTestHelper.assertTranslatesTo(pageOne, sb.toString(), sb2.toString());
+  }
+
+  private String createTableDefine(String name, int index, String postfix) {
+      return String.format("!define %s%s {|a|b|c|\n|a|b|%s}", name, index, postfix);
+  }
+      private String createExpectedDefinition(String name, int index, String postfix) {
+    return String.format("%s%s=|a|b|c|\n|a|b|%s", name, index, postfix);
   }
 
   @Test

--- a/test/fitnesse/wikitext/parser/TableTest.java
+++ b/test/fitnesse/wikitext/parser/TableTest.java
@@ -12,6 +12,8 @@ public class TableTest {
     ParserTestHelper.assertScansTokenType("-|a|\n", "Table", true);
     ParserTestHelper.assertScansTokenType("-!|a|\n", "Table", true);
     ParserTestHelper.assertScansTokenType("!|  a  |\n", "Table", true);
+    ParserTestHelper.assertScansTokenType("|}|\n", "Table", true);
+    ParserTestHelper.assertScansTokenType("|a|}|\n", "Table", true);
   }
 
   @Test
@@ -21,6 +23,15 @@ public class TableTest {
     ParserTestHelper.assertParses("|  a  |\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace]]]]");
     ParserTestHelper.assertParses("!|  a  |\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace]]]]");
     ParserTestHelper.assertParses("!|a:b|\n", "SymbolList[Table[TableRow[TableCell[Text, Colon, Text]]]]");
+    ParserTestHelper.assertParses("|  a |b|\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace], TableCell[Text]]]]");
+    ParserTestHelper.assertParses("| }  |\n", "SymbolList[Table[TableRow[TableCell[Whitespace, CloseBrace, Whitespace]]]]");
+    ParserTestHelper.assertParses("|  a |}|\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace], TableCell[CloseBrace]]]]");
+    ParserTestHelper.assertParses("|  a | } |\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace], TableCell[Whitespace, CloseBrace, Whitespace]]]]");
+    ParserTestHelper.assertParses("|  a | }|\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace], TableCell[Whitespace, CloseBrace]]]]");
+    ParserTestHelper.assertParses("|  a |} |\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace], TableCell[CloseBrace, Whitespace]]]]");
+    ParserTestHelper.assertParses("|  a |}\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace]]], CloseBrace, Newline]");
+    ParserTestHelper.assertParses("|  a | }\n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace]]], Whitespace, CloseBrace, Newline]");
+    ParserTestHelper.assertParses("|  a |} \n", "SymbolList[Table[TableRow[TableCell[Whitespace, Text, Whitespace]]], CloseBrace, Whitespace, Newline]");
   }
 
   @Test


### PR DESCRIPTION
Allow table symbol type to detect its line ends on close brace before a newline, so newline does not directly follow closing `|`. This can occur if table is used inside a `!define` 

#1280