### PR TITLE
Refactored how a cell displays when using ignore functionality

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 Pending Changes
+ * Fixed issue where a cells original value was overwritten when ignoring rest of a script table or page
  * Add date and page history link to XML responses. ([[1396][https://github.com/unclebob/fitnesse/issues/1396]])
  * Search and replace method/scenario names with new name. ([[1403][https://github.com/unclebob/fitnesse/pull/1403]])
  * Search method or scenario in pages. ([[1409][https://github.com/unclebob/fitnesse/pull/1409]])

--- a/src/fitnesse/testsystems/slim/HtmlTable.java
+++ b/src/fitnesse/testsystems/slim/HtmlTable.java
@@ -450,6 +450,9 @@ public class HtmlTable implements Table {
         case IGNORE:
           // IGNORE + does not count === Test Not Run
           if (testResult.doesCount()) {
+            if(testResult.getMessage() != null){
+              return String.format("%s <span class=\"ignore\">%s</span>", originalContent, message);
+            }
             return String.format("<span class=\"ignore\">%s</span>", message);
           } else {
             return String.format("%s <span class=\"ignore\">%s</span>", originalContent, message);

--- a/src/fitnesse/testsystems/slim/HtmlTable.java
+++ b/src/fitnesse/testsystems/slim/HtmlTable.java
@@ -450,7 +450,7 @@ public class HtmlTable implements Table {
         case IGNORE:
           // IGNORE + does not count === Test Not Run
           if (testResult.doesCount()) {
-            if(testResult.getMessage() != null){
+            if (testResult.getMessage() != null) {
               return String.format("%s <span class=\"ignore\">%s</span>", originalContent, message);
             }
             return String.format("<span class=\"ignore\">%s</span>", message);

--- a/test/fitnesse/testsystems/slim/HtmlTableTest.java
+++ b/test/fitnesse/testsystems/slim/HtmlTableTest.java
@@ -133,7 +133,7 @@ public class HtmlTableTest {
 
     cell.setTestResult(SlimTestResult.ignore("a message"));
 
-    assertThat(cell.formatTestResult(), is("<span class=\"ignore\">a message</span>"));
+    assertThat(cell.formatTestResult(), is("original content <span class=\"ignore\">a message</span>"));
   }
 
   private HtmlTable getDummyTable() {


### PR DESCRIPTION
Now it will show the original value along with 'Test Not Run'.

See below original issue where 'Test not run' overwrite original value:
![image](https://user-images.githubusercontent.com/20017348/229079673-b9123177-be72-48d1-ad46-9022d61d32ba.png)


Now with this code change it will show the original value also:
![image](https://user-images.githubusercontent.com/20017348/229079912-7541fae0-defb-4eda-9321-42299b2cc4fb.png)
