### PR TITLE
Feature/disable test history

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -11,7 +11,7 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
-You also have the possibility to disable !style_code(Test Histories) for a selected page by going to the !style_code(?properties) page and check the ''disableTestHistory'' option.
+You also have the possibility to disable !style_code(Test Histories) for a selected page by going to the !style_code(?properties) page and check the ''!-DisableTestHistory-!'' option.
 
 !4 Purging
 There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -11,6 +11,8 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
+You also have the possibility to disable !style_code(Test Histories) for a selected page by going to the !style_code(?properties) page and check the ''disableTestHistory'' option.
+
 !4 Purging
 There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 

--- a/src/fitnesse/reporting/history/TestXmlFormatter.java
+++ b/src/fitnesse/reporting/history/TestXmlFormatter.java
@@ -20,6 +20,7 @@ import fitnesse.util.DateTimeUtil;
 import fitnesse.util.TimeMeasurement;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -174,7 +175,11 @@ public class TestXmlFormatter extends BaseFormatter implements ExecutionLogListe
   }
 
   protected void writeResults() throws IOException {
-    writeResults(writerFactory.getWriter(context, getPage(), getPageCounts(), totalTimeMeasurement.startedAt()));
+    if (!getPage().getData().getProperties()
+        .has(WikiPageProperty.DISABLE_TESTHISTORY)) {
+      writeResults(writerFactory.getWriter(context, getPage(), getPageCounts(),
+          totalTimeMeasurement.startedAt()));
+    }
   }
 
   @Override

--- a/src/fitnesse/resources/templates/propertiesPage.vm
+++ b/src/fitnesse/resources/templates/propertiesPage.vm
@@ -35,6 +35,15 @@
 	<label for="$security"><input type="checkbox" id="$security" name="$security"#checked( $security )/>$security</label>
     #end
    </fieldset>
+   
+   #if ($disableTypes.size() > 0)
+    <fieldset>
+     <legend>Disable:</legend>
+     #foreach( $disableType in $disableTypes )
+      <label for="$disableType"><input type="checkbox" id="$disableType" name="$disableType"#checked( $disableType )/>$disableType</label>
+     #end
+    </fieldset>
+   #end
   </div>
 
   <div class="virtual-wiki-properties">

--- a/src/fitnesse/responders/editing/PropertiesResponder.java
+++ b/src/fitnesse/responders/editing/PropertiesResponder.java
@@ -35,11 +35,13 @@ import java.util.List;
 import java.util.Set;
 
 import static fitnesse.wiki.PageData.ACTION_ATTRIBUTES;
+import static fitnesse.wiki.PageData.DISABLE_ATTRIBUTES;
 import static fitnesse.wiki.PageData.NAVIGATION_ATTRIBUTES;
 import static fitnesse.wiki.PageData.PAGE_TYPE_ATTRIBUTES;
 import static fitnesse.wiki.PageData.SECURITY_ATTRIBUTES;
 import static fitnesse.wiki.PageType.SUITE;
 import static fitnesse.wiki.PageType.TEST;
+import static fitnesse.wiki.WikiPageProperty.DISABLE_TESTHISTORY;
 import static fitnesse.wiki.WikiPageProperty.EDIT;
 import static fitnesse.wiki.WikiPageProperty.FILES;
 import static fitnesse.wiki.WikiPageProperty.HELP;
@@ -99,7 +101,7 @@ public class PropertiesResponder implements SecureResponder {
         EDIT, PROPERTIES, VERSIONS, REFACTOR,
         WHERE_USED, RECENT_CHANGES, SUITE.toString(),
         PRUNE, SECURE_READ, SECURE_WRITE,
-        SECURE_TEST, FILES };
+        SECURE_TEST, FILES, DISABLE_TESTHISTORY };
     for (String attribute : attributes)
       addJsonAttribute(jsonObject, attribute);
     if (pageData.hasAttribute(HELP)) {
@@ -180,6 +182,7 @@ public class PropertiesResponder implements SecureResponder {
     makeTestActionCheckboxesHtml();
     makeNavigationCheckboxesHtml();
     makeSecurityCheckboxesHtml();
+    makeDisableCheckboxesHtml();
   }
 
   public void makePageTypeRadiosHtml(PageData pageData) {
@@ -260,6 +263,10 @@ public class PropertiesResponder implements SecureResponder {
 
   public void makeSecurityCheckboxesHtml() {
     html.put("securityTypes", SECURITY_ATTRIBUTES);
+  }
+  
+  public void makeDisableCheckboxesHtml() {
+    html.put("disableTypes", DISABLE_ATTRIBUTES);
   }
 
 

--- a/src/fitnesse/wiki/PageData.java
+++ b/src/fitnesse/wiki/PageData.java
@@ -2,10 +2,10 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.wiki;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.stream.Stream;
 
 import static fitnesse.wiki.PageType.*;
 
@@ -55,7 +55,11 @@ public class PageData implements ReadOnlyPageData, Serializable {
   public static final String[] NAVIGATION_ATTRIBUTES = {
       WikiPageProperty.RECENT_CHANGES, WikiPageProperty.FILES, WikiPageProperty.SEARCH };
 
-  public static final String[] NON_SECURITY_ATTRIBUTES = ArrayUtils.addAll(ACTION_ATTRIBUTES, NAVIGATION_ATTRIBUTES);
+  public static final String[] DISABLE_ATTRIBUTES = { WikiPageProperty.DISABLE_TESTHISTORY };
+
+  public static final String[] NON_SECURITY_ATTRIBUTES = Stream
+      .of(ACTION_ATTRIBUTES, NAVIGATION_ATTRIBUTES, DISABLE_ATTRIBUTES)
+      .flatMap(Stream::of).toArray(String[]::new);
 
   @Deprecated
   public static final String PropertySECURE_READ = WikiPageProperty.SECURE_READ;

--- a/src/fitnesse/wiki/WikiPageProperty.java
+++ b/src/fitnesse/wiki/WikiPageProperty.java
@@ -28,6 +28,7 @@ public class WikiPageProperty implements Serializable {
   public static final String VERSIONS = "Versions";
   public static final String EDIT = "Edit";
   public static final String SUITES = "Suites";
+  public static final String DISABLE_TESTHISTORY = "DisableTestHistory";
 
   public static final String SECURE_READ = "secure-read";
   public static final String SECURE_WRITE = "secure-write";

--- a/test/fitnesse/reporting/history/TestXmlFormatterTest.java
+++ b/test/fitnesse/reporting/history/TestXmlFormatterTest.java
@@ -15,6 +15,7 @@ import fitnesse.util.XmlUtil;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPageDummy;
+import fitnesse.wiki.WikiPageProperty;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class TestXmlFormatterTest {
@@ -221,4 +223,23 @@ public class TestXmlFormatterTest {
     });
   }
 
+  @Test
+  public void shouldNotCreateTestHistory() throws Exception {
+    WikiTestPage page = new WikiTestPage(new WikiPageDummy("name", "content", null));
+    page.getData().setAttribute(WikiPageProperty.DISABLE_TESTHISTORY, "true");
+    final LinkedList<StringWriter> writers = new LinkedList<>();
+    try (TestXmlFormatter formatter = new TestXmlFormatter(context,
+        page.getSourcePage(), new WriterFactory() {
+          @Override
+          public Writer getWriter(FitNesseContext context, WikiPage page,
+              TestSummary counts, long time) throws IOException {
+            StringWriter writer = new StringWriter();
+            writers.add(writer);
+            return writer;
+          }
+        })) {
+    }
+    
+    assertTrue(writers.isEmpty());
+  }
 }


### PR DESCRIPTION
Adding a new Property on a page to disable Test Histories for that page. This is turned off by default.
This might be taking care of this Request #1488 
The new Property does not work recursive though.