### PR TITLE
Feature/add limit to test histories

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
@@ -177,6 +177,8 @@ There are more properties which can be used to tweak parts of FitNesse:
  * '''VersionsController.days''' - number of days to keep old page versions around when using the Zip file based versions controller.
  * '''test.history.days''' - The number of days to keep test results around. Cleaned up after a new test run.
  * '''test.history.path''' - Location to store the test results. The default location is ''!-FitNesseRoot-!/files/testResults''.
+ * '''TestHistory.maxCount''' - The number of Test Histories that will be kept for each individual page.
+ * '''TestHistory.purgeTime''' - A comma separated list of numbers for purge options on the ''Test History'' page.
  * Any variable that can be defined on a wiki page.
 
 The Slim test system has a set of [[custom properties][<UserGuide.WritingAcceptanceTests.SliM]] that can either be set on a page or in the configuration file.

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -11,10 +11,13 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
+You also have the possibility to disable !style_code(Test Histories) for a selected page by going to the !style_code(?properties) page and check the ''disableTestHistory'' option.
+
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''> 30 days'', ''> 60 days'', or ''> 90 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeTime'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge times or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]])
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history.
+Additionally to this, you can configure a number to the property ''TestHistory.maxCount''. This will define how many histories will be kept for each page.
 
 !4 Comparing History
 When viewing the history for a page, you can select any two test results by clicking in their checkboxes.  Then, if you click the ''Compare'' button, you will be shown the two test results side-by-side along with an indicator that tells you if the results are identical or not.

--- a/plugins.properties
+++ b/plugins.properties
@@ -60,3 +60,13 @@ CustomComparators=inverse:fitnesse.slim.test.InverseComparator
 ##
 # Number of days to keep history
 test.history.days=1
+
+##
+# Deletes Test Histories that exceeds the given number. They are deleted when new histories are being created.
+#TestHistory.maxCount=10
+
+##
+# The given list of numbers represent the time values for purging test histories.
+# Test histories older than the given number are being deleted.
+# The value 0 represents 'Purge all'.
+#TestHistory.purgeTime=0,30,60,90

--- a/src/fitnesse/ConfigurationParameter.java
+++ b/src/fitnesse/ConfigurationParameter.java
@@ -43,7 +43,9 @@ public enum ConfigurationParameter {
   CONTEXT_ROOT("ContextRoot"),
   LOCALHOST_ONLY("LocalhostOnly"),
   MAXIMUM_WORKERS("MaximumWorkers"),
-  THEME("Theme");
+  THEME("Theme"),
+  TESTHISTORY_MAX_COUNT("TestHistory.maxCount"),
+  PURGE_TIME("TestHistory.purgeTime");
 
   private static final Logger LOG = Logger.getLogger(ConfigurationParameter.class.getName());
 

--- a/src/fitnesse/resources/javascript/fitnesse.js
+++ b/src/fitnesse/resources/javascript/fitnesse.js
@@ -115,6 +115,37 @@ $(document)
         }
     });
 
+    // When checking purgeGlobal then change the href elements to send true
+$(document)
+    .on('change', '.testHistory #purgeGlobal', function() {
+        const purgeGlobal = "&purgeGlobal=true";
+        let elems = $("a[href^='?responder=purgeHistory']");
+
+        if(this.checked) {
+            elems.each((index, link) => {
+                // Only adjust the href if it was not already adjusted
+                if(!link.href.includes(purgeGlobal)) {
+                    link.href = link.href.substring(link.href.indexOf("?")) + purgeGlobal;
+                }
+            });
+        } else {
+            elems.each((index, link) => {
+                // Only adjust the href if it was adjusted before
+                if(link.href.includes(purgeGlobal)) {
+                    link.href = link.href.substring(link.href.indexOf("?"), link.href.length - purgeGlobal.length);
+                }
+            });
+        }
+    });
+
+// When clicking on a purge link then ask before deletion
+function purgeConfirmation(event) {
+    if(!confirm('Are you sure you want to purge the test histories?')) {
+        event.preventDefault();
+        return false;
+    }
+}
+
 /**
  * Notify user when changing page while test execution is in progress.
  */

--- a/src/fitnesse/resources/templates/propertiesPage.vm
+++ b/src/fitnesse/resources/templates/propertiesPage.vm
@@ -37,7 +37,7 @@
    </fieldset>
 
    #if ($testhistoryTypes.size() > 0)
-    <fieldset class="col-md-6 col-lg-2">
+    <fieldset>
      <legend>Test History:</legend>
      #foreach( $testhistoryType in $testhistoryTypes )
       <label for="$testhistoryType"><input type="checkbox" id="$testhistoryType" name="$testhistoryType"#checked( $testhistoryType )/>$testhistoryType</label>

--- a/src/fitnesse/resources/templates/propertiesPage.vm
+++ b/src/fitnesse/resources/templates/propertiesPage.vm
@@ -35,6 +35,15 @@
 	<label for="$security"><input type="checkbox" id="$security" name="$security"#checked( $security )/>$security</label>
     #end
    </fieldset>
+
+   #if ($testhistoryTypes.size() > 0)
+    <fieldset class="col-md-6 col-lg-2">
+     <legend>Test History:</legend>
+     #foreach( $testhistoryType in $testhistoryTypes )
+      <label for="$testhistoryType"><input type="checkbox" id="$testhistoryType" name="$testhistoryType"#checked( $testhistoryType )/>$testhistoryType</label>
+     #end
+    </fieldset>
+  #end
   </div>
 
   <div class="virtual-wiki-properties">

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -2,11 +2,14 @@
 #set($noHistory = true)
 <div>
  <a class="button" href="?responder=overview">View as Overview</a>
- <a class="button" href="?responder=purgeHistory&days=30">Purge &gt; 30 days</a>
- <a class="button" href="?responder=purgeHistory&days=7">Purge &gt; 7 days</a>
- <a class="button" href="?responder=purgeHistory&days=0">Purge all</a>
  <a class="button" href="$viewLocation">Cancel</a>
  <label for="hidePassedTests"><input type="checkbox" id="hidePassedTests"/>Hide passed tests</label>
+</div>
+<div>
+ #foreach($purgeTime in $purgeTimes)
+  <a class="button" href="?responder=purgeHistory&days=$purgeTime" onclick="purgeConfirmation(event)">Purge#if ($purgeTime == 0) all#else &gt; $purgeTime days#end</a>
+ #end
+ <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
 </div>
 
 <table>

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -34,12 +34,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import static fitnesse.ConfigurationParameter.TESTHISTORY_MAX_COUNT;
 import static fitnesse.wiki.PageData.ACTION_ATTRIBUTES;
 import static fitnesse.wiki.PageData.NAVIGATION_ATTRIBUTES;
 import static fitnesse.wiki.PageData.PAGE_TYPE_ATTRIBUTES;
 import static fitnesse.wiki.PageData.SECURITY_ATTRIBUTES;
+import static fitnesse.wiki.PageData.TESTHISTORY_ATTRIBUTES;
 import static fitnesse.wiki.PageType.SUITE;
 import static fitnesse.wiki.PageType.TEST;
+import static fitnesse.wiki.WikiPageProperty.DISABLE_TESTHISTORY;
 import static fitnesse.wiki.WikiPageProperty.EDIT;
 import static fitnesse.wiki.WikiPageProperty.FILES;
 import static fitnesse.wiki.WikiPageProperty.HELP;
@@ -99,7 +102,7 @@ public class PropertiesResponder implements SecureResponder {
         EDIT, PROPERTIES, VERSIONS, REFACTOR,
         WHERE_USED, RECENT_CHANGES, SUITE.toString(),
         PRUNE, SECURE_READ, SECURE_WRITE,
-        SECURE_TEST, FILES };
+        SECURE_TEST, FILES, DISABLE_TESTHISTORY };
     for (String attribute : attributes)
       addJsonAttribute(jsonObject, attribute);
     if (pageData.hasAttribute(HELP)) {
@@ -180,6 +183,7 @@ public class PropertiesResponder implements SecureResponder {
     makeTestActionCheckboxesHtml();
     makeNavigationCheckboxesHtml();
     makeSecurityCheckboxesHtml();
+    makeTestHistoryCheckboxesHtml();
   }
 
   public void makePageTypeRadiosHtml(PageData pageData) {
@@ -260,6 +264,10 @@ public class PropertiesResponder implements SecureResponder {
 
   public void makeSecurityCheckboxesHtml() {
     html.put("securityTypes", SECURITY_ATTRIBUTES);
+  }
+
+  public void makeTestHistoryCheckboxesHtml() {
+	  html.put("testhistoryTypes", TESTHISTORY_ATTRIBUTES);
   }
 
 

--- a/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/PurgeHistoryResponder.java
@@ -2,6 +2,8 @@ package fitnesse.responders.testHistory;
 
 import java.io.File;
 
+import org.apache.commons.lang3.StringUtils;
+
 import fitnesse.FitNesseContext;
 import fitnesse.authentication.AlwaysSecureOperation;
 import fitnesse.authentication.SecureOperation;
@@ -11,6 +13,7 @@ import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.reporting.history.HistoryPurger;
 import fitnesse.responders.ErrorResponder;
+import fitnesse.wiki.WikiPagePath;
 
 public class PurgeHistoryResponder implements SecureResponder {
 
@@ -31,13 +34,26 @@ public class PurgeHistoryResponder implements SecureResponder {
   }
 
   private void purgeHistory(Request request, FitNesseContext context) {
+    WikiPagePath currentPath = new WikiPagePath(request.getResource().split("\\."));
+		String purgeGlobalInput = request.getInput("purgeGlobal");
+
     File resultsDirectory = context.getTestHistoryDirectory();
     int days = getDaysInput(request);
-    deleteTestHistoryOlderThanDays(resultsDirectory, days);
+    // If purgeGlobal is not set then only delete current path
+    if (StringUtils.isBlank(purgeGlobalInput) || !Boolean.parseBoolean(purgeGlobalInput)) {
+      deleteTestHistoryOlderThanDays(resultsDirectory, days, currentPath);
+    } else {
+      deleteTestHistoryOlderThanDays(resultsDirectory, days, null);
+    }
   }
 
-  public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days) {
-    new HistoryPurger(resultsDirectory, days).deleteTestHistoryOlderThanDays();
+  public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days, WikiPagePath path) {
+    HistoryPurger historyPurger = new HistoryPurger(resultsDirectory, days);
+    if (path != null) {
+      historyPurger.deleteTestHistoryOlderThanDays(path);
+    } else {
+      historyPurger.deleteTestHistoryOlderThanDays();
+    }
   }
 
   private Integer getDaysInput(Request request) {

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -5,8 +5,11 @@ import java.io.UnsupportedEncodingException;
 
 import fitnesse.reporting.history.TestHistory;
 import fitnesse.wiki.PathParser;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureReadOperation;
@@ -43,6 +46,8 @@ public class TestHistoryResponder implements SecureResponder {
     page.setNavTemplate("viewNav");
     page.put("viewLocation", request.getResource());
     page.put("testHistory", testHistory);
+    String purgeTimes = context.getProperties().getProperty(ConfigurationParameter.PURGE_TIME.getKey());
+    page.put("purgeTimes", StringUtils.isBlank(purgeTimes) ? new String[] { "0", "30", "60", "90" } : purgeTimes.split(","));
     page.setMainTemplate("testHistory");
     SimpleResponse response = new SimpleResponse();
     response.setContent(page.html(request));

--- a/src/fitnesse/wiki/PageData.java
+++ b/src/fitnesse/wiki/PageData.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.stream.Stream;
 
 import static fitnesse.wiki.PageType.*;
 
@@ -55,7 +56,9 @@ public class PageData implements ReadOnlyPageData, Serializable {
   public static final String[] NAVIGATION_ATTRIBUTES = {
       WikiPageProperty.RECENT_CHANGES, WikiPageProperty.FILES, WikiPageProperty.SEARCH };
 
-  public static final String[] NON_SECURITY_ATTRIBUTES = ArrayUtils.addAll(ACTION_ATTRIBUTES, NAVIGATION_ATTRIBUTES);
+  public static final String[] TESTHISTORY_ATTRIBUTES = { WikiPageProperty.DISABLE_TESTHISTORY };
+
+  public static final String[] NON_SECURITY_ATTRIBUTES = Stream.of(ACTION_ATTRIBUTES, NAVIGATION_ATTRIBUTES, TESTHISTORY_ATTRIBUTES).flatMap(Stream::of).toArray(String[]::new);
 
   @Deprecated
   public static final String PropertySECURE_READ = WikiPageProperty.SECURE_READ;

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -28,6 +28,7 @@ public class WikiPageProperty implements Serializable {
   public static final String VERSIONS = "Versions";
   public static final String EDIT = "Edit";
   public static final String SUITES = "Suites";
+  public static final String DISABLE_TESTHISTORY = "DisableTestHistory";
 
   public static final String SECURE_READ = "secure-read";
   public static final String SECURE_WRITE = "secure-write";

--- a/test/fitnesse/reporting/history/HistoryPurgerTest.java
+++ b/test/fitnesse/reporting/history/HistoryPurgerTest.java
@@ -132,6 +132,37 @@ public class HistoryPurgerTest {
     assertEquals(1, svnFiles.length);
   }
 
+  @Test
+  public void shouldBeAbleToDeleteSomeTestHistoriesIfMoreThanThree() throws Exception {
+    int testHistoryCount = 3;
+
+    File pageDirectory = addPageDirectory("SomePage");
+    addTestResult(pageDirectory, "20090614000000_1_0_0_0");
+    addTestResult(pageDirectory, "20090615000000_1_0_0_0");
+    addTestResult(pageDirectory, "20090616000000_1_0_0_0");
+    addTestResult(pageDirectory, "20090617000000_1_0_0_0");
+
+    historyPurger.deleteTestHistoryByCount(PathParser.parse("SomePage"), testHistoryCount);
+
+    TestHistory history = new TestHistory(resultsDirectory);
+    PageHistory pageHistory = history.getPageHistory("SomePage");
+    assertEquals(testHistoryCount, pageHistory.size());
+    assertNull(pageHistory.get(makeDate("20090614000000")));
+    assertNotNull(pageHistory.get(makeDate("20090615000000")));
+    assertNotNull(pageHistory.get(makeDate("20090616000000")));
+    assertNotNull(pageHistory.get(makeDate("20090617000000")));
+  }
+
+  @Test
+  public void shouldDeletePageHistoryDirectoryIfEmpty() throws Exception {
+    addPageDirectory("SomePage");
+
+    historyPurger.deleteTestHistoryByCount(PathParser.parse("SomePage"), 0);
+
+    String[] files = resultsDirectory.list();
+    assertEquals(0, files.length);
+  }
+
   private void removeResultsDirectory() throws IOException {
     if (resultsDirectory.exists())
       FileUtil.deleteFileSystemDirectory(resultsDirectory);

--- a/test/fitnesse/reporting/history/TestXmlFormatterTest.java
+++ b/test/fitnesse/reporting/history/TestXmlFormatterTest.java
@@ -1,5 +1,6 @@
 package fitnesse.reporting.history;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.reporting.history.TestExecutionReport.TestResult;
 import fitnesse.reporting.history.TestXmlFormatter.WriterFactory;
@@ -34,6 +35,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class TestXmlFormatterTest {
   private static final String TEST_TIME = "4/13/2009 15:21:43";
@@ -221,4 +224,20 @@ public class TestXmlFormatterTest {
     });
   }
 
+  @Test
+  public void shouldTryToDeleteHistoriesByCount() throws Exception {
+    context.getProperties().setProperty(ConfigurationParameter.TESTHISTORY_MAX_COUNT.getKey(), "2");
+    FitNesseContext spyContext = spy(context);
+    try (TestXmlFormatter formatter = new TestXmlFormatter(spyContext, new WikiPageDummy("name", "content", null),
+        new WriterFactory() {
+          @Override
+          public Writer getWriter(FitNesseContext context, WikiPage page, TestSummary counts, long time)
+              throws IOException {
+            return new StringWriter();
+          }
+        })) {
+    }
+
+    verify(spyContext).getTestHistoryDirectory();
+  }
 }

--- a/test/fitnesse/responders/editing/PropertiesResponderTest.java
+++ b/test/fitnesse/responders/editing/PropertiesResponderTest.java
@@ -74,7 +74,8 @@ public class PropertiesResponderTest {
     for (String attribute : new String[]{"Search", "Edit", "Properties", "Versions", "Refactor", "WhereUsed", "RecentChanges"})
       assertCheckboxChecked(attribute, content);
 
-    for (String attribute : new String[]{"Prune", WikiPageProperty.SECURE_READ, WikiPageProperty.SECURE_WRITE, WikiPageProperty.SECURE_TEST})
+    for (String attribute : new String[] { "Prune", WikiPageProperty.SECURE_READ, WikiPageProperty.SECURE_WRITE,
+        WikiPageProperty.SECURE_TEST, WikiPageProperty.DISABLE_TESTHISTORY })
       assertCheckboxNotChecked(content, attribute);
   }
 
@@ -119,6 +120,7 @@ public class PropertiesResponderTest {
     assertFalse(jsonObject.getBoolean(WikiImportProperty.SECURE_READ));
     assertFalse(jsonObject.getBoolean(WikiImportProperty.SECURE_WRITE));
     assertFalse(jsonObject.getBoolean(WikiImportProperty.SECURE_TEST));
+    assertFalse(jsonObject.getBoolean(WikiImportProperty.DISABLE_TESTHISTORY));
   }
 
   @Test
@@ -151,6 +153,7 @@ public class PropertiesResponderTest {
     assertFalse(jsonObject.getBoolean(WikiPageProperty.SECURE_READ));
     assertFalse(jsonObject.getBoolean(WikiPageProperty.SECURE_WRITE));
     assertFalse(jsonObject.getBoolean(WikiPageProperty.SECURE_TEST));
+    assertFalse(jsonObject.getBoolean(WikiPageProperty.DISABLE_TESTHISTORY));
   }
 
 
@@ -387,6 +390,15 @@ public class PropertiesResponderTest {
     assertSubString("<input type=\"checkbox\" id=\"secure-read\" name=\"secure-read\"/>", html);
     assertSubString("<input type=\"checkbox\" id=\"secure-write\" name=\"secure-write\"/>", html);
     assertSubString("<input type=\"checkbox\" id=\"secure-test\" name=\"secure-test\"/>", html);
+  }
+
+  @Test
+  public void testMakeTestHistoryPropertiesHtml() throws Exception {
+    SimpleResponse response = (SimpleResponse) new PropertiesResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertSubString("Test History:", html);
+    assertSubString("<input type=\"checkbox\" id=\"" + WikiPageProperty.DISABLE_TESTHISTORY + "\" name=\""
+        + WikiPageProperty.DISABLE_TESTHISTORY + "\"/>", html);
   }
 
   @Test

--- a/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
@@ -5,6 +5,7 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
+import fitnesse.wiki.WikiPagePath;
 
 import org.junit.After;
 import static org.junit.Assert.*;
@@ -50,6 +51,7 @@ public class PurgeHistoryResponderTest {
   public void shouldDeleteHistoryFromRequestAndRedirect() throws Exception {
     StubbedPurgeHistoryResponder responder = new StubbedPurgeHistoryResponder();
     request.addInput("days", "30");
+    request.addInput("purgeGlobal", "true");
     SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
     assertEquals(30, responder.daysDeleted);
     assertEquals(303, response.getStatus());
@@ -68,14 +70,23 @@ public class PurgeHistoryResponderTest {
     request.addInput("days", "bob");
     Response response = responder.makeResponse(context, request);
     assertEquals(400, response.getStatus());
+  }
 
+  @Test
+  public void shouldDeleteHistoryFromRequestForWikiPath() throws Exception {
+    StubbedPurgeHistoryResponder responder = new StubbedPurgeHistoryResponder();
+    request.addInput("days", "0");
+    request.addInput("purgeGlobal", "false");
+    SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+    assertEquals(303, response.getStatus());
+    assertEquals("?testHistory", response.getHeader("Location"));
   }
 
   private static class StubbedPurgeHistoryResponder extends PurgeHistoryResponder {
     public int daysDeleted = -1;
 
     @Override
-    public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days) {
+    public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days, WikiPagePath path) {
       daysDeleted = days;
     }
   }

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -1,5 +1,6 @@
 package fitnesse.responders.testHistory;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
@@ -27,6 +28,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static util.RegexTestCase.assertDoesntHaveRegexp;
 import static util.RegexTestCase.assertHasRegexp;
+import static util.RegexTestCase.assertNotSubString;
+import static util.RegexTestCase.assertSubString;
 
 public class TestHistoryResponderTest {
   private File resultsDirectory;
@@ -339,5 +342,28 @@ public class TestHistoryResponderTest {
     request.addInput("format", "xML");
     response = (SimpleResponse) responder.makeResponse(context, request);
     assertHasRegexp("text/xml", response.getContentType());
+  }
+
+  @Test
+  public void shouldShowDefaultPurgeTimes() throws Exception {
+    MockRequest request = new MockRequest();
+    SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=30\" onclick=\"purgeConfirmation(event)\">Purge &gt; 30 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=60\" onclick=\"purgeConfirmation(event)\">Purge &gt; 60 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=90\" onclick=\"purgeConfirmation(event)\">Purge &gt; 90 days</a>", html);
+  }
+
+  @Test
+  public void shouldShowConfiguredPurgeTimes() throws Exception {
+    MockRequest request = new MockRequest();
+    context.getProperties().setProperty(ConfigurationParameter.PURGE_TIME.getKey(), "7,14,28");
+    SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertNotSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=7\" onclick=\"purgeConfirmation(event)\">Purge &gt; 7 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=14\" onclick=\"purgeConfirmation(event)\">Purge &gt; 14 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=28\" onclick=\"purgeConfirmation(event)\">Purge &gt; 28 days</a>", html);
   }
 }


### PR DESCRIPTION
This PR would add a couple things to the Test Histories.

1. An additional Property on a page to disable Test Histories for that page. This is turned off by default.
2. The behaviour when purging Test Histories would now change to only delete Test Histories of the current page. Additionally, an extra Button, next to the purge Buttons, to still purge globally can be checked.
3. Two new Properties for the plugins.properties:
     * TestHistory.maxCount=10 would define that only 10 Test Histories per page should be saved. This is off by default.
     * TestHistory.purgeTime=0,30,60,90 defines the purge Buttons on the Test History page. Currently will default to 0,30,60,90 when nothing else is configured.

Depending on the configured purge times, the GUI for the Test Histories would look like this:
![image](https://github.com/unclebob/fitnesse/assets/135694182/42143c1a-fa1d-413c-ac3e-c248b896abb0)

By coincidence this might be taking care of this Request #1488 
The new Property does not work recursive though.
