### PR TITLE
Update default new suite page content

### DIFF
--- a/FitNesseRoot/TemplateLibrary/SuitePage/content.txt
+++ b/FitNesseRoot/TemplateLibrary/SuitePage/content.txt
@@ -1,2 +1,2 @@
-!1 Test suite X
+!1 Test suite ${PAGE_NAME}
 !contents -R2 -g -p -f -h


### PR DESCRIPTION
Team members hardly update the default suite name while adding a new suite page. This pull request will add the default page name in the suite template. Please refer to the screenshot before and after this change.

![image](https://user-images.githubusercontent.com/9042580/143302109-97416264-f4ba-43fc-a4f2-01a25ebe2a49.png)
