### PR TITLE
Fix incorrect character count in SlimSerializer with surrogate pairs.

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -2,6 +2,7 @@
  * Add date and page history link to XML responses. ([[1396][https://github.com/unclebob/fitnesse/issues/1396]])
  * Search and replace method/scenario names with new name. ([[1403][https://github.com/unclebob/fitnesse/pull/1403]])
  * Search method or scenario in pages. ([[1409][https://github.com/unclebob/fitnesse/pull/1409]])
+ * When serializing Slim streams, count surrogate pairs as a single character in character counts.
 
 !2 20221219
  * Add a new optional command line parameter to specify the maximum number of workers to use for handling incoming requests.

--- a/src/fitnesse/slim/protocol/SlimSerializer.java
+++ b/src/fitnesse/slim/protocol/SlimSerializer.java
@@ -34,7 +34,7 @@ public class SlimSerializer {
 
     for (Object o : list) {
       String s = marshalObjectToString(o);
-      appendLength(s.length());
+      appendLength(s.codePointCount(0, s.length()));
       appendString(s);
     }
     result.append(']');

--- a/test/fitnesse/slim/protocol/SlimSerializerTest.java
+++ b/test/fitnesse/slim/protocol/SlimSerializerTest.java
@@ -31,6 +31,12 @@ public class SlimSerializerTest {
   }
 
   @Test
+  public void oneItemListSerializeWithSurrogatePair() throws Exception {
+    list.add("\ud802\udd00 is only one character.");
+    assertEquals("[000001:000024:\ud802\udd00 is only one character.:]", SlimSerializer.serialize(list));
+  }
+
+  @Test
   public void twoItemListSerialize() throws Exception {
     list.add("hello");
     list.add("world");


### PR DESCRIPTION
When serializing Slim streams, count surrogate pairs as a single character in character counts.

This prevents a crash in CSlim that occurs when the number of characters specified exceeds the number of characters present.