### PR TITLE
HTTP Basic Authentication: Don't fail on colons (":") in passwords

### DIFF
--- a/src/fitnesse/http/Request.java
+++ b/src/fitnesse/http/Request.java
@@ -331,7 +331,8 @@ public class Request {
     if (hasHeader("Authorization")) {
       String authHeader = getHeader("Authorization");
       String userpass = getUserpass(authHeader);
-      String[] values = userpass.split(":");
+      // limit=2 in order to stop splitting after 1st colon. Following colons are part of the password.
+      String[] values = userpass.split(":", 2);
       if (values.length == 2) {
         authorizationUsername = values[0];
         authorizationPassword = values[1];

--- a/test/fitnesse/http/RequestTest.java
+++ b/test/fitnesse/http/RequestTest.java
@@ -403,6 +403,17 @@ public class RequestTest {
   }
 
   @Test
+  public void testCanGetCredentialsWithColonsInPassword() throws Exception {
+    appendToMessage("GET /abc?something HTTP/1.1\r\n");
+    appendToMessage("Authorization: Basic QWxhZGRpbjpvcGVuOnNlc2FtZTpub3c=\r\n");
+    appendToMessage("\r\n");
+    parseMessage();
+    request.getCredentials();
+    assertEquals("Aladdin", request.getAuthorizationUsername());
+    assertEquals("open:sesame:now", request.getAuthorizationPassword());
+  }
+
+  @Test
   public void testDoenstChokeOnMissingPassword() throws Exception {
     appendToMessage("GET /abc?something HTTP/1.1\r\n");
     appendToMessage("Authorization: Basic " + Base64.encode("Aladin") + "\r\n");


### PR DESCRIPTION
`fitnesse.http.Request#getCredentials()` fails to split the basic authentication header value correctly if the password contains one or more colons (":"). The splitting has to stop after the 1st colon separating user-id and password. Following colons are part of the password.

See:
*  https://www.rfc-editor.org/rfc/rfc7617.html page 4
> Furthermore, a user-id containing a colon character is invalid, as
> the first colon in a user-pass string separates user-id and password
> from one another; text after the first colon is part of the password.

* https://stackoverflow.com/a/28115727