### PR TITLE
Report tests with ExecutionResult IGNORED as Ignored to Junit

### DIFF
--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -60,13 +60,14 @@ public class JUnitRunNotifierResultsListener
     increaseCompletedTests();
     Description description = descriptionFor(test);
 
+
     if (firstFailure != null) {
       notifier.fireTestFailure(new Failure(description, firstFailure));
     } else if (testSummary.getExceptions() > 0) {
       notifier.fireTestFailure(new Failure(description, new Exception("Exception occurred on page " + test.getFullPath())));
     } else if (testSummary.getWrong() > 0) {
       notifier.fireTestFailure(new Failure(description, new AssertionError("Test failures occurred on page " + test.getFullPath())));
-    } else if (getExecutionResult(test.getName(), testSummary) == ExecutionResult.IGNORE) {
+    } else if (getExecutionResult(testSummary) == ExecutionResult.IGNORE) {
       notifier.fireTestIgnored(description);
       return;
     }

--- a/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
+++ b/src/fitnesse/junit/JUnitRunNotifierResultsListener.java
@@ -20,6 +20,8 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
+import static fitnesse.testsystems.ExecutionResult.getExecutionResult;
+
 public class JUnitRunNotifierResultsListener
         implements TestSystemListener, TestsRunnerListener, Closeable {
   private static final Logger LOG = Logger.getLogger(JUnitRunNotifierResultsListener.class.getName());
@@ -57,12 +59,16 @@ public class JUnitRunNotifierResultsListener
   public void testComplete(TestPage test, TestSummary testSummary) {
     increaseCompletedTests();
     Description description = descriptionFor(test);
+
     if (firstFailure != null) {
       notifier.fireTestFailure(new Failure(description, firstFailure));
     } else if (testSummary.getExceptions() > 0) {
       notifier.fireTestFailure(new Failure(description, new Exception("Exception occurred on page " + test.getFullPath())));
     } else if (testSummary.getWrong() > 0) {
       notifier.fireTestFailure(new Failure(description, new AssertionError("Test failures occurred on page " + test.getFullPath())));
+    } else if (getExecutionResult(test.getName(), testSummary) == ExecutionResult.IGNORE) {
+      notifier.fireTestIgnored(description);
+      return;
     }
     notifier.fireTestFinished(description);
   }

--- a/src/fitnesse/junit/JUnitXMLPerPageRunListener.java
+++ b/src/fitnesse/junit/JUnitXMLPerPageRunListener.java
@@ -83,6 +83,14 @@ public class JUnitXMLPerPageRunListener extends RunListener {
     }
   }
 
+  @Override
+  public void testIgnored(Description description) throws Exception {
+    super.testIgnored(description);
+    if (!timeMeasurement.isStopped()) {
+      testResultRecorder.recordTestResult(getTestName(description), 1, 0, 0, null, getExecutionTime());
+    }
+  }
+
   /**
    * @return test execution time in milliseconds
    */


### PR DESCRIPTION
Tests that FitNesse reports as ignored from a suite run (blue bar in html result, i.e. when a stop test exception was thrown in a SuiteSetUp) are reported as passed tests to JUnit.
This PR calls testIgnored on the notifier in this situation. The JunitXMLresultrecorder is the called to rcord a testresult for a skipped test.

This ensures pass/fail/skip results in JUnit are in sync with what we see when running from the wiki.