### PR TITLE
classpath order for fitnesse-standalone.jar

### DIFF
--- a/src/fitnesse/testsystems/ClassPath.java
+++ b/src/fitnesse/testsystems/ClassPath.java
@@ -45,8 +45,8 @@ public class ClassPath {
     String location = findLocationForClass(testRunner);
     if (location != null) {
       List<String> newElements = new ArrayList<>();
-      newElements.add(location);
       newElements.addAll(elements);
+      newElements.add(location);
       return new ClassPath(newElements, separator);
     }
     return this;


### PR DESCRIPTION
We can prevent library clashes for e. g. commons-lang3. The fitnesse-standalone.jar contains the library in a different version as we need for newest htmlunit library. Thank you.