### PR TITLE
Feature: Show number of test pages inside a suite.

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ContentsUsage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteWidgetTests/ContentsUsage/content.txt
@@ -14,3 +14,4 @@ Instead of defining arguments on the ''!contents'' widget, variables can be defi
 |-p            |Show property suffixes. !-
 -!Defaults:  Suite(*), Test(+), Imported(@), Symbolic(>), Skip(-).                           | PROPERTY_TOC {true} !-
 -!PROPERTY_CHARACTERS {*+@>-}|
+|-c            |Show number of test pages in a suite.                                        |                                |

--- a/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/QuickReferenceGuide/content.txt
@@ -116,6 +116,7 @@ ${SPC}${SPC}'' N.B.: Multiple asterisks are allowed, e.g.,'' ${BANG}'''****'''${
 | Contents List - Properties | ${CODE} ${BANG}'''contents -p'''     ${CODEend} |
 | Contents List - Suite Filters | ${CODE} ${BANG}'''contents -f'''     ${CODEend} |
 | Contents List - Help Text | ${CODE} ${BANG}'''contents -h'''     ${CODEend} |
+| Contents List - Test Page Count | ${CODE} ${BANG}'''contents -c'''     ${CODEend} |
 )
 
 #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/fitnesse/wikitext/parser/Contents.java
+++ b/src/fitnesse/wikitext/parser/Contents.java
@@ -39,7 +39,8 @@ public class Contents extends SymbolType implements Rule, Translation {
                   Names.PROPERTY_TOC,
                   Names.FILTER_TOC,
                   Names.MORE_SUFFIX_TOC,
-                  Names.PROPERTY_CHARACTERS},
+                  Names.PROPERTY_CHARACTERS,
+                  Names.TEST_PAGE_COUNT_TOC},
                 parser.getVariableSource());
 
         return new Maybe<>(current);

--- a/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
@@ -77,16 +77,21 @@ public class ContentsItemBuilder {
         }
         return listItem;
     }
+    private boolean isSpecialPageToBeCountedAsTest(SourcePage page){
+      String pageName = page.getName();
+      return pageName.contains("SuiteSetUp") || pageName.contains("SuiteTearDown");
+    }
 
-    private int getTotalTestPagesInASuite(SourcePage page, int counter) {
-      if (page.hasProperty(PageType.TEST.toString())) {
-        return ++counter;
+    private int getTotalTestPagesInASuite(SourcePage page) {
+      if (page.hasProperty(PageType.TEST.toString()) || isSpecialPageToBeCountedAsTest(page)){
+        return 1;
       }
+      int counter = 0;
       if (page.hasProperty(PageType.SUITE.toString())) {
         Iterator<SourcePage> pages = page.getChildren().iterator();
         while (pages.hasNext()) {
           SourcePage sourcePage = pages.next();
-          counter = getTotalTestPagesInASuite(sourcePage, counter);
+          counter += getTotalTestPagesInASuite(sourcePage);
         }
       }
       return counter;
@@ -97,7 +102,7 @@ public class ContentsItemBuilder {
         //Will show count of test pages under this suite
         if (hasOption("-c", Names.TEST_PAGE_COUNT_TOC)) {
           if (page.hasProperty(PageType.SUITE.toString()))
-            itemText += "(Test pages:" + getTotalTestPagesInASuite(page, 0) + ")";
+            itemText += " ( " + getTotalTestPagesInASuite(page) + " )";
         }
 
         if (hasOption("-g", Names.REGRACE_TOC)) {

--- a/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
@@ -12,6 +12,7 @@ import util.GracefulNamer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 
 public class ContentsItemBuilder {
     private final PropertySource contents;
@@ -77,8 +78,27 @@ public class ContentsItemBuilder {
         return listItem;
     }
 
+    private int getTotalTestPagesInASuite(SourcePage page, int counter) {
+      if (page.hasProperty(PageType.TEST.toString())) {
+        return ++counter;
+      }
+      if (page.hasProperty(PageType.SUITE.toString())) {
+        Iterator<SourcePage> pages = page.getChildren().iterator();
+        while (pages.hasNext()) {
+          SourcePage sourcePage = pages.next();
+          counter = getTotalTestPagesInASuite(sourcePage, counter);
+        }
+      }
+      return counter;
+    }
+
     private String buildBody(SourcePage page) {
         String itemText = page.getName();
+        //Will show count of test pages under this suite
+        if (hasOption("-c", Names.TEST_PAGE_COUNT_TOC)) {
+          if (page.hasProperty(PageType.SUITE.toString()))
+            itemText += "(Test pages:" + getTotalTestPagesInASuite(page, 0) + ")";
+        }
 
         if (hasOption("-g", Names.REGRACE_TOC)) {
             //todo: DRY? see wikiwordbuilder

--- a/src/fitnesse/wikitext/shared/Names.java
+++ b/src/fitnesse/wikitext/shared/Names.java
@@ -12,6 +12,7 @@ public class Names {
   public static final String PROPERTY_CHARACTERS = "PROPERTY_CHARACTERS";
   public static final String PROPERTY_TOC = "PROPERTY_TOC";
   public static final String REGRACE_TOC = "REGRACE_TOC";
+  public static final String TEST_PAGE_COUNT_TOC = "TEST_PAGE_COUNT_TOC";
 
   // variable for the expression widget
   public static final String FORMAT_LOCALE = "FORMAT_LOCALE";

--- a/test/fitnesse/wikitext/parser/ContentsItemTest.java
+++ b/test/fitnesse/wikitext/parser/ContentsItemTest.java
@@ -47,6 +47,12 @@ public class ContentsItemTest {
         assertBuildsOption("PlainItem", new String[]{}, "-g", "REGRACE_TOC", "<a href=\"PlainItem\" class=\"static\">Plain Item</a>");
     }
 
+  @Test
+  public void buildsTestPageCount() throws Exception {
+    assertBuildsOption("PlainItem", new String[]{"Suite=true"}, "-c", "TEST_PAGE_COUNT_TOC",
+            "<a href=\"PlainItem\" class=\"suite\">PlainItem(Test pages:0)</a>");
+  }
+
     @Test
     public void assertBuildsSymbolicLinkSuffix() throws Exception{
         Symbol contents = new Symbol(new Contents());

--- a/test/fitnesse/wikitext/parser/ContentsItemTest.java
+++ b/test/fitnesse/wikitext/parser/ContentsItemTest.java
@@ -8,6 +8,7 @@ import fitnesse.wiki.*;
 import fitnesse.wiki.fs.InMemoryPage;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ContentsItemTest {
     @Test
@@ -47,11 +48,45 @@ public class ContentsItemTest {
         assertBuildsOption("PlainItem", new String[]{}, "-g", "REGRACE_TOC", "<a href=\"PlainItem\" class=\"static\">Plain Item</a>");
     }
 
-  @Test
-  public void buildsTestPageCount() throws Exception {
-    assertBuildsOption("PlainItem", new String[]{"Suite=true"}, "-c", "TEST_PAGE_COUNT_TOC",
-            "<a href=\"PlainItem\" class=\"suite\">PlainItem(Test pages:0)</a>");
-  }
+    @Test
+    public void buildsTestPageCountForASuitePageWithNoChildren() throws Exception {
+      assertBuildsOption("PlainItem", new String[]{"Suite=true"}, "-c", "TEST_PAGE_COUNT_TOC",
+        "<a href=\"PlainItem\" class=\"suite\">PlainItem ( 0 )</a>");
+    }
+
+    @Test
+    public void buildsTestPageCountForASuiteWithTestPage() throws Exception {
+      TestRoot root = new TestRoot();
+      WikiPage pageOne = root.makePage("PageOne", "!contents -R1 -g -p -f -h -c");
+      setPageProperties(pageOne,"Suite");
+      WikiPage pageTwo = pageOne.addChildPage("PageTwo");
+      setPageProperties(pageTwo,"Suite");
+      setPageProperties(pageTwo.addChildPage("TestOne"),"Test");
+      //SuiteSetUp and SuiteTearDown should be counted as test just like they are counted when run
+      setPageProperties(pageTwo.addChildPage("SuiteSetUp"),"Static");
+      setPageProperties(pageTwo.addChildPage("SuiteTearDown"),"Static");
+      assertTrue(pageOne.getHtml().contains("Page Two (  3 ) *"));
+    }
+
+    @Test
+    public void buildsTestPageCountForASuiteWithSetUpAndTearDown() throws Exception {
+      TestRoot root = new TestRoot();
+      WikiPage pageOne = root.makePage("PageOne", "!contents -R1 -g -p -f -h -c");
+      setPageProperties(pageOne,"Suite");
+      WikiPage pageTwo = pageOne.addChildPage("PageTwo");
+      setPageProperties(pageTwo,"Suite");
+      setPageProperties(pageTwo.addChildPage("SampleTest"),"Test");
+      //SetUp and TearDown should not be counted as tests.
+      setPageProperties(pageTwo.addChildPage("SetUp"),"Static");
+      setPageProperties(pageTwo.addChildPage("TearDown"),"Static");
+      assertTrue(pageOne.getHtml().contains("Page Two (  1 ) *"));
+    }
+
+    @Test
+    public void buildsTestPageCountForATest() throws Exception {
+      assertBuildsOption("PlainItem", new String[]{"Test=true"}, "-c", "TEST_PAGE_COUNT_TOC",
+        "<a href=\"PlainItem\" class=\"test\">PlainItem</a>");
+    }
 
     @Test
     public void assertBuildsSymbolicLinkSuffix() throws Exception{
@@ -101,6 +136,12 @@ public class ContentsItemTest {
 
         page.commit(data);
         return page;
+    }
+
+    private void setPageProperties(WikiPage pageOne, String properties){
+      PageData pageOneData = pageOne.getData();
+      pageOneData.setAttribute(properties);
+      pageOne.commit(pageOneData);
     }
 
 }


### PR DESCRIPTION
When the tests grow, it becomes a little difficult to know the number of test pages inside a suite just by looking at the suite level. This pull request will make it possible to see the test page count for a test suite if enabled. This is enabled by "-c" option (c for count) like below
!contents -R1 -g -p -f -h -c
For details, please see the attached video.

https://user-images.githubusercontent.com/9042580/113959782-533a6c80-97d8-11eb-8975-58e75f1d7475.mov
