### PR TITLE
HTTP Basic Authentication: Decode Base64 to UTF-8

### DIFF
--- a/src/fitnesse/util/Base64.java
+++ b/src/fitnesse/util/Base64.java
@@ -20,8 +20,10 @@ public class Base64 {
     base64Value[pad] = 0;
   }}
 
-  public static String decode(String value) throws UnsupportedEncodingException {
-    return new String(decode(value.getBytes(FileUtil.CHARENCODING)));
+  public static String decode(String base64) throws UnsupportedEncodingException {
+    // The INPUT's charset is irrelevant because Base64 is US-ASCII which is compatible to any charset
+    // The OUTPUT of decode() will most likely be UTF-8 as most browsers encode basic auth in UTF-8 now
+    return new String(decode(base64.getBytes()), FileUtil.CHARENCODING);
   }
 
   public static byte[] decode(byte[] bytes) {

--- a/test/fitnesse/http/RequestTest.java
+++ b/test/fitnesse/http/RequestTest.java
@@ -403,6 +403,22 @@ public class RequestTest {
   }
 
   @Test
+  public void testCanGetCredentialsWithNonASCII() throws Exception {
+    appendToMessage("GET /abc?something HTTP/1.1\r\n");
+    appendToMessage("Authorization: Basic w4Rsw6JkZMOtbjrDtnDDqG4gc8Oqw5/DpG3DqSDDvHJn4oKsbnRsw78=\r\n");
+    appendToMessage("\r\n");
+    parseMessage();
+    request.getCredentials();
+    // Unicode Escape converted by https://dencode.com/string/unicode-escape
+    assertEquals(
+      "\u00C4l\u00E2dd\u00EDn",   // Älâddín
+      request.getAuthorizationUsername());
+    assertEquals(
+      "\u00F6p\u00E8n s\u00EA\u00DF\u00E4m\u00E9 \u00FCrg\u20ACntl\u00FF",   // öpèn sêßämé ürg€ntlÿ
+      request.getAuthorizationPassword());
+  }
+
+  @Test
   public void testDoenstChokeOnMissingPassword() throws Exception {
     appendToMessage("GET /abc?something HTTP/1.1\r\n");
     appendToMessage("Authorization: Basic " + Base64.encode("Aladin") + "\r\n");

--- a/test/fitnesse/util/Base64Test.java
+++ b/test/fitnesse/util/Base64Test.java
@@ -20,6 +20,7 @@ package fitnesse.util;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import java.nio.charset.StandardCharsets;
 
 public class Base64Test {
 
@@ -97,8 +98,26 @@ public class Base64Test {
 
   @Test
   public void testDecodeBinary() throws Exception {
-    assertEquals(Base64.decode("////"), new String(new byte [] { -1,-1,-1 }));
-    assertEquals(Base64.decode("WqVapVql"), new String(new byte [] { 90,-91,90,-91,90,-91 }));
+    assertEquals(
+      new String(new byte [] { -1,-1,-1 }, StandardCharsets.UTF_8),
+      Base64.decode("////"));
+    assertEquals(
+      new String(new byte [] { 90,-91,90,-91,90,-91 }, StandardCharsets.UTF_8),
+      Base64.decode("WqVapVql"));  // "Z¥Z¥Z¥" as ISO-8859-1 input converted to Base64
+    assertEquals(
+      "\u005A\u00A5\u005A\u00A5\u005A\u00A5",
+      Base64.decode("WsKlWsKlWsKl"));   // "Z¥Z¥Z¥" as UTF-8 input converted to Base64
+  }
+
+  @Test
+  public void testDecodeNonASCII() throws Exception {
+    // https://dencode.com/string
+    assertEquals(
+      "\u00F6p\u00E8n s\u00EA\u00DF\u00E4m\u00E9 \u00FCrg\u20ACntl\u00FF",  // öpèn sêßämé ürg€ntlÿ
+      Base64.decode("w7Zww6huIHPDqsOfw6Rtw6kgw7xyZ+KCrG50bMO/"));
+    assertEquals(
+      "\u00E4\u00F6\u00FC\u00DF\u00C4\u00D6\u00DC",   // äöüßÄÖÜ
+      Base64.decode("w6TDtsO8w5/DhMOWw5w="));
   }
 
 }


### PR DESCRIPTION
Fitnesse basic authentication fails on non-ASCII characters (for example german umlauts) in user-id and passwords

`fitnesse.util.Base64#decode(java.lang.String)` incorrectly uses the charset UTF-8 (defined in `FileUtil.CHARENCODING`) to convert the **input** to Base64-`decode()`. This input's charset however is irrelevant because Base64 is US-ASCII which is compatible to any charset.
The **output** of Base64-`decode()` has to be converted to UTF-8 as most browsers encode basic auth in UTF-8 now.

For nearly all users this change will be without any effect as their user-ids / passwords are in US-ASCII which is fully compatible to UTF-8. Only users with Latin1 (ISO-8859-1) chars in user-id / passwords that managed to have their browser NOT to encode basic auth as UTF-8 (Safari? IE?) and their fitnesse installation's java default file encoding fitting their browser's encoding, will experience a change and authentication might fail. Remedy is to use a current web browser which encodes basic auth as UTF-8.

See:
* https://stackoverflow.com/questions/7242316/what-encoding-should-i-use-for-http-basic-authentication
* https://en.wikipedia.org/wiki/Basic_access_authentication
* https://bugzilla.mozilla.org/show_bug.cgi?id=41489 (Firefox bug open from 2000 to 2021 !!)

Perhaps fitnesse should send the new "charset" auth-param from RFC-7617 to user agents to explicitly tell them that the "Authorization" header value is expected to be UTF-8 encoded (see https://datatracker.ietf.org/doc/html/rfc7617#section-2.1).