### PR TITLE
Unequal partitioning through partitioning file

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestSuites/SuitePartitioning.wiki
@@ -30,6 +30,13 @@ FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.AlwaysSecureOperation	0	s
 FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureReadOperations	1	slim	0
 FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests.SecureTestOperations	1	slim	1
 }}}
+It is also possible to specify any level in the tree for a partition. For example, all tests under !-SuiteWikiImportTests-! in below table will be included in partition 0 and !-SuiteAuthenticationTests-! will be in partition 1. Remaining tests not included in this file will be evenly spread across all partitions.
+Closest match in the tree takes precedence in case of a conflict. For example, if you specify both the test page and parent level in this file, test page partitioning index will be applied for that test.
+{{{
+Page	Partition	Test System	Order
+FitNesse.SuiteAcceptanceTests.SuiteWikiImportTests	0	slim	0
+FitNesse.SuiteAcceptanceTests.SuiteAuthenticationTests	1	slim	0
+}}}
 
 !3 Partitioning Algorithm
 

--- a/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
@@ -1,5 +1,7 @@
 package fitnesse.util.partitioner;
 
+import fitnesse.wiki.WikiPage;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,6 +53,9 @@ public class FunctionBasedListPartitioner<T> implements ListPartitioner<T> {
     List<T> notFound = new ArrayList<>();
     for (T item : source) {
       Optional<Integer> pos = positionFunction.apply(item);
+      if (!pos.isPresent()) {
+        pos = findParentPosition(item);
+      }
       if (pos.isPresent()) {
         int index = pos.get();
         if (index >= 0 && index < partitionCount) {
@@ -63,6 +68,20 @@ public class FunctionBasedListPartitioner<T> implements ListPartitioner<T> {
       }
     }
     return notFound;
+  }
+
+  private Optional<Integer> findParentPosition(T item) {
+    if (item instanceof WikiPage) {
+      WikiPage wikiPage = ((WikiPage) item);
+      while (!wikiPage.isRoot()) {
+        Optional<Integer> pos = positionFunction.apply((T) wikiPage);
+        if (pos.isPresent()) {
+          return pos;
+        }
+        wikiPage = wikiPage.getParent();
+      }
+    }
+    return Optional.empty();
   }
 
   protected List<List<T>> combinePlacedAndNotFound(List<List<T>> partitions, List<List<T>> extraItems) {

--- a/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/FunctionBasedListPartitioner.java
@@ -72,7 +72,7 @@ public class FunctionBasedListPartitioner<T> implements ListPartitioner<T> {
 
   private Optional<Integer> findParentPosition(T item) {
     if (item instanceof WikiPage) {
-      WikiPage wikiPage = ((WikiPage) item);
+      WikiPage wikiPage = ((WikiPage) item).getParent();
       while (!wikiPage.isRoot()) {
         Optional<Integer> pos = positionFunction.apply((T) wikiPage);
         if (pos.isPresent()) {

--- a/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
@@ -1,5 +1,7 @@
 package fitnesse.util.partitioner;
 
+import fitnesse.wiki.WikiPage;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,7 +23,8 @@ public class MapBasedListPartitioner<T> extends FunctionBasedListPartitioner<T> 
                                  BiFunction<List<List<T>>, List<T>, List<List<T>>> notFoundFunction) {
     super(
       t -> {
-        String key = keyFunction.apply(t);
+        Object object = keyFunction.apply(t);
+        String key = (object instanceof WikiPage) ? ((WikiPage) object).getFullPath().toString() : object.toString();
         Integer value = positionMap.get(key);
         return Optional.ofNullable(value);
       },

--- a/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
+++ b/src/fitnesse/util/partitioner/MapBasedListPartitioner.java
@@ -1,7 +1,5 @@
 package fitnesse.util.partitioner;
 
-import fitnesse.wiki.WikiPage;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,8 +21,7 @@ public class MapBasedListPartitioner<T> extends FunctionBasedListPartitioner<T> 
                                  BiFunction<List<List<T>>, List<T>, List<List<T>>> notFoundFunction) {
     super(
       t -> {
-        Object object = keyFunction.apply(t);
-        String key = (object instanceof WikiPage) ? ((WikiPage) object).getFullPath().toString() : object.toString();
+        String key = keyFunction.apply(t);
         Integer value = positionMap.get(key);
         return Optional.ofNullable(value);
       },

--- a/test/fitnesse/util/partitioner/FunctionBasedListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/FunctionBasedListPartitionerTest.java
@@ -1,5 +1,8 @@
 package fitnesse.util.partitioner;
 
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wikitext.parser.TestRoot;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -85,4 +88,90 @@ public class FunctionBasedListPartitionerTest {
         asList("nf7", "6")),
       parts);
   }
+
+  @Test
+  public void testWithEmptyPartitionFile() {
+
+    LinkedHashMap<String, Integer> positions = new LinkedHashMap<>();
+    //Perform the split
+    Function<WikiPage, Optional<Integer>> f = s -> Optional.ofNullable(positions.get(s.getFullPath().toString()));
+    List<List<WikiPage>> noFoundArgs = new ArrayList<>();
+
+    FunctionBasedListPartitioner<WikiPage> partitioner =
+      new FunctionBasedListPartitioner<>(f, (parts, nf) -> {
+        noFoundArgs.add(nf);
+        return new EqualLengthListPartitioner<WikiPage>().split(nf, parts.size());
+      });
+
+    List<List<WikiPage>> parts = partitioner.split(constructTreeAndReturnAllTests(), 2);
+    assertEquals(2, parts.get(0).size());
+    assertEquals(2, parts.get(1).size());
+
+    List<String> actualPartition1TestCases = new ArrayList<>();
+    parts.get(0).forEach(e -> actualPartition1TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test1", "Suite1Test2"), actualPartition1TestCases);
+
+    List<String> actualPartition2TestCases = new ArrayList<>();
+    parts.get(1).forEach(e -> actualPartition2TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test3", "Suite2Test1"), actualPartition2TestCases);
+  }
+
+  @Test
+  public void testWithSuiteInPartitionFile() {
+    //Define the partition file
+    LinkedHashMap<String, Integer> positions = new LinkedHashMap<>();
+    positions.put("Suite1", 0);
+    positions.put("Suite2", 1);
+
+    Function<WikiPage, Optional<Integer>> f = s -> Optional.ofNullable(positions.get(s.getFullPath().toString()));
+    List<List<WikiPage>> noFoundArgs = new ArrayList<>();
+
+    FunctionBasedListPartitioner<WikiPage> partitioner =
+      new FunctionBasedListPartitioner<>(f, (parts, nf) -> {
+        noFoundArgs.add(nf);
+        return new ArrayList<>(parts.size());
+      });
+
+    List<List<WikiPage>> parts = partitioner.split(constructTreeAndReturnAllTests(), 2);
+
+    //Assertions
+    assertEquals(3, parts.get(0).size());
+    assertEquals(1, parts.get(1).size());
+
+    List<String> actualPartition1TestCases = new ArrayList<>();
+    parts.get(0).forEach(e -> actualPartition1TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test1", "Suite1Test2", "Suite1Test3"), actualPartition1TestCases);
+
+    List<String> actualPartition2TestCases = new ArrayList<>();
+    parts.get(1).forEach(e -> actualPartition2TestCases.add(e.getName()));
+    assertEquals(asList("Suite2Test1"), actualPartition2TestCases);
+  }
+
+  //Construct tree with 3 tests in first suite and 1 test in second suite
+  private List<WikiPage> constructTreeAndReturnAllTests() {
+    TestRoot root = new TestRoot();
+    WikiPage suite1 = root.makePage("Suite1", "!contents -R1 -g -p -f -h");
+    setPageProperties(suite1, "Suite");
+    WikiPage suite1Test1 = setPageProperties(suite1.addChildPage("Suite1Test1"), "Test");
+    WikiPage suite1Test2 = setPageProperties(suite1.addChildPage("Suite1Test2"), "Test");
+    WikiPage suite1Test3 = setPageProperties(suite1.addChildPage("Suite1Test3"), "Test");
+    WikiPage suite2 = root.makePage("Suite2", "!contents -R1 -g -p -f -h");
+    setPageProperties(suite2, "Suite");
+    WikiPage suite2Test1 = setPageProperties(suite2.addChildPage("Suite2Test1"), "Test");
+
+    List<WikiPage> list = new ArrayList<>();
+    list.add(0, suite1Test1);
+    list.add(1, suite1Test2);
+    list.add(2, suite1Test3);
+    list.add(3, suite2Test1);
+    return list;
+  }
+
+  private WikiPage setPageProperties(WikiPage wikiPage, String properties) {
+    PageData pageData = wikiPage.getData();
+    pageData.setAttribute(properties);
+    wikiPage.commit(pageData);
+    return wikiPage;
+  }
+
 }

--- a/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
@@ -1,5 +1,8 @@
 package fitnesse.util.partitioner;
 
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wikitext.parser.TestRoot;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -137,4 +140,75 @@ public class MapBasedListPartitionerTest {
     assertEquals(6, parts.size());
     assertEquals(Collections.singletonList(asList("bad", "otherBad")), notFoundArgs);
   }
+
+  @Test
+  public void testWithEmptyPartitionFile() {
+    //Perform the split
+    MapBasedListPartitioner<WikiPage> partitioner = new MapBasedListPartitioner(identity(), new LinkedHashMap<>());
+    List<List<WikiPage>> parts = partitioner.split(constructTreeAndReturnAllTests(), 2);
+
+    assertEquals(2, parts.get(0).size());
+    assertEquals(2, parts.get(1).size());
+
+    List<String> actualPartition1TestCases = new ArrayList<>();
+    parts.get(0).forEach(e -> actualPartition1TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test1", "Suite1Test2"), actualPartition1TestCases);
+
+    List<String> actualPartition2TestCases = new ArrayList<>();
+    parts.get(1).forEach(e -> actualPartition2TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test3", "Suite2Test1"), actualPartition2TestCases);
+  }
+
+  @Test
+  public void testWithSuiteInPartitionFile() {
+
+    //Define the partition file
+    LinkedHashMap<String, Integer> positions = new LinkedHashMap<>();
+    positions.put("Suite1", 0);
+    positions.put("Suite2", 1);
+
+    //Perform the split
+    MapBasedListPartitioner<WikiPage> partitioner = new MapBasedListPartitioner(identity(), positions);
+    List<List<WikiPage>> parts = partitioner.split(constructTreeAndReturnAllTests(), 2);
+
+    //Assertions
+    assertEquals(3, parts.get(0).size());
+    assertEquals(1, parts.get(1).size());
+
+    List<String> actualPartition1TestCases = new ArrayList<>();
+    parts.get(0).forEach(e -> actualPartition1TestCases.add(e.getName()));
+    assertEquals(asList("Suite1Test1", "Suite1Test2", "Suite1Test3"), actualPartition1TestCases);
+
+    List<String> actualPartition2TestCases = new ArrayList<>();
+    parts.get(1).forEach(e -> actualPartition2TestCases.add(e.getName()));
+    assertEquals(asList("Suite2Test1"), actualPartition2TestCases);
+  }
+
+  //Construct tree with 3 tests in first suite and 1 test in second suite
+  private List<WikiPage> constructTreeAndReturnAllTests() {
+    TestRoot root = new TestRoot();
+    WikiPage suite1 = root.makePage("Suite1", "!contents -R1 -g -p -f -h");
+    setPageProperties(suite1, "Suite");
+    WikiPage suite1Test1 = setPageProperties(suite1.addChildPage("Suite1Test1"), "Test");
+    WikiPage suite1Test2 = setPageProperties(suite1.addChildPage("Suite1Test2"), "Test");
+    WikiPage suite1Test3 = setPageProperties(suite1.addChildPage("Suite1Test3"), "Test");
+    WikiPage suite2 = root.makePage("Suite2", "!contents -R1 -g -p -f -h");
+    setPageProperties(suite2, "Suite");
+    WikiPage suite2Test1 = setPageProperties(suite2.addChildPage("Suite2Test1"), "Test");
+
+    List<WikiPage> list = new ArrayList<>();
+    list.add(0, suite1Test1);
+    list.add(1, suite1Test2);
+    list.add(2, suite1Test3);
+    list.add(3, suite2Test1);
+    return list;
+  }
+
+  private WikiPage setPageProperties(WikiPage wikiPage, String properties) {
+    PageData pageData = wikiPage.getData();
+    pageData.setAttribute(properties);
+    wikiPage.commit(pageData);
+    return wikiPage;
+  }
+
 }

--- a/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
+++ b/test/fitnesse/util/partitioner/MapBasedListPartitionerTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static java.util.Arrays.asList;
 import static java.util.function.Function.identity;
@@ -168,7 +169,8 @@ public class MapBasedListPartitionerTest {
     positions.put("Suite2", 1);
 
     //Perform the split
-    MapBasedListPartitioner<WikiPage> partitioner = new MapBasedListPartitioner(identity(), positions);
+    Function<WikiPage, String> keyFunction = s -> s.getName();
+    MapBasedListPartitioner<WikiPage> partitioner = new MapBasedListPartitioner(keyFunction, positions);
     List<List<WikiPage>> parts = partitioner.split(constructTreeAndReturnAllTests(), 2);
 
     //Assertions


### PR DESCRIPTION
In the image below, we wanted Windows, Mac and Linux cases to run in parallel as defined in the partitioning file. This could not be done with default partitioning which works by splitting the test cases equally. This pull request implements suite based unequal split. 

**Partitioning file**
```
Page	Partition	Test System	Order
Demo.DemoSuite.Linux	0	slim	0
Demo.DemoSuite.Mac	1	slim	0
Demo.DemoSuite.Windows	2	slim	0
```

![image](https://user-images.githubusercontent.com/9042580/142573568-5c16c082-5743-47c9-a37b-81174e6e22d0.png)
