### PR TITLE
Create distinct rerun failed pages, to allow concurrent suites to run

### DIFF
--- a/src/fitnesse/responders/run/SuiteResponder.java
+++ b/src/fitnesse/responders/run/SuiteResponder.java
@@ -292,7 +292,10 @@ public class SuiteResponder extends ChunkingResponder implements SecureResponder
   }
 
   protected String getRerunPageName() {
-    return "RerunLastFailures";
+    PageCrawler pageCrawler = page.getPageCrawler();
+    WikiPagePath fullPath = pageCrawler.getFullPath();
+    String fullPathName = PathParser.render(fullPath);
+    return "RerunLastFailures_"+fullPathName.replace(".","-");
   }
 
   protected String getTitle() {


### PR DESCRIPTION
In a scenario where we have multiple suites running at the same time towards the same fitnesse instance, at the end of the run we get only one page for rerunning failed tests, as each run overwrites them. 
Adding the page name to "RerunLastFailures" prefix allows identifying and rerunning the failed tests for each individual suite we run.