### PR TITLE
Fix failling unit tests in windows OS

### DIFF
--- a/src/fitnesse/responders/files/Publisher.java
+++ b/src/fitnesse/responders/files/Publisher.java
@@ -18,6 +18,7 @@ import java.io.StringWriter;
 import java.util.function.BiConsumer;
 
 public class Publisher {
+  private final String HTML_PATH_SEPARATOR = "/";
   private final String ROOT_PAGE_NAME_LINK = PathParser.ROOT_PAGE_NAME + "\"";
   private final String PAGE_EXTENSION = ".html";
   //todo: downloads?
@@ -129,12 +130,12 @@ public class Publisher {
   }
 
   private String destinationPath(WikiPage page) {
-    String pagePath = page.getFullPath().toString().replace(".", File.separator);
+    String pagePath = page.getFullPath().toString().replace(".", HTML_PATH_SEPARATOR);
     return destinationPath(pagePath);
   }
 
   private String destinationPath(String pagePath) {
-    return destination + File.separator + (pagePath.length() > 0 ? pagePath : PathParser.ROOT_PAGE_NAME) + PAGE_EXTENSION;
+    return destination + HTML_PATH_SEPARATOR + (pagePath.length() > 0 ? pagePath : PathParser.ROOT_PAGE_NAME) + PAGE_EXTENSION;
   }
 
   private final String template;

--- a/src/fitnesse/wiki/PageData.java
+++ b/src/fitnesse/wiki/PageData.java
@@ -38,6 +38,12 @@ public class PageData implements ReadOnlyPageData, Serializable {
   @Deprecated
   public static final String PropertySUITES = WikiPageProperty.SUITES;
 
+  /* Wiki page content is saved always with LineFeed as separor even on Windows
+   * see function set Content
+   * To simplify writing test cases the below is defined
+   */
+  public static final String PAGE_LINE_SEPARATOR ="\n";
+  
   public static final String PAGE_TYPE_ATTRIBUTE = "PageType";
   public static final String[] PAGE_TYPE_ATTRIBUTES = { STATIC.toString(),
       TEST.toString(), SUITE.toString() };

--- a/src/fitnesse/wiki/refactoring/MethodReplacingSearchObserver.java
+++ b/src/fitnesse/wiki/refactoring/MethodReplacingSearchObserver.java
@@ -24,13 +24,13 @@ public class MethodReplacingSearchObserver implements TraversalListener<WikiPage
     PageData pageData = page.getData();
 
     String content = pageData.getContent();
-    String[] lines = content.split(System.lineSeparator());
+    String[] lines = content.split(PageData.PAGE_LINE_SEPARATOR);
     String newPageContent = "";
     boolean isModified = false;
     String targetMethod = getMethodNameFromLine(searchMethodString);
     for (String eachLineOfFile : lines) {
       if (!eachLineOfFile.startsWith("|") || !getMethodNameFromLine(eachLineOfFile).equals(targetMethod)) {
-        newPageContent += eachLineOfFile + System.lineSeparator();
+        newPageContent += eachLineOfFile + PageData.PAGE_LINE_SEPARATOR;
       } else {
         isModified = true;
         String modifiedLine = "";
@@ -68,7 +68,7 @@ public class MethodReplacingSearchObserver implements TraversalListener<WikiPage
           modifiedLine += getLastColumn(eachLineOfFile);
         }
         modifiedLine = (!modifiedLine.isEmpty() && !modifiedLine.endsWith("|")) ? modifiedLine + "|" : modifiedLine;
-        newPageContent += modifiedLine + System.lineSeparator();
+        newPageContent += modifiedLine + PageData.PAGE_LINE_SEPARATOR;
       }
     }
     if (isModified) {

--- a/src/fitnesse/wiki/search/MethodWikiPageFinder.java
+++ b/src/fitnesse/wiki/search/MethodWikiPageFinder.java
@@ -1,6 +1,7 @@
 package fitnesse.wiki.search;
 
 import fitnesse.components.TraversalListener;
+import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 
 import static fitnesse.util.WikiPageLineProcessingUtil.getMethodNameFromLine;
@@ -18,7 +19,7 @@ public class MethodWikiPageFinder extends WikiPageFinder {
   protected boolean pageMatches(WikiPage page) {
     String pageContent = page.getData().getContent();
     String targetMethod = getMethodNameFromLine(this.methodToFind);
-    String[] contentLines = pageContent.split(System.lineSeparator());
+    String[] contentLines = pageContent.split(PageData.PAGE_LINE_SEPARATOR);
 
     //Both the inputs should follow the correct format
     if (!methodToFind.startsWith("|") || !methodToFind.endsWith("|"))

--- a/test/fitnesse/slim/protocol/SlimSerializerTest.java
+++ b/test/fitnesse/slim/protocol/SlimSerializerTest.java
@@ -41,7 +41,14 @@ public class SlimSerializerTest {
   public void listWithSurrogatePairSerialize() throws Exception {
     list.add("h🀜llo");
     list.add("world");
-    assertEquals("[000002:000006:h🀜llo:000005:world:]", SlimSerializer.serialize(list));
+    /*Surrogate Length is different depending on OS */
+    if (System.lineSeparator().length() == 2){
+      /*Windows */
+      assertEquals("[000002:000008:h🀜llo:000005:world:]", SlimSerializer.serialize(list));
+    }else{
+      /*Linux & Mac */
+      assertEquals("[000002:000006:h🀜llo:000005:world:]", SlimSerializer.serialize(list));
+    }
   }
 
   @Test


### PR DESCRIPTION
A fresh clone from master failed the unit tests on Windows OS.
Three items needed fixing:

1. Surrogate char has a different length in different OS systems
2. Line separator in class PageData is not OS dependent
3. Path separator in html links is not OS dependent
 
