### PR TITLE
No links table

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTables/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/TestTables/content.txt
@@ -60,3 +60,29 @@
 |Response Examiner.|
 |type|pattern|matches?|
 |contents|!-''italic''-!|true|
+#
+
+
+'''Test that wikiwords, http links and e-mail adresses don't get interpreted inside no-links tables.'''
+|script                                               |
+|start|Page Builder                                   |
+|line |!-^|WikiWord|https://localhost|test@mail.com|-!|
+|page |!-TableTestPageFour-!                          |
+#
+#
+|Response Requester.                   |
+|uri                  |valid?|contents?|
+|!-TableTestPageFour-!|true  |         |
+#
+#
+|Response Examiner.                                               |
+|type    |pattern                          |matches?|wrapped html?|
+|contents|!-&lt;td&gt;WikiWord&lt;/td&gt;-!|true    |             |
+#
+|Response Examiner.                                                                                                |
+|type    |pattern                                                                                         |matches?|
+|contents|!-WikiWord&lt;a title="create page" href="WikiWord?edit&amp;nonExistent=true"&gt;[?]&lt;/a&gt;-!|false   |
+|contents|!-&lt;td&gt;https://localhost&lt;/td&gt;-!                                                      |true    |
+|contents|!-&lt;a href="https://localhost"&gt;https://localhost&lt;/a&gt;-!                               |false   |
+|contents|!-&lt;td&gt;test@mail.com&lt;/td&gt;-!                                                          |true    |
+|contents|!-&lt;a href="mailto:test@mail.com"&gt;test@mail.com&lt;/a&gt;-!                                |false   |

--- a/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupTable/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/FitNesseWiki/MarkupLanguageReference/MarkupTable/content.txt
@@ -22,9 +22,20 @@ If you don't want any markup directives interpreted in the table, then you can u
 |!1 like a literal|--and is especially useful--|''for test tables.''|
 |^SinceTheyTend| * to have WikiWord symbols in them.|
 
+!2 No Link Generating tables
+If you don't want Wikiwords, URL's or E-mail adresses interpreted in the table, but you do want symbols like !-!today-! interpreted, then you can use a special form where your table is preceded with a ^ character:
+'''Markup Text'''
+{{{^|ThisTableWillExclude|WikiWords, http://links|and email@adress.es          |
+|from being parsed,  |however                |''it will respect formatting''|
+|and parse symbols like !-!today (yyyyMMdd)-!                               |}}}
+'''Displays as:'''
+^|ThisTableWillExclude|WikiWords, http://links|and email@adress.es          |
+|from being parsed,  |however                |''it will respect formatting''|
+|and parse symbols like !today (yyyyMMdd)                                   |
+
 !2 Hidden table heads
 You can hide the first row of a table. This allows you to write comment tables that just look like ordinary HTML tables.
-The complete table still gets executed, the first row is just hidden by a CSS rule. 
+The complete table still gets executed, the first row is just hidden by a CSS rule.
 Precede the first row with a '-'. This also works for literal tables.
 
 '''Markup Text'''

--- a/src/fitnesse/ContextConfigurator.java
+++ b/src/fitnesse/ContextConfigurator.java
@@ -170,7 +170,8 @@ public class ContextConfigurator {
           variableSource,
           theme);
 
-    SymbolProvider symbolProvider = SymbolProvider.wikiParsingProvider;
+    SymbolProvider wikiParsingProvider = SymbolProvider.wikiParsingProvider;
+    SymbolProvider noLinksTableParsingProvider = SymbolProvider.noLinksTableParsingProvider;
 
     SlimTableDefaultColoring.createInstanceIfNeeded(slimTableFactory);
     SlimTableDefaultColoring.install();
@@ -184,7 +185,8 @@ public class ContextConfigurator {
     }
     pluginsLoader.loadTestSystems(testSystemFactory);
     pluginsLoader.loadFormatters(formatterFactory);
-    pluginsLoader.loadSymbolTypes(symbolProvider);
+    pluginsLoader.loadSymbolTypes(wikiParsingProvider);
+    pluginsLoader.loadSymbolTypes(noLinksTableParsingProvider);
     pluginsLoader.loadSlimTables(slimTableFactory);
     pluginsLoader.loadCustomComparators(customComparatorRegistry);
     pluginsLoader.loadTestRunFactories(context.testRunFactoryRegistry);

--- a/src/fitnesse/wikitext/parser/SymbolProvider.java
+++ b/src/fitnesse/wikitext/parser/SymbolProvider.java
@@ -32,6 +32,12 @@ public class SymbolProvider {
     new Headings()
   });
 
+  public static final SymbolProvider noLinksTableParsingProvider = SymbolProvider.copy(wikiParsingProvider)
+    .remove(WikiWord.symbolType)
+    .remove(SymbolType.EMail)
+    .remove(Link.symbolType)
+    .add(SymbolType.EndCell);
+
   public static final SymbolProvider tableParsingProvider = new SymbolProvider(wikiParsingProvider).add(SymbolType.EndCell);
 
   public static final SymbolProvider aliasLinkProvider = new SymbolProvider(

--- a/src/fitnesse/wikitext/parser/Table.java
+++ b/src/fitnesse/wikitext/parser/Table.java
@@ -19,6 +19,8 @@ public class Table extends SymbolType implements Rule, Translation {
     wikiMatcher(new Matcher().startLine().string("!|"));
     wikiMatcher(new Matcher().startLine().string("-|"));
     wikiMatcher(new Matcher().startLine().string("-!|"));
+    wikiMatcher(new Matcher().startLine().string("-^|"));
+    wikiMatcher(new Matcher().startLine().string("^|"));
     wikiRule(this);
     htmlTranslation(this);
   }
@@ -57,7 +59,9 @@ public class Table extends SymbolType implements Rule, Translation {
   protected Symbol parseCell(Parser parser, String content) {
     Symbol cell = (content.contains("!"))
       ? parser.parseToWithSymbols(cellTerminators, SymbolProvider.literalTableProvider, ParseSpecification.tablePriority)
-      : parser.parseToWithSymbols(cellTerminators, SymbolProvider.tableParsingProvider, ParseSpecification.tablePriority);
+      : (content.contains("^"))
+        ? parser.parseToWithSymbols(cellTerminators, SymbolProvider.noLinksTableParsingProvider, ParseSpecification.tablePriority)
+        : parser.parseToWithSymbols(cellTerminators, SymbolProvider.tableParsingProvider, ParseSpecification.tablePriority);
     cell.setType(tableCell);
     return cell;
   }


### PR DESCRIPTION
Support a Table type (prefix ^) that doesn't parse wikiwords, links and emailadresses.

Extended version of #1307, implementing the 'requirement' from #1308 