### PR TITLE
Add support to identify output chunk by test pages

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -68,7 +68,7 @@ public class JUnitRunNotifierResultsListener
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
   }
 
   @Override

--- a/src/fitnesse/junit/JavaFormatter.java
+++ b/src/fitnesse/junit/JavaFormatter.java
@@ -163,7 +163,7 @@ public class JavaFormatter extends BaseFormatter implements Closeable {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
     try {
       resultsRepository.write(output);
     } catch (IOException e) {

--- a/src/fitnesse/junit/PrintTestListener.java
+++ b/src/fitnesse/junit/PrintTestListener.java
@@ -38,7 +38,7 @@ public class PrintTestListener implements TestSystemListener, Closeable {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
   }
 
   @Override

--- a/src/fitnesse/reporting/BaseFormatter.java
+++ b/src/fitnesse/reporting/BaseFormatter.java
@@ -28,7 +28,7 @@ public abstract class BaseFormatter implements Formatter {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
   }
 
   @Override

--- a/src/fitnesse/reporting/ExitCodeListener.java
+++ b/src/fitnesse/reporting/ExitCodeListener.java
@@ -14,7 +14,7 @@ public class ExitCodeListener implements TestSystemListener {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
   }
 
   @Override

--- a/src/fitnesse/reporting/SuiteHtmlFormatter.java
+++ b/src/fitnesse/reporting/SuiteHtmlFormatter.java
@@ -153,7 +153,7 @@ public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeabl
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
     writeData(output);
   }
 

--- a/src/fitnesse/reporting/TestTextFormatter.java
+++ b/src/fitnesse/reporting/TestTextFormatter.java
@@ -33,7 +33,7 @@ public class TestTextFormatter extends BaseFormatter implements Closeable {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
   }
 
   @Override

--- a/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
+++ b/src/fitnesse/reporting/history/SuiteHistoryFormatter.java
@@ -68,9 +68,9 @@ public class SuiteHistoryFormatter extends BaseFormatter implements ExecutionLog
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
     if (testHistoryFormatter != null) {
-      testHistoryFormatter.testOutputChunk(output);
+      testHistoryFormatter.testOutputChunk(testPage, output);
     }
   }
 

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -71,7 +71,7 @@ public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListe
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
     appendHtmlToBuffer(output);
   }
 

--- a/src/fitnesse/testrunner/MultipleTestsRunner.java
+++ b/src/fitnesse/testrunner/MultipleTestsRunner.java
@@ -190,8 +190,8 @@ public class MultipleTestsRunner implements Stoppable {
     }
 
     @Override
-    public void testOutputChunk(String output) {
-      formatters.testOutputChunk(output);
+    public void testOutputChunk(TestPage testPage, String output) {
+      formatters.testOutputChunk(testPage, output);
     }
 
     @Override

--- a/src/fitnesse/testsystems/CompositeTestSystemListener.java
+++ b/src/fitnesse/testsystems/CompositeTestSystemListener.java
@@ -26,9 +26,9 @@ public class CompositeTestSystemListener implements TestSystemListener {
   }
 
   @Override
-  public void testOutputChunk(final String output) {
+  public void testOutputChunk(final TestPage testPage, final String output) {
     for (TestSystemListener listener : listeners)
-      listener.testOutputChunk(output);
+      listener.testOutputChunk(testPage, output);
   }
 
   @Override

--- a/src/fitnesse/testsystems/TestSystemListener.java
+++ b/src/fitnesse/testsystems/TestSystemListener.java
@@ -5,7 +5,7 @@ package fitnesse.testsystems;
 public interface TestSystemListener {
   void testSystemStarted(TestSystem testSystem);
 
-  void testOutputChunk(String output);
+  void testOutputChunk(TestPage testPage, String output);
 
   void testStarted(TestPage testPage);
 

--- a/src/fitnesse/testsystems/example/EchoTestSystemFactory.java
+++ b/src/fitnesse/testsystems/example/EchoTestSystemFactory.java
@@ -52,7 +52,7 @@ public class EchoTestSystemFactory implements TestSystemFactory {
     @Override
     public void runTests(TestPage pageToTest) {
       testSystemListener.testStarted(pageToTest);
-      testSystemListener.testOutputChunk("<pre>" + pageToTest.getHtml() + "</pre>");
+      testSystemListener.testOutputChunk(pageToTest, "<pre>" + pageToTest.getHtml() + "</pre>");
       testSystemListener.testComplete(pageToTest, new TestSummary(1, 0, 0, 0));
     }
 

--- a/src/fitnesse/testsystems/fit/FitTestSystem.java
+++ b/src/fitnesse/testsystems/fit/FitTestSystem.java
@@ -90,7 +90,7 @@ public class FitTestSystem implements TestSystem, FitClientListener {
       currentTestPage = processingQueue.removeFirst();
       testSystemListener.testStarted(currentTestPage);
     }
-    testSystemListener.testOutputChunk(output);
+    testSystemListener.testOutputChunk(currentTestPage, output);
   }
 
   @Override

--- a/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/HtmlSlimTestSystem.java
@@ -45,7 +45,7 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
 
     if (allTables.isEmpty()) {
       String html = createHtmlResults(START_OF_TEST, END_OF_TEST);
-      testOutputChunk(html);
+      testOutputChunk(pageToTest, html);
     } else {
       for (int index = 0; index < allTables.size(); index++) {
         SlimTable theTable = allTables.get(index);
@@ -61,7 +61,7 @@ public class HtmlSlimTestSystem extends SlimTestSystem {
         }
 
         String html = createHtmlResults(startWithTable, nextTable);
-        testOutputChunk(html);
+        testOutputChunk(pageToTest, html);
       }
     }
   }

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -176,8 +176,8 @@ public abstract class SlimTestSystem implements TestSystem {
     }
   }
 
-  protected void testOutputChunk(String output) {
-    testSystemListener.testOutputChunk(output);
+  protected void testOutputChunk(TestPage testPage, String output) {
+    testSystemListener.testOutputChunk(testPage, output);
   }
 
   protected void testStarted(TestPage testPage) {

--- a/test/fitnesse/junit/JUnitHelperExampleTest.java
+++ b/test/fitnesse/junit/JUnitHelperExampleTest.java
@@ -75,7 +75,7 @@ public class JUnitHelperExampleTest {
     }
 
     @Override
-    public void testOutputChunk(String output) {
+    public void testOutputChunk(TestPage testPage, String output) {
 
     }
 

--- a/test/fitnesse/junit/JavaFormatterTest.java
+++ b/test/fitnesse/junit/JavaFormatterTest.java
@@ -2,6 +2,7 @@ package fitnesse.junit;
 
 import fitnesse.testrunner.WikiTestPage;
 import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.util.TimeMeasurement;
 import fitnesse.wiki.WikiPageDummy;
@@ -108,7 +109,8 @@ public class JavaFormatterTest {
 
   @Test
   public void testOutputChunk_forwardsWriteToResultRepository() throws Exception{
-    jf.testOutputChunk("Hey there!");
+    TestPage testPage = new WikiTestPage(new WikiPageDummy("name", "content", null));
+    jf.testOutputChunk(testPage, "Hey there!");
     verify(mockResultsRepository).write("Hey there!");
   }
 

--- a/test/fitnesse/plugins/slimcoverage/SlimCoverageTestSystem.java
+++ b/test/fitnesse/plugins/slimcoverage/SlimCoverageTestSystem.java
@@ -84,12 +84,12 @@ public class SlimCoverageTestSystem extends HtmlSlimTestSystem {
         }
     }
 
-    protected void reportScenarioUsageHeader(String header) {
-        testOutputChunk("<h4>" + header + "</h4>");
+    protected void reportScenarioUsageHeader(TestPage testPage, String header) {
+        testOutputChunk(testPage, "<h4>" + header + "</h4>");
     }
 
-    protected void reportScenarioUsageNewline() {
-        testOutputChunk("<br/>");
+    protected void reportScenarioUsageNewline(TestPage testPage) {
+        testOutputChunk(testPage, "<br/>");
     }
 
     protected void reportScenarioUsage() {
@@ -99,86 +99,86 @@ public class SlimCoverageTestSystem extends HtmlSlimTestSystem {
 
         Map<String, Integer> totalUsage = usage.getScenarioUsage().getUsage();
         if (totalUsage.isEmpty()) {
-            testOutputChunk("No scenarios in run");
+            testOutputChunk(testPage, "No scenarios in run");
         } else {
             Collection<String> unused = usage.getUnusedScenarios();
             if (!unused.isEmpty()) {
-                reportScenarioUsageHeader("Unused scenarios:");
-                testOutputChunk("<ul>");
+                reportScenarioUsageHeader(testPage, "Unused scenarios:");
+                testOutputChunk(testPage, "<ul>");
                 for (String scenarioName : unused) {
-                    testOutputChunk("<li>" + scenarioName + "</li>");
+                    testOutputChunk(testPage, "<li>" + scenarioName + "</li>");
                 }
-                testOutputChunk("</ul>");
-                reportScenarioUsageNewline();
+                testOutputChunk(testPage, "</ul>");
+                reportScenarioUsageNewline(testPage);
             }
 
-            reportScenarioUsageHeader("Total usage count per scenario:");
-            testOutputChunk("<table>");
-            testOutputChunk("<tr><th>Scenario</th><th>Count</th></tr>");
+            reportScenarioUsageHeader(testPage, "Total usage count per scenario:");
+            testOutputChunk(testPage, "<table>");
+            testOutputChunk(testPage, "<tr><th>Scenario</th><th>Count</th></tr>");
             for (Map.Entry<String, Integer> totalUsageEntry : totalUsage.entrySet()) {
-                testOutputChunk("<tr>");
-                testOutputChunk("<td>");
-                testOutputChunk(totalUsageEntry.getKey()
+                testOutputChunk(testPage, "<tr>");
+                testOutputChunk(testPage, "<td>");
+                testOutputChunk(testPage, totalUsageEntry.getKey()
                         + "</td><td>"
                         + totalUsageEntry.getValue());
-                testOutputChunk("</td>");
-                testOutputChunk("</tr>");
+                testOutputChunk(testPage, "</td>");
+                testOutputChunk(testPage, "</tr>");
             }
-            testOutputChunk("</table>");
-            reportScenarioUsageNewline();
+            testOutputChunk(testPage, "</table>");
+            reportScenarioUsageNewline(testPage);
 
-            reportScenarioUsageHeader("Scenarios grouped by usage scope:");
-            testOutputChunk("<ul>");
+            reportScenarioUsageHeader(testPage, "Scenarios grouped by usage scope:");
+            testOutputChunk(testPage, "<ul>");
             for (Map.Entry<String, Collection<String>> sByScopeEntry : usage.getScenariosBySmallestScope().entrySet()) {
                 String scope = sByScopeEntry.getKey();
-                testOutputChunk("<li>");
-                testOutputChunk(scope);
-                testOutputChunk("<ul>");
+                testOutputChunk(testPage, "<li>");
+                testOutputChunk(testPage, scope);
+                testOutputChunk(testPage, "<ul>");
                 for (String scenario : sByScopeEntry.getValue()) {
-                    testOutputChunk("<li>" + scenario + "</li>");
+                    testOutputChunk(testPage, "<li>" + scenario + "</li>");
                 }
-                testOutputChunk("</ul>");
-                testOutputChunk("</li>");
+                testOutputChunk(testPage, "</ul>");
+                testOutputChunk(testPage, "</li>");
             }
-            testOutputChunk("</ul>");
-            reportScenarioUsageNewline();
+            testOutputChunk(testPage, "</ul>");
+            reportScenarioUsageNewline(testPage);
 
-            reportScenarioUsageHeader("Usage count per scenario per page:");
-            testOutputChunk("<table>");
-            testOutputChunk("<tr><th>Page</th><th>Scenario</th><th>Count</th></tr>");
+            reportScenarioUsageHeader(testPage, "Usage count per scenario per page:");
+            testOutputChunk(testPage, "<table>");
+            testOutputChunk(testPage, "<tr><th>Page</th><th>Scenario</th><th>Count</th></tr>");
             for (SlimScenarioUsagePer usagePerPage : usage.getUsage()) {
                 String pageName = usagePerPage.getGroupName();
                 for (Map.Entry<String, Integer> usagePerScenario : usagePerPage.getUsage().entrySet()) {
-                    testOutputChunk("<tr>");
-                    testOutputChunk("<td>");
-                    testOutputChunk(pageName
+                    testOutputChunk(testPage, "<tr>");
+                    testOutputChunk(testPage, "<td>");
+                    testOutputChunk(testPage, pageName
                             + "</td><td>"
                             + usagePerScenario.getKey()
                             + "</td><td>"
                             + usagePerScenario.getValue());
-                    testOutputChunk("</td>");
-                    testOutputChunk("</tr>");
+                    testOutputChunk(testPage, "</td>");
+                    testOutputChunk(testPage, "</tr>");
                 }
             }
-            testOutputChunk("</table>");
+            testOutputChunk(testPage, "</table>");
 
             Map<String, Collection<String>> overriddenPerPage = usage.getOverriddenScenariosPerPage();
             if (!overriddenPerPage.isEmpty()) {
-                reportScenarioUsageNewline();
-                reportScenarioUsageHeader("Overridden scenario(s) per page:");
-                testOutputChunk("<ul>");
+                reportScenarioUsageNewline(testPage);
+                reportScenarioUsageHeader(testPage, "Overridden scenario(s) per page:");
+                testOutputChunk(testPage, "<ul>");
                 for (Map.Entry<String, Collection<String>> overriddenForPage : overriddenPerPage.entrySet()) {
                     String pageName = overriddenForPage.getKey();
-                    testOutputChunk("<li>");
-                    testOutputChunk(pageName);
-                    testOutputChunk("<ul>");
+                    testOutputChunk(testPage, "<li>");
+                    testOutputChunk(testPage, pageName);
+                    testOutputChunk(testPage, "<ul>");
                     for (String scenario : overriddenForPage.getValue()) {
-                        testOutputChunk("<li>" + scenario + "</li>");
+                        testOutputChunk(testPage, "<li>" + scenario + "</li>");
                     }
-                    testOutputChunk("</ul>");
-                    testOutputChunk("</li>");
+                    testOutputChunk(testPage, "</ul>");
+                    testOutputChunk(testPage, "</li>");
                 }
-                testOutputChunk("</ul>");
+                testOutputChunk(testPage, "</ul>");
             }
         }
         testComplete(testPage, new TestSummary(0, 0, 1, 0));

--- a/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
+++ b/test/fitnesse/reporting/SuiteHtmlFormatterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static util.RegexTestCase.*;
 
 import fitnesse.testrunner.WikiTestPage;
+import fitnesse.testsystems.TestPage;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
 import fitnesse.wiki.WikiPage;
@@ -142,13 +143,16 @@ public class SuiteHtmlFormatterTest {
     formatter.testSystemStarted(fitMock);
     formatter.announceNumberTestsToRun(2);
     formatter.announceStartNewTest("RelativeName", "FullName");
-    formatter.testOutputChunk("starting");
-    formatter.testOutputChunk(" output");
+    TestPage testPage = new WikiTestPage(new WikiPageDummy("RelativeName", "Content", null));
+    formatter.testOutputChunk(testPage, "starting");
+    formatter.testOutputChunk(testPage, " output");
     formatter.processTestResults("RelativeName", new TestSummary(1, 0, 0, 0));
+
     formatter.testSystemStarted(slimMock);
     formatter.announceStartNewTest("NewRelativeName", "NewFullName");
-    formatter.testOutputChunk("second");
-    formatter.testOutputChunk(" test");
+    TestPage newTestPage = new WikiTestPage(new WikiPageDummy("NewRelativeName", "NewContent", null));
+    formatter.testOutputChunk(newTestPage, "second");
+    formatter.testOutputChunk(newTestPage, " test");
     formatter.processTestResults("NewRelativeName", new TestSummary(0, 1, 0, 0));
     formatter.finishWritingOutput();
 

--- a/test/fitnesse/reporting/history/TestXmlFormatterTest.java
+++ b/test/fitnesse/reporting/history/TestXmlFormatterTest.java
@@ -78,7 +78,7 @@ public class TestXmlFormatterTest {
     };
     final long startTime = clock.currentClockTimeInMillis();
 
-    formatter.testOutputChunk("outputChunk");
+    formatter.testOutputChunk(page, "outputChunk");
 
     formatter.testStarted(page);
 

--- a/test/fitnesse/responders/run/slimResponder/SlimResponder.java
+++ b/test/fitnesse/responders/run/slimResponder/SlimResponder.java
@@ -113,7 +113,7 @@ public abstract class SlimResponder implements Responder, TestSystemListener {
   }
 
   @Override
-  public void testOutputChunk(String output) {
+  public void testOutputChunk(TestPage testPage, String output) {
     this.output.append(output);
   }
 

--- a/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
+++ b/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
@@ -191,7 +191,7 @@ public class SlimTestSystemTableProcessingTest {
     }
 
     @Override
-    public void testOutputChunk(String output) {
+    public void testOutputChunk(TestPage testPage, String output) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Hello, 

On the project I work, we use FitNesse for end to end validation. We have recently switched from running the tests from a JUnit test on Jenkins to launching the tests on the test machine using the suite responder. The problem is that the suite responder does not create reports for each test page nor does it aggregates them nicely in a summary report file (as JUnit does). So we have created a custom responder to create a report file for each test page and aggregate them in a summary report file.

This has been much difficult than we have previously thought because currently there is no easy way of linking the output chunk to a test page. This pull request tries to fix this problem by adding the test page to the testOutputChunk method.