### PR TITLE
If verbose via slim.flags -v, then popup window that shows slim instructions.

### DIFF
--- a/src/fitnesse/slim/ListExecutor.java
+++ b/src/fitnesse/slim/ListExecutor.java
@@ -2,14 +2,13 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
-import fitnesse.slim.instructions.Instruction;
-import fitnesse.slim.instructions.InstructionFactory;
-import fitnesse.slim.instructions.InstructionResult;
+import fitnesse.slim.instructions.*;
+import util.*;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
-import static java.util.Arrays.asList;
+import static java.util.Arrays.*;
 
 /**
  * executes a list of SLIM statements, and returns a list of return values.
@@ -18,6 +17,7 @@ public class ListExecutor {
   private StatementExecutorInterface executor;
   private NameTranslator methodNameTranslator;
   private boolean verbose;
+  private static LogView logView = null;
 
   public ListExecutor(SlimFactory slimFactory) {
     this(false, slimFactory);
@@ -63,6 +63,13 @@ public class ListExecutor {
   }
 
   private class LoggingExecutive extends Executive {
+    private static final String imgPath = "fitnesse_dbg.png";
+
+    public LoggingExecutive() {
+      if(logView==null) {
+        logView = new LogView("slim instructions", LogView.getImageIconFromPath(imgPath));
+      }
+    }
     @Override
     public void prepareToExecute() {
       verboseMessage("!1 Instructions");
@@ -92,6 +99,9 @@ public class ListExecutor {
   }
 
   private void verboseMessage(Object message) {
-    if (verbose) System.out.println(message);
+    if (verbose) {
+      System.out.println(message);
+      logView.append(message + "\n");
+    }
   }
 }

--- a/src/fitnesse/slim/ListExecutor.java
+++ b/src/fitnesse/slim/ListExecutor.java
@@ -2,13 +2,15 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim;
 
-import fitnesse.slim.instructions.*;
-import util.*;
+import fitnesse.slim.instructions.Instruction;
+import fitnesse.slim.instructions.InstructionFactory;
+import fitnesse.slim.instructions.InstructionResult;
+import util.LogView;
 
 import java.util.ArrayList;
-import java.util.*;
+import java.util.List;
 
-import static java.util.Arrays.*;
+import static java.util.Arrays.asList;
 
 /**
  * executes a list of SLIM statements, and returns a list of return values.

--- a/src/util/LogView.java
+++ b/src/util/LogView.java
@@ -3,9 +3,16 @@ package util;
 
 // https://stackoverflow.com/questions/21682761/reading-a-log-file-and-displaying-it-in-jtextarea
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.*;
+import javax.swing.ImageIcon;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 public class LogView {
 

--- a/src/util/LogView.java
+++ b/src/util/LogView.java
@@ -1,0 +1,81 @@
+package util;
+
+
+// https://stackoverflow.com/questions/21682761/reading-a-log-file-and-displaying-it-in-jtextarea
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class LogView {
+
+  private JDialog dialog;
+  private JTextArea textArea;
+  private final String title;
+  private final ImageIcon imageIcon;
+  private boolean isClosing;
+  private boolean isClosed;
+
+  public LogView(String title, ImageIcon imageIcon) {
+    this.title = title;
+    this.imageIcon = imageIcon;
+    SwingUtilities.invokeLater(new GUIRunnable());
+  }
+  public void append(final String text) {
+    SwingUtilities.invokeLater(new Runnable() {
+      public void run() {
+        if(isClosed || isClosing) {
+          return;
+        }
+        textArea.append(text);
+      }
+    });
+  }
+  public void dispose() {
+    SwingUtilities.invokeLater(new Runnable() {
+      public void run() {
+        if(isClosed || isClosing) {
+          return;
+        }
+        dialog.dispose();
+      }
+    });
+  }
+
+  private class GUIRunnable implements Runnable {
+    public void run() {
+      isClosing = false;
+      isClosed = false;
+      textArea = new JTextArea(25, 60);
+      dialog = new JDialog((Window)null, title);
+      if(imageIcon != null) {
+        dialog.setIconImage(imageIcon.getImage());
+      }
+      dialog.addWindowListener(new WindowAdapter() {
+        public void windowClosing(WindowEvent windowEvent) {
+          LogView.this.isClosing = true;
+        }
+        public void windowClosed(WindowEvent windowEvent) {
+          LogView.this.isClosed = true;
+        }
+      });
+      JScrollPane scrollPane = new JScrollPane(textArea);
+      new SmartScroller(scrollPane, SmartScroller.VERTICAL, SmartScroller.END);
+      dialog.add(scrollPane, BorderLayout.CENTER);
+      dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+      dialog.pack();
+      dialog.setLocationByPlatform(true);
+      dialog.setVisible(true);
+    }
+  }
+  public static ImageIcon getImageIconFromPath(String imgPath) {
+    ImageIcon imageIcon = null;
+    java.net.URL imgURL = LogView.class.getClassLoader().getResource(imgPath);
+    if (imgURL != null) {
+      imageIcon = new ImageIcon(imgURL);
+    } else {
+      System.err.println("Couldn't find icon resource: " + imgPath);
+    }
+    return imageIcon;
+  }
+}

--- a/src/util/SmartScroller.java
+++ b/src/util/SmartScroller.java
@@ -23,9 +23,14 @@
 package util;
 
 import java.awt.Component;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.text.*;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import javax.swing.BoundedRangeModel;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.JTextComponent;
 
 // https://github.com/tips4java/tips4java/blob/main/source/SmartScroller.java
 

--- a/src/util/SmartScroller.java
+++ b/src/util/SmartScroller.java
@@ -1,0 +1,198 @@
+//MIT License
+//
+//  Copyright (c) 2023 Rob Camick
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+package util;
+
+import java.awt.Component;
+import java.awt.event.*;
+import javax.swing.*;
+import javax.swing.text.*;
+
+// https://github.com/tips4java/tips4java/blob/main/source/SmartScroller.java
+
+/**
+ *  The SmartScroller will attempt to keep the viewport positioned based on
+ *  the users interaction with the scrollbar. The normal behaviour is to keep
+ *  the viewport positioned to see new data as it is dynamically added.
+ *
+ *  Assuming vertical scrolling and data is added to the bottom:
+ *
+ *  - when the viewport is at the bottom and new data is added,
+ *    then automatically scroll the viewport to the bottom
+ *  - when the viewport is not at the bottom and new data is added,
+ *    then do nothing with the viewport
+ *
+ *  Assuming vertical scrolling and data is added to the top:
+ *
+ *  - when the viewport is at the top and new data is added,
+ *    then do nothing with the viewport
+ *  - when the viewport is not at the top and new data is added, then adjust
+ *    the viewport to the relative position it was at before the data was added
+ *
+ *  Similiar logic would apply for horizontal scrolling.
+ */
+public class SmartScroller implements AdjustmentListener
+{
+  public final static int HORIZONTAL = 0;
+  public final static int VERTICAL = 1;
+
+  public final static int START = 0;
+  public final static int END = 1;
+
+  private int viewportPosition;
+
+  private JScrollBar scrollBar;
+  private boolean adjustScrollBar = true;
+
+  private int previousValue = -1;
+  private int previousMaximum = -1;
+
+  /**
+   *  Convenience constructor.
+   *  Scroll direction is VERTICAL and viewport position is at the END.
+   *
+   *  @param scrollPane the scroll pane to monitor
+   */
+  public SmartScroller(JScrollPane scrollPane)
+  {
+    this(scrollPane, VERTICAL, END);
+  }
+
+  /**
+   *  Convenience constructor.
+   *  Scroll direction is VERTICAL.
+   *
+   *  @param scrollPane the scroll pane to monitor
+   *  @param viewportPosition valid values are START and END
+   */
+  public SmartScroller(JScrollPane scrollPane, int viewportPosition)
+  {
+    this(scrollPane, VERTICAL, viewportPosition);
+  }
+
+  /**
+   *  Specify how the SmartScroller will function.
+   *
+   *  @param scrollPane the scroll pane to monitor
+   *  @param scrollDirection indicates which JScrollBar to monitor.
+   *                         Valid values are HORIZONTAL and VERTICAL.
+   *  @param viewportPosition indicates where the viewport will normally be
+   *                          positioned as data is added.
+   *                          Valid values are START and END
+   */
+  public SmartScroller(JScrollPane scrollPane, int scrollDirection, int viewportPosition)
+  {
+    if (scrollDirection != HORIZONTAL
+      &&  scrollDirection != VERTICAL)
+      throw new IllegalArgumentException("invalid scroll direction specified");
+
+    if (viewportPosition != START
+      &&  viewportPosition != END)
+      throw new IllegalArgumentException("invalid viewport position specified");
+
+    this.viewportPosition = viewportPosition;
+
+    if (scrollDirection == HORIZONTAL)
+      scrollBar = scrollPane.getHorizontalScrollBar();
+    else
+      scrollBar = scrollPane.getVerticalScrollBar();
+
+    scrollBar.addAdjustmentListener( this );
+
+    //  Turn off automatic scrolling for text components
+
+    Component view = scrollPane.getViewport().getView();
+
+    if (view instanceof JTextComponent)
+    {
+      JTextComponent textComponent = (JTextComponent)view;
+      DefaultCaret caret = (DefaultCaret)textComponent.getCaret();
+      caret.setUpdatePolicy(DefaultCaret.NEVER_UPDATE);
+    }
+  }
+
+  @Override
+  public void adjustmentValueChanged(final AdjustmentEvent e)
+  {
+    SwingUtilities.invokeLater(new Runnable()
+    {
+      public void run()
+      {
+        checkScrollBar(e);
+      }
+    });
+  }
+
+  /*
+   *  Analyze every adjustment event to determine when the viewport
+   *  needs to be repositioned.
+   */
+  private void checkScrollBar(AdjustmentEvent e)
+  {
+    //  The scroll bar listModel contains information needed to determine
+    //  whether the viewport should be repositioned or not.
+
+    JScrollBar scrollBar = (JScrollBar)e.getSource();
+    BoundedRangeModel listModel = scrollBar.getModel();
+    int value = listModel.getValue();
+    int extent = listModel.getExtent();
+    int maximum = listModel.getMaximum();
+
+    boolean valueChanged = previousValue != value;
+    boolean maximumChanged = previousMaximum != maximum;
+
+    //  Check if the user has manually repositioned the scrollbar
+
+    if (valueChanged && !maximumChanged)
+    {
+      if (viewportPosition == START)
+        adjustScrollBar = value != 0;
+      else
+        adjustScrollBar = value + extent >= maximum;
+    }
+
+    //  Reset the "value" so we can reposition the viewport and
+    //  distinguish between a user scroll and a program scroll.
+    //  (ie. valueChanged will be false on a program scroll)
+
+    if (adjustScrollBar && viewportPosition == END)
+    {
+      //  Scroll the viewport to the end.
+      scrollBar.removeAdjustmentListener( this );
+      value = maximum - extent;
+      scrollBar.setValue( value );
+      scrollBar.addAdjustmentListener( this );
+    }
+
+    if (adjustScrollBar && viewportPosition == START)
+    {
+      //  Keep the viewport at the same relative viewportPosition
+      scrollBar.removeAdjustmentListener( this );
+      value = value + maximum - previousMaximum;
+      scrollBar.setValue( value );
+      scrollBar.addAdjustmentListener( this );
+    }
+
+    previousValue = value;
+    previousMaximum = maximum;
+  }
+}

--- a/test/util/LogViewTest.java
+++ b/test/util/LogViewTest.java
@@ -1,6 +1,6 @@
 package util;
 
-import javax.swing.*;
+import javax.swing.JOptionPane;
 
 public class LogViewTest {
 

--- a/test/util/LogViewTest.java
+++ b/test/util/LogViewTest.java
@@ -1,0 +1,25 @@
+package util;
+
+import javax.swing.*;
+
+public class LogViewTest {
+
+  public static void main(String[] args) {
+    String line = "Live hoogwater: Nachtelijke controlerondes in Hoorn uit vrees voor gevolgen hoge waterstand Markermeer in combinatie met harde wind ";
+
+    LogView view = new LogView("LogViewTest", null);
+
+    for(int i=0; i<1000; ++i) {
+      view.append("" + i + ": " + line + "\n");
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    JOptionPane.showConfirmDialog(null, "That was it.");
+
+    view.dispose();
+  }
+}


### PR DESCRIPTION
If slim verbose is enabled, then popup Swing window that shows slim instructions as they are executed.
Enabling verbose is either via
!define slim.flags {-v}
or via
<url to test script>?test&slim.flags=-v

The slim.flags -v option is an existing option. Up until now it only wrote the slim instructions to stdout, and they were shown in Execution Log after the script finished.
Maybe its better to have a separate slim.flags option, for example  -slimview , to show the Swing window.
Maybe its better to have a SlimListener interface, and static method ListExecutor.addSlimListener , to not have Swing code called directly from within ListExecutor.
I'm happy to receive any feedback on this.