### PR TITLE
commons-text 1.10.0 - addresses CVE-2022-42889

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
   implementation "org.slf4j:slf4j-jdk14:1.7.36"
   implementation "org.json:json:20220320"
   implementation "com.googlecode.java-diff-utils:diffutils:1.3.0"
-  implementation "org.apache.commons:commons-text:1.9"
+  implementation "org.apache.commons:commons-text:1.10.0"
   compileOnly gradleApi()
   compileOnly "org.apache.ant:ant:1.10.12"
   compileOnly "junit:junit:4.13.2"


### PR DESCRIPTION
Fixes CVE-2022-42889 through upgrading commons-text lib to `org.apache.commons:commons-text:1.10.0`

### References:
- https://commons.apache.org/proper/commons-text/security.html
- https://www.cve.org/CVERecord?id=CVE-2022-42889