### PR TITLE
hide slim symbol values prefixed with SECRET_ on the slim runner side

### DIFF
--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SlimSymbols/SlimSymbolsWithSecretPrefixAreNotExpandedInHtml.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SlimSymbols/SlimSymbolsWithSecretPrefixAreNotExpandedInHtml.wiki
@@ -10,11 +10,13 @@ Test
 |fitnesse.slim.test|
 |fitnesse.fixtures |
 
-|script         |echo fixture            |
-|$SECRET_symbol=|echo|this is secret info|
-|set name       |$SECRET_symbol          |
+|script         |echo fixture                           |
+|$SECRET_symbol=|echo|this is secret info               |
+|set name       |$SECRET_symbol                         |
+|check          |echo|$SECRET_symbol|this is secret info|
 -! |
-|check |request page    |SecretSymbolTest?test |200 |
-|ensure|content contains|!-$SECRET_symbol->[*****]-!|
-|show  |content                                     |
+|check |request page    |SecretSymbolTest?test            |200           |
+|ensure|content contains|!-$SECRET_symbol->[*****]-!                     |
+|ensure|content contains|&lt;span class="pass">this is secret info</span>|
+|show  |content                                                          |
 

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SlimSymbols/SlimSymbolsWithSecretPrefixAreNotExpandedInHtml.wiki
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SlimSymbols/SlimSymbolsWithSecretPrefixAreNotExpandedInHtml.wiki
@@ -1,0 +1,20 @@
+---
+Test
+---
+!3 When a symbol is prefixed with SECRET, it's contents will not be shown upon accessing the symbol
+
+!| script                                |
+|given page|SecretSymbolTest|with content|!-!define TEST_SYSTEM {slim}
+
+|import            |
+|fitnesse.slim.test|
+|fitnesse.fixtures |
+
+|script         |echo fixture            |
+|$SECRET_symbol=|echo|this is secret info|
+|set name       |$SECRET_symbol          |
+-! |
+|check |request page    |SecretSymbolTest?test |200 |
+|ensure|content contains|!-$SECRET_symbol->[*****]-!|
+|show  |content                                     |
+

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -2,6 +2,11 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.testsystems.slim;
 
+import fitnesse.testsystems.ExecutionResult;
+import fitnesse.testsystems.TestPage;
+import fitnesse.testsystems.TestSummary;
+import fitnesse.testsystems.slim.tables.ScenarioTable;
+import fitnesse.testsystems.slim.tables.ScriptTable;
 import fitnesse.util.TimeMeasurement;
 
 import java.util.ArrayList;
@@ -11,12 +16,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import fitnesse.testsystems.ExecutionResult;
-import fitnesse.testsystems.TestPage;
-import fitnesse.testsystems.TestSummary;
-import fitnesse.testsystems.slim.tables.ScenarioTable;
-import fitnesse.testsystems.slim.tables.ScriptTable;
 
 public class SlimTestContextImpl implements SlimTestContext {
   private final Map<String, String> symbols = new HashMap<>();
@@ -36,7 +35,7 @@ public class SlimTestContextImpl implements SlimTestContext {
 
   @Override
   public String getSymbol(String symbolName) {
-    if(symbolName.startsWith("SECRET_")) {
+    if (symbolName.startsWith("SECRET_")) {
       return "*****";
     }
     return symbols.get(symbolName);

--- a/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
+++ b/src/fitnesse/testsystems/slim/SlimTestContextImpl.java
@@ -36,6 +36,9 @@ public class SlimTestContextImpl implements SlimTestContext {
 
   @Override
   public String getSymbol(String symbolName) {
+    if(symbolName.startsWith("SECRET_")) {
+      return "*****";
+    }
     return symbols.get(symbolName);
   }
 

--- a/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
@@ -52,7 +52,7 @@ public class SlimTableTest {
   public void replaceSymbolsShouldReplaceSecretSymbol() throws Exception {
     SlimTable table = new MockTable();
     table.setSymbol("SECRET_x", "a");
-    assertEquals("this is a", table.replaceSymbols("this is $SECRET_x"));
+    assertEquals("this is *****", table.replaceSymbols("this is $SECRET_x"));
   }
 
   @Test
@@ -98,7 +98,7 @@ public class SlimTableTest {
   public void replaceSymbolsFullExpansion_ShouldReplaceSecretSymbol() throws Exception {
     SlimTable table = new MockTable();
     table.setSymbol("SECRET_x", "a");
-    assertEquals("this is $SECRET_x->[a]", table.replaceSymbolsWithFullExpansion("this is $SECRET_x"));
+    assertEquals("this is $SECRET_x->[*****]", table.replaceSymbolsWithFullExpansion("this is $SECRET_x"));
   }
 
   @Test

--- a/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
+++ b/test/fitnesse/testsystems/slim/tables/SlimTableTest.java
@@ -49,6 +49,13 @@ public class SlimTableTest {
   }
 
   @Test
+  public void replaceSymbolsShouldReplaceSecretSymbol() throws Exception {
+    SlimTable table = new MockTable();
+    table.setSymbol("SECRET_x", "a");
+    assertEquals("this is a", table.replaceSymbols("this is $SECRET_x"));
+  }
+
+  @Test
   public void replaceSymbolsShouldReplaceMoreThanOneSymbol() throws Exception {
     SlimTable table = new MockTable();
     table.setSymbol("x", "a");
@@ -85,6 +92,13 @@ public class SlimTableTest {
     SlimTable table = new MockTable();
     table.setSymbol("x", "a");
     assertEquals("this is $x->[a]", table.replaceSymbolsWithFullExpansion("this is $x"));
+  }
+
+  @Test
+  public void replaceSymbolsFullExpansion_ShouldReplaceSecretSymbol() throws Exception {
+    SlimTable table = new MockTable();
+    table.setSymbol("SECRET_x", "a");
+    assertEquals("this is $SECRET_x->[a]", table.replaceSymbolsWithFullExpansion("this is $SECRET_x"));
   }
 
   @Test


### PR DESCRIPTION
This PR replaces slim symbol for display in test results if they are prefixed with `$SECRET_` with `$_SECRET_symbolName->[*****]`

This is useful to prevent unintentional display of secrets (such as passwords, api keys, etc) when using Slim. Ofcourse it's still easily possible to display these values by echo-ing them through a fixture method, but it helps keeping unwanted info out of test results and dashboards.



