### PR TITLE
Addresses issue #1402 - Possible to search and replace method/scenario names with new name.

### DIFF
--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -36,7 +36,7 @@
   <a class="button" href="$viewLocation">Cancel</a>
  </fieldset>
 <p>
-  You may change a method/scenario name and want to reflect this name change across all existing test cases. To accomplish this, you can supply a relevant existing line using that method from any test page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep in mind following.
+  Reflect an updated method/scenario name across all existing test cases. To accomplish this, you can supply an existing line using that method from any test page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep the following in mind:
   <ul>
    <li>This will keep the original parameters (if any) in the wiki which is good in most cases.</li>
    <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having similar name. This will be desired in most cases. If you used same method in multiple classes, all of them will be impacted in the wiki pages.</li>

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -38,7 +38,7 @@
 <p>
   Reflect an updated method/scenario name across all existing test cases. To accomplish this, you can supply an existing line using that method from any test page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep the following in mind:
   <ul>
-   <li>This will keep the original parameters (if any) in the wiki which is good in most cases.</li>
+   <li>This will not change the parameters (if any) in the wiki.</li>
    <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having similar name. This will be desired in most cases. If you used same method in multiple classes, all of them will be impacted in the wiki pages.</li>
    <li>It is a good idea to review the replaced lines locally (e.g. using Git) and undo any undesired changes before sharing/committing the tests. Most IDE has version control comparison and selective undo feature.</li>
   </ul>

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -40,7 +40,7 @@
   <ul>
    <li>This will not change the parameters (if any) in the wiki.</li>
    <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having a similar name. This will be desired in most cases. But if you have multiple classes with the same method of which you only changed one this will not work as desired, since all calls are replaced.</li>
-   <li>It is a good idea to review the replaced lines locally (e.g. using Git) and undo any undesired changes before sharing/committing the tests. Most IDE has version control comparison and selective undo feature.</li>
+   <li>It is a good idea to review the updated lines locally (e.g. using Git) and undo any undesired changes before sharing/committing the tests. Most IDE have a version control comparison and selective undo feature.</li>
   </ul>
  </p>
 </form>

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -1,6 +1,6 @@
 #if( !$type || $type == "replace" )
-<h2>Replace</h2>
 <form action="$refactoredRootPage" method="post">
+<h2>Replace Text</h2>
  <input type="hidden" name="responder" value="replace"/>
  <fieldset>
   <label for="searchString">Search String:</label>
@@ -11,19 +11,32 @@
   <input type="text" size="50" id="replacementString" name="replacementString" value="#if ($request.hasInput("replacementString"))$request.getInput("replacementString")#end"/>
  </fieldset>
  <fieldset class="buttons">
-  <label style="width:100%;text-align:left" for="methodReplaceCheckbox"><input type="checkbox" id="methodReplaceCheckbox" name="methodReplaceCheckbox"/>Replace Method? (See notes below)**</label>
- </fieldset>
- <fieldset class="buttons">
   <input type="submit" name="replace" value="Replace!"/>
   <a class="button" href="$viewLocation">Cancel</a>
  </fieldset>
- <br />
+
  <p><strong>Search &amp; Replace: </strong>
- <p>Please note that this feature is experimental!</p>
- <p> For regex replace (when checkbox is not selected), it uses <a href="http://java.sun.com/javase/6/docs/api/java/util/regex/Pattern.html" target="_new">java-based regular expressions</a>.
- </p>
- <p>
-  ** When you change a method or a scenario name and you want to reflect the changes across all your tests, you can select the checkbox. You can use existing line in wiki page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep in mind following.
+  Please note that this feature is experimental! It uses java-based regular expressions. For an introduction, take a look <a href="http://java.sun.com/javase/6/docs/api/java/util/regex/Pattern.html" target="_new">here</a> (new window).</p>
+</form>
+
+<form action="$refactoredRootPage" method="post">
+<h2>Replace Method</h2>
+ <input type="hidden" name="responder" value="replace"/>
+ <input type="hidden" name="isMethodReplace"/>
+ <fieldset>
+  <label for="searchString">Search Method:</label>
+  <input type="text" size="50" id="searchStringMethod" name="searchString" value="#if ($request.hasInput("searchString"))$request.getInput("searchString")#end"/>
+ </fieldset>
+ <fieldset>
+  <label for="replacementString">Replacing Method:</label>
+  <input type="text" size="50" id="replacementString" name="replacementString" value="#if ($request.hasInput("replacementString"))$request.getInput("replacementString")#end"/>
+ </fieldset>
+ <fieldset class="buttons">
+  <input type="submit" name="replace" value="Replace Method!"/>
+  <a class="button" href="$viewLocation">Cancel</a>
+ </fieldset>
+<p>
+  You may change a method/scenario name and want to reflect this name change across all existing test cases. To accomplish this, you can supply a relevant existing line using that method from any test page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep in mind following.
   <ul>
    <li>This will keep the original parameters (if any) in the wiki which is good in most cases.</li>
    <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having similar name. This will be desired in most cases. If you used same method in multiple classes, all of them will be impacted in the wiki pages.</li>

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -4,19 +4,32 @@
  <input type="hidden" name="responder" value="replace"/>
  <fieldset>
   <label for="searchString">Search String:</label>
-  <input type="text" id="searchString" name="searchString" value="#if ($request.hasInput("searchString"))$request.getInput("searchString")#end"/>
+  <input type="text" size="50" id="searchString" name="searchString" value="#if ($request.hasInput("searchString"))$request.getInput("searchString")#end"/>
  </fieldset>
  <fieldset>
   <label for="replacementString">Replacement:</label>
-  <input type="text" id="replacementString" name="replacementString" value="#if ($request.hasInput("replacementString"))$request.getInput("replacementString")#end"/>
+  <input type="text" size="50" id="replacementString" name="replacementString" value="#if ($request.hasInput("replacementString"))$request.getInput("replacementString")#end"/>
+ </fieldset>
+ <fieldset class="buttons">
+  <label style="width:100%;text-align:left" for="methodReplaceCheckbox"><input type="checkbox" id="methodReplaceCheckbox" name="methodReplaceCheckbox"/>Replace Method? (See notes below)**</label>
  </fieldset>
  <fieldset class="buttons">
   <input type="submit" name="replace" value="Replace!"/>
   <a class="button" href="$viewLocation">Cancel</a>
  </fieldset>
-
+ <br />
  <p><strong>Search &amp; Replace: </strong>
- Please note that this feature is experimental! It uses java-based regular expressions. For an introduction, take a look <a href="http://java.sun.com/javase/6/docs/api/java/util/regex/Pattern.html" target="_new">here</a> (new window).
+ <p>Please note that this feature is experimental!</p>
+ <p> For regex replace (when checkbox is not selected), it uses <a href="http://java.sun.com/javase/6/docs/api/java/util/regex/Pattern.html" target="_new">java-based regular expressions</a>.
+ </p>
+ <p>
+  ** When you change a method or a scenario name and you want to reflect the changes across all your tests, you can select the checkbox. You can use existing line in wiki page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep in mind following.
+  <ul>
+   <li>This will keep the original parameters (if any) in the wiki which is good in most cases.</li>
+   <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having similar name. This will be desired in most cases. If you used same method in multiple classes, all of them will be impacted in the wiki pages.</li>
+   <li>It is a good idea to review the replaced lines locally (e.g. using Git) and undo any undesired changes before sharing/committing the tests. Most IDE has version control comparison and selective undo feature.</li>
+  </ul>
+ </p>
 </form>
 #end
 

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -39,7 +39,7 @@
   Reflect an updated method/scenario name across all existing test cases. To accomplish this, you can supply an existing line using that method from any test page. e.g. <strong>|Go to|url|</strong> can be changed to <strong>|Navigate to|url|</strong>. Keep the following in mind:
   <ul>
    <li>This will not change the parameters (if any) in the wiki.</li>
-   <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having similar name. This will be desired in most cases. If you used same method in multiple classes, all of them will be impacted in the wiki pages.</li>
+   <li>This will replace any line which evaluates to a method name including a line in script table, a scenario or a decision table having a similar name. This will be desired in most cases. But if you have multiple classes with the same method of which you only changed one this will not work as desired, since all calls are replaced.</li>
    <li>It is a good idea to review the replaced lines locally (e.g. using Git) and undo any undesired changes before sharing/committing the tests. Most IDE has version control comparison and selective undo feature.</li>
   </ul>
  </p>

--- a/src/fitnesse/responders/refactoring/SearchReplaceResponder.java
+++ b/src/fitnesse/responders/refactoring/SearchReplaceResponder.java
@@ -30,9 +30,8 @@ public class SearchReplaceResponder extends ResultResponder {
   protected PageFinder getPageFinder(TraversalListener<WikiPage> webOutputObserver) {
     String searchString = getSearchString();
     String replacementString = getReplacementString();
-    boolean isReplaceMethod = isReplaceMethod();
 
-    if (isReplaceMethod) {
+    if (isMethodReplace()) {
       MethodReplacingSearchObserver methodReplaceObserver =
         new MethodReplacingSearchObserver(searchString, replacementString);
 
@@ -46,8 +45,8 @@ public class SearchReplaceResponder extends ResultResponder {
     }
   }
 
-  private boolean isReplaceMethod() {
-    return request.hasInput("methodReplaceCheckbox");
+  private boolean isMethodReplace() {
+    return request.hasInput("isMethodReplace");
   }
 
   private String getReplacementString() {

--- a/src/fitnesse/responders/refactoring/SearchReplaceResponder.java
+++ b/src/fitnesse/responders/refactoring/SearchReplaceResponder.java
@@ -1,11 +1,13 @@
 package fitnesse.responders.refactoring;
 
-import fitnesse.wiki.refactoring.ContentReplacingSearchObserver;
-import fitnesse.wiki.search.PageFinder;
-import fitnesse.wiki.search.RegularExpressionWikiPageFinder;
 import fitnesse.components.TraversalListener;
 import fitnesse.responders.search.ResultResponder;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.refactoring.ContentReplacingSearchObserver;
+import fitnesse.wiki.refactoring.MethodReplacingSearchObserver;
+import fitnesse.wiki.search.MethodWikiPageFinder;
+import fitnesse.wiki.search.PageFinder;
+import fitnesse.wiki.search.RegularExpressionWikiPageFinder;
 
 public class SearchReplaceResponder extends ResultResponder {
 
@@ -21,19 +23,31 @@ public class SearchReplaceResponder extends ResultResponder {
   @Override
   protected String getTitle() {
     return String.format("Replacing matching content \"%s\" with content \"%s\"",
-        getSearchString(), getReplacementString());
+      getSearchString(), getReplacementString());
   }
 
   @Override
   protected PageFinder getPageFinder(TraversalListener<WikiPage> webOutputObserver) {
     String searchString = getSearchString();
     String replacementString = getReplacementString();
+    boolean isReplaceMethod = isReplaceMethod();
 
-    ContentReplacingSearchObserver contentReplaceObserver =
-            new ContentReplacingSearchObserver(searchString, replacementString);
+    if (isReplaceMethod) {
+      MethodReplacingSearchObserver methodReplaceObserver =
+        new MethodReplacingSearchObserver(searchString, replacementString);
 
-    return new RegularExpressionWikiPageFinder(searchString,
-            new SearchReplaceTraverser(contentReplaceObserver, webOutputObserver));
+      return new MethodWikiPageFinder(searchString,
+        new SearchReplaceTraverser(methodReplaceObserver, webOutputObserver));
+    } else {
+      ContentReplacingSearchObserver contentReplaceObserver =
+        new ContentReplacingSearchObserver(searchString, replacementString);
+      return new RegularExpressionWikiPageFinder(searchString,
+        new SearchReplaceTraverser(contentReplaceObserver, webOutputObserver));
+    }
+  }
+
+  private boolean isReplaceMethod() {
+    return request.hasInput("methodReplaceCheckbox");
   }
 
   private String getReplacementString() {

--- a/src/fitnesse/util/WikiPageLineProcessingUtil.java
+++ b/src/fitnesse/util/WikiPageLineProcessingUtil.java
@@ -1,0 +1,82 @@
+package fitnesse.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public class WikiPageLineProcessingUtil {
+
+  public static boolean isColumnSpecialWikiKeyWord(String stringPassed) {
+    stringPassed = stringPassed.trim();
+    return stringPassed.isEmpty() || stringPassed.startsWith("$") || stringPassed.equals("ensure") || stringPassed.equals("reject") || stringPassed.equals("check") || stringPassed.equals("check not") || stringPassed.equals("show") || stringPassed.equals("note");
+  }
+
+  public static boolean doesLineNeedExtraLastColumn(String stringPassed) {
+    String firstColumn = Arrays.asList(stringPassed.split("\\|")).get(1).trim();
+    return firstColumn.equals("check") || firstColumn.equals("check not");
+  }
+
+  public static String getLastColumn(String stringPassed) {
+    if (isValidLine(stringPassed)) {
+      List<String> allColumns = Arrays.asList(stringPassed.split("\\|"));
+      return allColumns.get(allColumns.size() - 1);
+    }
+    return "";
+  }
+
+  private static boolean isValidLine(String textPassed) {
+    return (textPassed.startsWith("|") && textPassed.trim().endsWith("|"));
+  }
+
+  public static String getMethodNameFromLine(String textPassed) {
+    String methodNameToReturn = "";
+    if (isValidLine(textPassed)) {
+      List<String> methodSplit = new ArrayList<>();
+      methodSplit.addAll(Arrays.asList(textPassed.split("\\|")));
+      methodSplit.remove(0);//First one is always empty. We can discard it.
+      String firstColumn = methodSplit.get(0);
+      int counter = !isColumnSpecialWikiKeyWord(firstColumn) ? 0 : 1;
+      boolean lineHasExtraColumn = doesLineNeedExtraLastColumn(textPassed);
+      for (int i = counter; i < methodSplit.size(); i += 2) {
+        //Ensure last column is not included in the method name.
+        if (lineHasExtraColumn && methodSplit.size() == (i + 1)) {
+        } else {
+          List<String> currentCellWords = Arrays.asList(methodSplit.get(i).trim().split(" "));
+          for (String currentCellWord : currentCellWords) {
+            if (!currentCellWord.trim().isEmpty()) {
+              methodNameToReturn += org.apache.commons.lang3.StringUtils.capitalize(currentCellWord.trim());
+            }
+          }
+        }
+      }
+      methodNameToReturn = StringUtils.uncapitalize(methodNameToReturn);
+    }
+    return methodNameToReturn;
+  }
+
+  public static LinkedHashMap<Integer, String> getRowColumnsExcludingKeywordInFirstColumnIfPresent(String currentLine) {
+    LinkedHashMap<Integer, String> allColumnsOfCurrentLine = new LinkedHashMap<>();
+    String remainingText = currentLine;
+    int currentIndexOfPipe = 1;
+    boolean isFirstColumnSpecialKey = true;
+    while (remainingText.contains("|")) {
+      int nextIndexOfPipe = currentLine.indexOf("|", currentIndexOfPipe);
+      String currentColumnText = currentLine.substring(currentIndexOfPipe, nextIndexOfPipe);
+      if (isFirstColumnSpecialKey && !isColumnSpecialWikiKeyWord(currentColumnText)) {
+        isFirstColumnSpecialKey = false;
+        allColumnsOfCurrentLine.put(currentIndexOfPipe, currentColumnText);
+      } else if (!isFirstColumnSpecialKey) {
+        allColumnsOfCurrentLine.put(currentIndexOfPipe, currentColumnText);
+      }
+      currentIndexOfPipe = nextIndexOfPipe + 1;
+      remainingText = currentLine.substring(nextIndexOfPipe + 1);
+    }
+    if (doesLineNeedExtraLastColumn(currentLine))
+      allColumnsOfCurrentLine.remove(allColumnsOfCurrentLine.size() - 1);
+    return allColumnsOfCurrentLine;
+  }
+
+}

--- a/src/fitnesse/wiki/refactoring/MethodReplacingSearchObserver.java
+++ b/src/fitnesse/wiki/refactoring/MethodReplacingSearchObserver.java
@@ -1,0 +1,80 @@
+package fitnesse.wiki.refactoring;
+
+import fitnesse.components.TraversalListener;
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+import static fitnesse.util.WikiPageLineProcessingUtil.*;
+
+public class MethodReplacingSearchObserver implements TraversalListener<WikiPage> {
+
+  private String searchMethodString;
+  private String replacingMethodString;
+
+  public MethodReplacingSearchObserver(String searchString, String replacement) {
+    this.searchMethodString = searchString;
+    this.replacingMethodString = replacement;
+  }
+
+  @Override
+  public void process(WikiPage page) {
+    PageData pageData = page.getData();
+
+    String content = pageData.getContent();
+    String[] lines = content.split(System.lineSeparator());
+    String newPageContent = "";
+    boolean isModified = false;
+    String targetMethod = getMethodNameFromLine(searchMethodString);
+    for (String eachLineOfFile : lines) {
+      if (!eachLineOfFile.startsWith("|") || !getMethodNameFromLine(eachLineOfFile).equals(targetMethod)) {
+        newPageContent += eachLineOfFile + System.lineSeparator();
+      } else {
+        isModified = true;
+        String modifiedLine = "";
+        LinkedHashMap<Integer, String> toBeReplacedText = getRowColumnsExcludingKeywordInFirstColumnIfPresent(eachLineOfFile);
+        Iterator<Integer> toBeReplacedKeys = toBeReplacedText.keySet().iterator();
+        LinkedHashMap<Integer, String> toReplaceText = getRowColumnsExcludingKeywordInFirstColumnIfPresent(replacingMethodString);
+        Iterator<Integer> toReplaceKeys = toReplaceText.keySet().iterator();
+        for (int i = 0; toBeReplacedKeys.hasNext() || toReplaceKeys.hasNext(); i++) {
+          int toBeReplacedIndex = toBeReplacedKeys.hasNext() ? toBeReplacedKeys.next() : -1;
+          int toReplaceIndex = toReplaceKeys.hasNext() ? toReplaceKeys.next() : -1;
+          modifiedLine = modifiedLine.isEmpty() ? eachLineOfFile.substring(0, toBeReplacedIndex - 1) : modifiedLine;
+          if (toBeReplacedIndex > 0 && toReplaceIndex > 0) {
+            if (i % 2 == 1) {
+              modifiedLine += "|" + eachLineOfFile.substring(toBeReplacedIndex, toBeReplacedIndex + toBeReplacedText.get(toBeReplacedIndex).length());
+            } else {
+              modifiedLine += "|" + toReplaceText.get(toReplaceIndex);
+            }
+          }
+          //Below case is when there are more columns in replacing text than in original text.
+          else if (toBeReplacedIndex == -1) {
+            //All remaining columns of replacing text should be appended.
+            modifiedLine += "|" + toReplaceText.get(toReplaceIndex);
+            while (toReplaceKeys.hasNext()) {
+              modifiedLine += "|" + toReplaceText.get(toReplaceKeys.next());
+            }
+            break;
+          }
+          //below case is when there are more columns in original text which need to be removed.
+          else if (toReplaceIndex == -1) {
+            modifiedLine += "|";
+            break;
+          }
+        }
+        if (doesLineNeedExtraLastColumn(eachLineOfFile)) {
+          modifiedLine += getLastColumn(eachLineOfFile);
+        }
+        modifiedLine = (!modifiedLine.isEmpty() && !modifiedLine.endsWith("|")) ? modifiedLine + "|" : modifiedLine;
+        newPageContent += modifiedLine + System.lineSeparator();
+      }
+    }
+    if (isModified) {
+      pageData.setContent(newPageContent);
+    }
+    page.commit(pageData);
+  }
+
+}

--- a/src/fitnesse/wiki/search/MethodWikiPageFinder.java
+++ b/src/fitnesse/wiki/search/MethodWikiPageFinder.java
@@ -1,0 +1,34 @@
+package fitnesse.wiki.search;
+
+import fitnesse.components.TraversalListener;
+import fitnesse.wiki.WikiPage;
+
+import static fitnesse.util.WikiPageLineProcessingUtil.getMethodNameFromLine;
+
+public class MethodWikiPageFinder extends WikiPageFinder {
+
+  private String methodToFind;
+
+  public MethodWikiPageFinder(String methodToFind, TraversalListener<? super WikiPage> observer) {
+    super(observer);
+    this.methodToFind = methodToFind;
+  }
+
+  @Override
+  protected boolean pageMatches(WikiPage page) {
+    String pageContent = page.getData().getContent();
+    String targetMethod = getMethodNameFromLine(this.methodToFind);
+    String[] contentLines = pageContent.split(System.lineSeparator());
+
+    //Both the inputs should follow the correct format
+    if (!methodToFind.startsWith("|") || !methodToFind.endsWith("|"))
+      return false;
+
+    for (String eachLine : contentLines) {
+      if (getMethodNameFromLine(eachLine).equals(targetMethod))
+        return true;
+    }
+    return false;
+  }
+
+}

--- a/test/fitnesse/responders/refactoring/SearchReplaceMethodResponderTest.java
+++ b/test/fitnesse/responders/refactoring/SearchReplaceMethodResponderTest.java
@@ -194,7 +194,7 @@ public class SearchReplaceMethodResponderTest extends ResponderTestCase {
   private String getResponseContentUsingSearchReplace(String searchString, String replacementString) throws Exception {
     request.addInput("searchString", searchString);
     request.addInput("replacementString", replacementString);
-    request.addInput("methodReplaceCheckbox", "true");
+    request.addInput("isMethodReplace", "true");
     Response response = responder.makeResponse(context, request);
     MockResponseSender sender = new MockResponseSender();
     sender.doSending(response);

--- a/test/fitnesse/responders/refactoring/SearchReplaceMethodResponderTest.java
+++ b/test/fitnesse/responders/refactoring/SearchReplaceMethodResponderTest.java
@@ -1,0 +1,204 @@
+package fitnesse.responders.refactoring;
+
+import fitnesse.Responder;
+import fitnesse.http.MockResponseSender;
+import fitnesse.http.Response;
+import fitnesse.responders.ResponderTestCase;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPagePath;
+import fitnesse.wiki.WikiPageUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class SearchReplaceMethodResponderTest extends ResponderTestCase {
+  private WikiPagePath pagePath;
+  private WikiPage somePage;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    pagePath = PathParser.parse("SomePage");
+    somePage = WikiPageUtil.addPage(root, pagePath, "|update with|param|");
+    request.setResource("SomePage");
+  }
+
+  @Override
+  protected Responder responderInstance() {
+    return new SearchReplaceResponder();
+  }
+
+  @Test
+  public void testSingleReplacementHtml() throws Exception {
+    String content = getResponseContentUsingSearchReplace("|update with|param|", "|updated with|param|");
+
+    assertThat(content, containsString("|updated with|param|"));
+    assertThat(content, containsString("SomePage"));
+  }
+
+  @Test
+  public void replacementsWithDifferentContentEvaluatedToSameMethodNoParam() throws Exception {
+
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage1"), "|update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage2"), "|updateNoParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage3"), "|Update      no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage4"), "|ensure|update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage5"), "|reject|update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage6"), "|check|update no param|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage7"), "|check not|update no param|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage8"), "|note|update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage9"), "| |update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage10"), "|show|update no param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage11"), "|$value=|update no param|");
+
+    String content = getResponseContentUsingSearchReplace("|update no param|", "|updated with no param|");
+
+    assertThat(content, containsString("ChildPage1"));
+    assertThat(content, containsString("ChildPage2"));
+    assertThat(content, containsString("ChildPage3"));
+    assertThat(content, containsString("ChildPage4"));
+    assertThat(content, containsString("ChildPage5"));
+    assertThat(content, containsString("ChildPage6"));
+    assertThat(content, containsString("ChildPage7"));
+    assertThat(content, containsString("ChildPage8"));
+    assertThat(content, containsString("ChildPage9"));
+    assertThat(content, containsString("ChildPage10"));
+    assertThat(content, containsString("ChildPage11"));
+  }
+
+  @Test
+  public void replacementsWithDifferentTextEvaluatedToSameMethodOneParam() throws Exception {
+
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage1"), "|update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage2"), "|update      with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage3"), "|ensure|update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage4"), "|reject|update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage5"), "|check|update with|param|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage6"), "|check not|update with|param|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage7"), "|note|update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage8"), "| |update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage9"), "|show|update with|param|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage10"), "|$value=|update with|param|");
+
+    String content = getResponseContentUsingSearchReplace("|update with|param|", "|updated with|param|");
+
+    assertThat(content, containsString("ChildPage1"));
+    assertThat(content, containsString("ChildPage2"));
+    assertThat(content, containsString("ChildPage3"));
+    assertThat(content, containsString("ChildPage4"));
+    assertThat(content, containsString("ChildPage5"));
+    assertThat(content, containsString("ChildPage6"));
+    assertThat(content, containsString("ChildPage7"));
+    assertThat(content, containsString("ChildPage8"));
+    assertThat(content, containsString("ChildPage9"));
+    assertThat(content, containsString("ChildPage10"));
+  }
+
+  @Test
+  public void replacementsWithDifferentTextEvaluatedToSameMethodTwoParams() throws Exception {
+
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage1"), "|update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage2"), "|update|param|value with|newParam|value|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage3"), "|update|param|value with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage4"), "|ensure|update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage5"), "|reject|update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage6"), "|check|update value|param|with value|newParam|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage7"), "|check not|update value|param|with value|newParam|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage8"), "|note|update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage9"), "| |update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage10"), "|show|update value|param|with value|newParam|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage11"), "|$value=|update value|param|with value|newParam|");
+
+    String content = getResponseContentUsingSearchReplace("|update value|param|with value|newParam|", "|updated value|param|with value|newParam|");
+
+    assertThat(content, containsString("ChildPage1"));
+    assertThat(content, containsString("ChildPage2"));
+    assertThat(content, containsString("ChildPage3"));
+    assertThat(content, containsString("ChildPage4"));
+    assertThat(content, containsString("ChildPage5"));
+    assertThat(content, containsString("ChildPage6"));
+    assertThat(content, containsString("ChildPage7"));
+    assertThat(content, containsString("ChildPage8"));
+    assertThat(content, containsString("ChildPage9"));
+    assertThat(content, containsString("ChildPage10"));
+    assertThat(content, containsString("ChildPage11"));
+  }
+
+  @Test
+  public void replacementsWithDifferentTextEvaluatedToSameMethodThreeParams() throws Exception {
+
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage1"), "|update value|param1|with value|param2|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage2"), "|update|param1|value with|param2|value and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage3"), "|update|param|value with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage4"), "|ensure|update value|param|with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage5"), "|reject|update value|param|with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage6"), "|check|update value|param|with value|newParam|and|param3|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage7"), "|check not|update value|param|with value|newParam|and|param3|someValue|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage8"), "|note|update value|param|with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage9"), "| |update value|param|with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage10"), "|show|update value|param|with value|newParam|and|param3|");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage11"), "|$value=|update value|param|with value|newParam|and|param3|");
+
+    String content = getResponseContentUsingSearchReplace("|update value|param|with value|newParam|and|param3|", "|updated value|param|with value|newParam|and|param3|");
+
+    assertThat(content, containsString("ChildPage1"));
+    assertThat(content, containsString("ChildPage2"));
+    assertThat(content, containsString("ChildPage3"));
+    assertThat(content, containsString("ChildPage4"));
+    assertThat(content, containsString("ChildPage5"));
+    assertThat(content, containsString("ChildPage6"));
+    assertThat(content, containsString("ChildPage7"));
+    assertThat(content, containsString("ChildPage8"));
+    assertThat(content, containsString("ChildPage9"));
+    assertThat(content, containsString("ChildPage10"));
+    assertThat(content, containsString("ChildPage11"));
+  }
+
+  @Test
+  public void onlyReplacedPagesAreListed() throws Exception {
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage"), "|Already update no param|");
+    String content = getResponseContentUsingSearchReplace("|update no param|", "|updated no param|");
+    assertThat(content, containsString("SomePage"));
+    assertThat(content, not(containsString("ChildPage")));
+  }
+
+  @Test
+  public void testReplacement() throws Exception {
+    getResponseContentUsingSearchReplace("|update with|", "|updated with|param|");
+    WikiPage page = root.getPageCrawler().getPage(pagePath);
+    assertThat(page.getData().getContent(), containsString("|updated with|param|"));
+    assertThat(page.getData().getContent(), not(containsString("|update with|param|")));
+  }
+
+  @Test
+  public void noPageMatched() throws Exception {
+    String content = getResponseContentUsingSearchReplace("|update with no|param|", "|updated with|param|");
+
+    assertThat(content, containsString("No pages matched your search criteria."));
+  }
+
+  @Test
+  public void onlySelectedPageAndChildrenAreSearched() throws Exception {
+    request.setResource("SomePage.ChildPage");
+    WikiPageUtil.addPage(somePage, PathParser.parse("ChildPage"), "|update with no param|");
+    String content = getResponseContentUsingSearchReplace("|update with no param|", "|updated with no param|");
+    assertThat(content, not(containsString("<a href=\"SomePage\">")));
+    assertThat(content, containsString("SomePage.ChildPage"));
+  }
+
+  private String getResponseContentUsingSearchReplace(String searchString, String replacementString) throws Exception {
+    request.addInput("searchString", searchString);
+    request.addInput("replacementString", replacementString);
+    request.addInput("methodReplaceCheckbox", "true");
+    Response response = responder.makeResponse(context, request);
+    MockResponseSender sender = new MockResponseSender();
+    sender.doSending(response);
+    return sender.sentData();
+  }
+
+}

--- a/test/fitnesse/util/WikiPageLineProcessingUtilTest.java
+++ b/test/fitnesse/util/WikiPageLineProcessingUtilTest.java
@@ -1,0 +1,80 @@
+package fitnesse.util;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class WikiPageLineProcessingUtilTest {
+
+  @Test
+  public void testColumnSpecialWiki() {
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("ensure"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("reject"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("check"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("check not"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("note"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("show"));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord(" "));
+    assertTrue(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("$value="));
+    assertFalse(WikiPageLineProcessingUtil.isColumnSpecialWikiKeyWord("not a keyword"));
+  }
+
+  @Test
+  public void testLineNeedsExtraLastColumn() {
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|ensure|keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|reject|keyword|"));
+    assertTrue(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|check|keyword|"));
+    assertTrue(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|check not|keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|note|keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|show|keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("| |keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|$value=|keyword|"));
+    assertFalse(WikiPageLineProcessingUtil.doesLineNeedExtraLastColumn("|not a |keyword|keyword"));
+  }
+
+  @Test
+  public void testGetLastColumn() {
+    assertEquals("", WikiPageLineProcessingUtil.getLastColumn("not valid line ensure|keyword"));
+    assertEquals(" ", WikiPageLineProcessingUtil.getLastColumn("|ensure|keyword| |"));
+    assertEquals("check value", WikiPageLineProcessingUtil.getLastColumn("|check|keyword|check value|"));
+    assertEquals("check not value", WikiPageLineProcessingUtil.getLastColumn("|check not|keyword|check not value|"));
+    assertEquals("keyword", WikiPageLineProcessingUtil.getLastColumn("|note|keyword|"));
+  }
+
+  @Test
+  public void testGetMethodNameFromLine() {
+    assertEquals("", WikiPageLineProcessingUtil.getMethodNameFromLine("not a valid line"));
+    assertEquals("noParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|no param|"));
+    assertEquals("noParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|$value=|no param|"));
+    assertEquals("noParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|show|no param|"));
+    assertEquals("noParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|ensure|no param|"));
+    assertEquals("noParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|reject|no           param      |"));
+    assertEquals("itHasOneParam", WikiPageLineProcessingUtil.getMethodNameFromLine("|check|it has one param|1|check value|"));
+    assertEquals("itHasAnd", WikiPageLineProcessingUtil.getMethodNameFromLine("|check not|it has|param1|and|param2|check not value|"));
+    assertEquals("itHas3ParamAndAnd", WikiPageLineProcessingUtil.getMethodNameFromLine("|note|it has 3 param|param1|and|param2|and|param3|"));
+    assertEquals("itHas3ParamAndAnd", WikiPageLineProcessingUtil.getMethodNameFromLine("||it has ||3 param and|param2|and|param3|"));
+  }
+
+  @Test
+  public void testGetRowColumnsExcludingKeywordInFirstColumnIfPresent() {
+    Map map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|a|b|c|");
+    assertEquals(3, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|ensure|a|b|c|");
+    assertEquals(3, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|reject|a|b|c|");
+    assertEquals(3, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|check|a|b|c|checkValue|");
+    assertEquals(4, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|check not|a|b|c|check not value|");
+    assertEquals(4, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|show|a|b|c|");
+    assertEquals(3, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("|note|a|b|c|");
+    assertEquals(3, map.size());
+    map = WikiPageLineProcessingUtil.getRowColumnsExcludingKeywordInFirstColumnIfPresent("||a|b|c|");
+    assertEquals(3, map.size());
+  }
+
+}

--- a/test/fitnesse/wiki/refactoring/MethodReplacingSearchObserverTest.java
+++ b/test/fitnesse/wiki/refactoring/MethodReplacingSearchObserverTest.java
@@ -1,0 +1,125 @@
+package fitnesse.wiki.refactoring;
+
+import fitnesse.wiki.PageData;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.fs.InMemoryPage;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class MethodReplacingSearchObserverTest {
+
+  private WikiPage wikiPage;
+  private MethodReplacingSearchObserver observer;
+
+  @Test
+  public void replacesPageContent() throws Exception {
+    wikiPage = createPageWithContent("|methodWith noParam|");
+    observer = simpleMethodReplacer();
+
+    observer.process(wikiPage);
+
+    assertThat(wikiPage, contentMatches("|method with no param|"));
+  }
+
+  private MethodReplacingSearchObserver simpleMethodReplacer() {
+    return new MethodReplacingSearchObserver(".*", "|method with no param|");
+  }
+
+  @Test
+  public void replacesPageContentWithGroups() throws Exception {
+
+    WikiPage wikiPage1 = createPageWithContent("|update no param|");
+    observer = new MethodReplacingSearchObserver("|update no param|", "|updated no param|");
+    observer.process(wikiPage1);
+    assertTrue(wikiPage1.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage2 = createPageWithContent("|Update      no param|");
+    observer = new MethodReplacingSearchObserver("|update no param|", "|updated no param|");
+    observer.process(wikiPage2);
+    assertTrue(wikiPage2.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage3 = createPageWithContent("|ensure|update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage3);
+    assertTrue(wikiPage3.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage4 = createPageWithContent("|reject|update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage4);
+    assertTrue(wikiPage4.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage5 = createPageWithContent("|check|update no param|someValue|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage5);
+    assertTrue(wikiPage5.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage6 = createPageWithContent("|check not|update no param|someValue|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage6);
+    assertTrue(wikiPage6.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage7 = createPageWithContent("|note|update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage7);
+    assertTrue(wikiPage7.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage8 = createPageWithContent("| |update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage8);
+    assertTrue(wikiPage8.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage9 = createPageWithContent("|show|update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage9);
+    assertTrue(wikiPage9.getData().getContent().contains("|updated no param|"));
+
+    WikiPage wikiPage10 = createPageWithContent("|$value=|update no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|updated no param|");
+    observer.process(wikiPage10);
+    assertTrue(wikiPage10.getData().getContent().contains("|updated no param|"));
+  }
+
+  @Test
+  public void replacesMultiLinedContent() throws Exception {
+    wikiPage = createPageWithContent("|update no param|" + System.lineSeparator() + "|$value=|update          no param|");
+    observer = new MethodReplacingSearchObserver("|updateNoParam|", "|Updated no param|");
+
+    observer.process(wikiPage);
+
+    assertTrue(wikiPage.getData().getContent().contains("|Updated no param|" + System.lineSeparator() + "|$value=|Updated no param|"));
+  }
+
+  private WikiPage createPageWithContent(String pageContent) throws Exception {
+    WikiPage wikiPage = InMemoryPage.makeRoot("wikiPage");
+    PageData pageData = wikiPage.getData();
+    pageData.setContent(pageContent);
+    wikiPage.commit(pageData);
+    return wikiPage;
+  }
+
+  private Matcher<WikiPage> contentMatches(final String simpleReplacement) {
+    return new TypeSafeMatcher<WikiPage>() {
+
+      @Override
+      public boolean matchesSafely(WikiPage wikiPage) {
+        try {
+          return wikiPage.getData().getContent().matches(String.format(".*%s.*", simpleReplacement));
+        } catch (Exception e) {
+          return false;
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("content matching ").appendValue(simpleReplacement);
+      }
+
+    };
+  }
+
+}

--- a/test/fitnesse/wiki/search/MethodWikiPageFinderTest.java
+++ b/test/fitnesse/wiki/search/MethodWikiPageFinderTest.java
@@ -1,0 +1,140 @@
+package fitnesse.wiki.search;
+
+import fitnesse.wiki.HitCollector;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageUtil;
+import fitnesse.wiki.fs.InMemoryPage;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MethodWikiPageFinderTest {
+
+  private WikiPage root;
+  private WikiPage pageOne;
+  private WikiPage childPage1;
+  private WikiPage childPage2;
+
+  HitCollector hits = new HitCollector();
+  private WikiPageFinder pageFinder;
+
+  @Before
+  public void setUp() {
+    root = InMemoryPage.makeRoot("RooT");
+    pageOne = WikiPageUtil.addPage(root, PathParser.parse("PageOne"), "|method with no param|");
+    childPage1 = WikiPageUtil.addPage(root, PathParser.parse("PageOne.PageOneChild1"),
+      "|check|method with one param|p1|");
+    childPage2 = WikiPageUtil.addPage(root, PathParser.parse("PageOne.PageOneChild2"),
+      "|method     with    no    param|" + System.lineSeparator() + "^PageOneChild");
+  }
+
+  @Test
+  public void searcherNoMethodMatch() {
+    pageFinder = pageFinder("no");
+    pageFinder.search(root);
+    hits.assertPagesFound();
+  }
+
+  @Test
+  public void singlePageMatches() {
+    pageFinder = pageFinder("|method with one param||");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void multiplePageMatch() {
+    pageFinder = pageFinder("|method with no param|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentTextFormatting() {
+    pageFinder = pageFinder("|methodWithNoParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentTextFormatting2() {
+    pageFinder = pageFinder("|method with one |p1|param|");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void matchWithDifferentTextFormatting3() {
+    pageFinder = pageFinder("|method |p1|with one param|");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void matchWithDifferentTextFormatting4() {
+    pageFinder = pageFinder("|method       with       one |    p1|    param|");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordEnsure() {
+    pageFinder = pageFinder("|ensure|method withNoParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordReject() {
+    pageFinder = pageFinder("|reject|methodWith noParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordCheck() {
+    pageFinder = pageFinder("|check|method with one param|p1|checkValue|");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordCheckNot() {
+    pageFinder = pageFinder("|check not|method with one param|p1|checkNotValue|");
+    pageFinder.search(root);
+    hits.assertPagesFound(childPage1.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordShow() {
+    pageFinder = pageFinder("|show|methodWithNoParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordNote() {
+    pageFinder = pageFinder("|note|methodWithNoParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithDifferentKeywordEmpty() {
+    pageFinder = pageFinder("||methodWithNoParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  @Test
+  public void matchWithAssignedValue() {
+    pageFinder = pageFinder("|$value=|method with noParam|");
+    pageFinder.search(root);
+    hits.assertPagesFound(pageOne.getName(), childPage2.getName());
+  }
+
+  private WikiPageFinder pageFinder(String searchText) {
+    return new MethodWikiPageFinder(searchText, hits);
+  }
+
+}


### PR DESCRIPTION
If we want to change method or scenario name in tests, we can use this feature. This will also take care of existing parameters without impacting them. Please refer to below is example.

![FitnesseReplaceWindow](https://user-images.githubusercontent.com/9042580/206886077-6173da55-53ec-4625-a064-c9107d991d60.png)

![FitnesseSerchReplace](https://user-images.githubusercontent.com/9042580/206886079-8fd801e4-de3b-42b5-8d01-b98c14345140.png)
