### PR TITLE
Added property to configure purge options

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
@@ -177,7 +177,7 @@ There are more properties which can be used to tweak parts of FitNesse:
  * '''VersionsController.days''' - number of days to keep old page versions around when using the Zip file based versions controller.
  * '''test.history.days''' - The number of days to keep test results around. Cleaned up after a new test run.
  * '''test.history.path''' - Location to store the test results. The default location is ''!-FitNesseRoot-!/files/testResults''.
- * '''TestHistory.purgeTime''' - A comma separated list of numbers for purge options on the ''Test History'' page.
+ * '''TestHistory.purgeTime''' - A comma separated list of the age, in number of days, to offer as purge options on the ''Test History'' page.
  * Any variable that can be defined on a wiki page.
 
 The Slim test system has a set of [[custom properties][<UserGuide.WritingAcceptanceTests.SliM]] that can either be set on a page or in the configuration file.

--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
@@ -177,6 +177,7 @@ There are more properties which can be used to tweak parts of FitNesse:
  * '''VersionsController.days''' - number of days to keep old page versions around when using the Zip file based versions controller.
  * '''test.history.days''' - The number of days to keep test results around. Cleaned up after a new test run.
  * '''test.history.path''' - Location to store the test results. The default location is ''!-FitNesseRoot-!/files/testResults''.
+ * '''TestHistory.purgeTime''' - A comma separated list of numbers for purge options on the ''Test History'' page.
  * Any variable that can be defined on a wiki page.
 
 The Slim test system has a set of [[custom properties][<UserGuide.WritingAcceptanceTests.SliM]] that can either be set on a page or in the configuration file.

--- a/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/AdministeringFitNesse/ConfigurationFile/content.txt
@@ -177,7 +177,7 @@ There are more properties which can be used to tweak parts of FitNesse:
  * '''VersionsController.days''' - number of days to keep old page versions around when using the Zip file based versions controller.
  * '''test.history.days''' - The number of days to keep test results around. Cleaned up after a new test run.
  * '''test.history.path''' - Location to store the test results. The default location is ''!-FitNesseRoot-!/files/testResults''.
- * '''TestHistory.purgeTime''' - A comma separated list of the age, in number of days, to offer as purge options on the ''Test History'' page.
+ * '''TestHistory.purgeOptions''' - A comma separated list of the age, in number of days, to offer as purge options on the ''Test History'' page.
  * Any variable that can be defined on a wiki page.
 
 The Slim test system has a set of [[custom properties][<UserGuide.WritingAcceptanceTests.SliM]] that can either be set on a page or in the configuration file.

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -12,7 +12,7 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeTime'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge times, or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeOptions'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge options, or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history.
 

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -12,7 +12,7 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeTime'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge times or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeTime'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge times, or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history.
 

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -1,6 +1,6 @@
 Every time you run a test or a suite, the results are recorded in the ''test history database''.  You can view the history by clicking on the !style_code(Test History) button.  The reports are pretty self-explanatory.
 
-When you click on !style_code(Test History) you will be shown the directory of all tests and suites that are in thie ''test history database''.  This directory also shows you the status of the last 20 results from each test or suite.  You can click on the name of the test or suite to get a detailed ''page history'', or you can click on any of the individual status elements to see the particular test result.
+When you click on !style_code(Test History) you will be shown the directory of all tests and suites that are in the ''test history database''.  This directory also shows you the status of the last 20 results from each test or suite.  You can click on the name of the test or suite to get a detailed ''page history'', or you can click on any of the individual status elements to see the particular test result.
 
 The detailed ''page history'' shows you a directory of all the test results for that test or suite.  The bar chart shows how how the number of tests (for suites) or assertions (for tests) has grown over time, and the pass/fail ratio.  Clicking on an entry takes you to that specific test result.
 
@@ -12,7 +12,7 @@ The test result files are named using the following scheme !style_code(YYYYMMDDH
 The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeTime'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge times or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history.
 

--- a/plugins.properties
+++ b/plugins.properties
@@ -65,4 +65,4 @@ test.history.days=1
 # The given list of numbers represent the options offered for purging test histories.
 # Test histories older than the given number of days will be deleted.
 # The value 0 represents 'Purge all'.
-#TestHistory.purgeTime=0,7,30
+#TestHistory.purgeOptions=0,7,30

--- a/plugins.properties
+++ b/plugins.properties
@@ -62,7 +62,7 @@ CustomComparators=inverse:fitnesse.slim.test.InverseComparator
 test.history.days=1
 
 ##
-# The given list of numbers represent the time values for purging test histories.
-# Test histories older than the given number are being deleted.
+# The given list of numbers represent the options offered for purging test histories.
+# Test histories older than the given number of days will be deleted.
 # The value 0 represents 'Purge all'.
 #TestHistory.purgeTime=0,7,30

--- a/plugins.properties
+++ b/plugins.properties
@@ -65,4 +65,5 @@ test.history.days=1
 # The given list of numbers represent the options offered for purging test histories.
 # Test histories older than the given number of days will be deleted.
 # The value 0 represents 'Purge all'.
+# Enabling the property without setting any value, removes the offered options completely.
 #TestHistory.purgeOptions=0,7,30

--- a/plugins.properties
+++ b/plugins.properties
@@ -60,3 +60,9 @@ CustomComparators=inverse:fitnesse.slim.test.InverseComparator
 ##
 # Number of days to keep history
 test.history.days=1
+
+##
+# The given list of numbers represent the time values for purging test histories.
+# Test histories older than the given number are being deleted.
+# The value 0 represents 'Purge all'.
+#TestHistory.purgeTime=0,7,30

--- a/src/fitnesse/ConfigurationParameter.java
+++ b/src/fitnesse/ConfigurationParameter.java
@@ -44,7 +44,7 @@ public enum ConfigurationParameter {
   LOCALHOST_ONLY("LocalhostOnly"),
   MAXIMUM_WORKERS("MaximumWorkers"),
   THEME("Theme"),
-  PURGE_TIME("TestHistory.purgeTime");
+  PURGE_OPTIONS("TestHistory.purgeOptions");
 
   private static final Logger LOG = Logger.getLogger(ConfigurationParameter.class.getName());
 

--- a/src/fitnesse/ConfigurationParameter.java
+++ b/src/fitnesse/ConfigurationParameter.java
@@ -43,7 +43,8 @@ public enum ConfigurationParameter {
   CONTEXT_ROOT("ContextRoot"),
   LOCALHOST_ONLY("LocalhostOnly"),
   MAXIMUM_WORKERS("MaximumWorkers"),
-  THEME("Theme");
+  THEME("Theme"),
+  PURGE_TIME("TestHistory.purgeTime");
 
   private static final Logger LOG = Logger.getLogger(ConfigurationParameter.class.getName());
 

--- a/src/fitnesse/resources/javascript/fitnesse.js
+++ b/src/fitnesse/resources/javascript/fitnesse.js
@@ -119,19 +119,19 @@ $(document)
 $(document)
     .on('change', '.testHistory #purgeGlobal', function() {
         const purgeGlobal = "&purgeGlobal=true";
-        let elems = $("a[href^='?responder=purgeHistory']");
+        const elems = $("a[href^='?responder=purgeHistory']");
 
-        if(this.checked) {
+        if (this.checked) {
             elems.each((index, link) => {
                 // Only adjust the href if it was not already adjusted
-                if(!link.href.includes(purgeGlobal)) {
+                if (!link.href.includes(purgeGlobal)) {
                     link.href = link.href.substring(link.href.indexOf("?")) + purgeGlobal;
                 }
             });
         } else {
             elems.each((index, link) => {
                 // Only adjust the href if it was adjusted before
-                if(link.href.includes(purgeGlobal)) {
+                if (link.href.includes(purgeGlobal)) {
                     link.href = link.href.substring(link.href.indexOf("?"), link.href.length - purgeGlobal.length);
                 }
             });
@@ -140,7 +140,7 @@ $(document)
 
 // When clicking on a purge link then ask before deletion
 function purgeConfirmation(event) {
-    if(!confirm('Are you sure you want to purge the test histories?')) {
+    if (!confirm('Are you sure you want to purge the test histories?')) {
         event.preventDefault();
         return false;
     }

--- a/src/fitnesse/resources/javascript/fitnesse.js
+++ b/src/fitnesse/resources/javascript/fitnesse.js
@@ -115,6 +115,37 @@ $(document)
         }
     });
 
+// When checking purgeGlobal then change the href elements to send true
+$(document)
+    .on('change', '.testHistory #purgeGlobal', function() {
+        const purgeGlobal = "&purgeGlobal=true";
+        let elems = $("a[href^='?responder=purgeHistory']");
+
+        if(this.checked) {
+            elems.each((index, link) => {
+                // Only adjust the href if it was not already adjusted
+                if(!link.href.includes(purgeGlobal)) {
+                    link.href = link.href.substring(link.href.indexOf("?")) + purgeGlobal;
+                }
+            });
+        } else {
+            elems.each((index, link) => {
+                // Only adjust the href if it was adjusted before
+                if(link.href.includes(purgeGlobal)) {
+                    link.href = link.href.substring(link.href.indexOf("?"), link.href.length - purgeGlobal.length);
+                }
+            });
+        }
+    });
+
+// When clicking on a purge link then ask before deletion
+function purgeConfirmation(event) {
+    if(!confirm('Are you sure you want to purge the test histories?')) {
+        event.preventDefault();
+        return false;
+    }
+}
+
 /**
  * Notify user when changing page while test execution is in progress.
  */

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -2,11 +2,14 @@
 #set($noHistory = true)
 <div>
  <a class="button" href="?responder=overview">View as Overview</a>
- <a class="button" href="?responder=purgeHistory&days=30">Purge &gt; 30 days</a>
- <a class="button" href="?responder=purgeHistory&days=7">Purge &gt; 7 days</a>
- <a class="button" href="?responder=purgeHistory&days=0">Purge all</a>
  <a class="button" href="$viewLocation">Cancel</a>
  <label for="hidePassedTests"><input type="checkbox" id="hidePassedTests"/>Hide passed tests</label>
+</div>
+<div>
+ #foreach($purgeTime in $purgeTimes)
+  <a class="button" href="?responder=purgeHistory&days=$purgeTime" onclick="purgeConfirmation(event)">Purge#if ($purgeTime == 0) all#else &gt; $purgeTime days#end</a>
+ #end
+ <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
 </div>
 
 <table>

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -6,10 +6,12 @@
  <label for="hidePassedTests"><input type="checkbox" id="hidePassedTests"/>Hide passed tests</label>
 </div>
 <div>
- #foreach($purgeTime in $purgeTimes)
-  <a class="button" href="?responder=purgeHistory&days=$purgeTime" onclick="purgeConfirmation(event)">Purge#if ($purgeTime == 0) all#else &gt; $purgeTime days#end</a>
+ #if(!$purgeOptions.isEmpty())
+  #foreach($purgeOption in $purgeOptions)
+   <a class="button" href="?responder=purgeHistory&days=$purgeOption" onclick="purgeConfirmation(event)">Purge#if ($purgeOption == 0) all#else &gt; $purgeOption days#end</a>
+  #end
+  <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
  #end
- <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
 </div>
 
 <table>

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -46,12 +46,24 @@ public class TestHistoryResponder implements SecureResponder {
     page.setNavTemplate("viewNav");
     page.put("viewLocation", request.getResource());
     page.put("testHistory", testHistory);
-    String purgeTimes = context.getProperties().getProperty(ConfigurationParameter.PURGE_TIME.getKey());
-    page.put("purgeTimes", StringUtils.isBlank(purgeTimes) ? new String[] { "0", "7", "30" } : purgeTimes.split(","));
+    page.put("purgeOptions", getPurgeOptions());
     page.setMainTemplate("testHistory");
     SimpleResponse response = new SimpleResponse();
     response.setContent(page.html(request));
     return response;
+  }
+
+  private String[] getPurgeOptions() {
+    String configuredPurgeOptions = context.getProperties().getProperty(ConfigurationParameter.PURGE_OPTIONS.getKey());
+    String[] purgeOptionsForPage;
+    if(configuredPurgeOptions == null) {
+      purgeOptionsForPage = new String[] { "0", "7", "30" };
+    } else if (configuredPurgeOptions.isBlank()) {
+      purgeOptionsForPage = new String[0];
+    } else {
+      purgeOptionsForPage = configuredPurgeOptions.split(",");
+    }
+    return purgeOptionsForPage;
   }
 
   private Response makeTestHistoryXmlResponse(TestHistory history) throws UnsupportedEncodingException {

--- a/src/fitnesse/responders/testHistory/TestHistoryResponder.java
+++ b/src/fitnesse/responders/testHistory/TestHistoryResponder.java
@@ -5,8 +5,11 @@ import java.io.UnsupportedEncodingException;
 
 import fitnesse.reporting.history.TestHistory;
 import fitnesse.wiki.PathParser;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureReadOperation;
@@ -43,6 +46,8 @@ public class TestHistoryResponder implements SecureResponder {
     page.setNavTemplate("viewNav");
     page.put("viewLocation", request.getResource());
     page.put("testHistory", testHistory);
+    String purgeTimes = context.getProperties().getProperty(ConfigurationParameter.PURGE_TIME.getKey());
+    page.put("purgeTimes", StringUtils.isBlank(purgeTimes) ? new String[] { "0", "7", "30" } : purgeTimes.split(","));
     page.setMainTemplate("testHistory");
     SimpleResponse response = new SimpleResponse();
     response.setContent(page.html(request));

--- a/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/PurgeHistoryResponderTest.java
@@ -5,6 +5,7 @@ import fitnesse.http.MockRequest;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.testutil.FitNesseUtil;
+import fitnesse.wiki.WikiPagePath;
 
 import org.junit.After;
 import static org.junit.Assert.*;
@@ -50,6 +51,7 @@ public class PurgeHistoryResponderTest {
   public void shouldDeleteHistoryFromRequestAndRedirect() throws Exception {
     StubbedPurgeHistoryResponder responder = new StubbedPurgeHistoryResponder();
     request.addInput("days", "30");
+    request.addInput("purgeGlobal", "true");
     SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
     assertEquals(30, responder.daysDeleted);
     assertEquals(303, response.getStatus());
@@ -68,14 +70,23 @@ public class PurgeHistoryResponderTest {
     request.addInput("days", "bob");
     Response response = responder.makeResponse(context, request);
     assertEquals(400, response.getStatus());
-
+  }
+  
+  @Test
+  public void shouldDeleteHistoryFromRequestForWikiPath() throws Exception {
+    StubbedPurgeHistoryResponder responder = new StubbedPurgeHistoryResponder();
+    request.addInput("days", "0");
+    request.addInput("purgeGlobal", "false");
+    SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+    assertEquals(303, response.getStatus());
+    assertEquals("?testHistory", response.getHeader("Location"));
   }
 
   private static class StubbedPurgeHistoryResponder extends PurgeHistoryResponder {
     public int daysDeleted = -1;
 
     @Override
-    public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days) {
+    public void deleteTestHistoryOlderThanDays(File resultsDirectory, int days, WikiPagePath path) {
       daysDeleted = days;
     }
   }

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -345,24 +345,37 @@ public class TestHistoryResponderTest {
   }
   
   @Test
-  public void shouldShowDefaultPurgeTimes() throws Exception {
+  public void shouldShowDefaultPurgeOptions() throws Exception {
     MockRequest request = new MockRequest();
     SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
     String html = response.getContent();
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=7\" onclick=\"purgeConfirmation(event)\">Purge &gt; 7 days</a>", html);
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=30\" onclick=\"purgeConfirmation(event)\">Purge &gt; 30 days</a>", html);
+    assertSubString("<label for=\"purgeGlobal\"><input type=\"checkbox\" id=\"purgeGlobal\" />Purge global</label>", html);
   }
 
   @Test
-  public void shouldShowConfiguredPurgeTimes() throws Exception {
+  public void shouldShowConfiguredPurgeOptions() throws Exception {
     MockRequest request = new MockRequest();
-    context.getProperties().setProperty(ConfigurationParameter.PURGE_TIME.getKey(), "30,60,90");
+    context.getProperties().setProperty(ConfigurationParameter.PURGE_OPTIONS.getKey(), "30,60,90");
     SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
     String html = response.getContent();
     assertNotSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=30\" onclick=\"purgeConfirmation(event)\">Purge &gt; 30 days</a>", html);
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=60\" onclick=\"purgeConfirmation(event)\">Purge &gt; 60 days</a>", html);
     assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=90\" onclick=\"purgeConfirmation(event)\">Purge &gt; 90 days</a>", html);
+    assertSubString("<label for=\"purgeGlobal\"><input type=\"checkbox\" id=\"purgeGlobal\" />Purge global</label>", html);
+  }
+  
+  @Test
+  public void shouldShowNoPurgeOptions() throws Exception {
+    MockRequest request = new MockRequest();
+    context.getProperties().setProperty(ConfigurationParameter.PURGE_OPTIONS.getKey(), "");
+    SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertNotSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
+    assertNotSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=7\" onclick=\"purgeConfirmation(event)\">Purge &gt; 7 days</a>", html);
+    assertNotSubString("<label for=\"purgeGlobal\"><input type=\"checkbox\" id=\"purgeGlobal\" />Purge global</label>", html);
   }
 }

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -1,5 +1,6 @@
 package fitnesse.responders.testHistory;
 
+import fitnesse.ConfigurationParameter;
 import fitnesse.FitNesseContext;
 import fitnesse.http.MockRequest;
 import fitnesse.http.SimpleResponse;
@@ -27,6 +28,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static util.RegexTestCase.assertDoesntHaveRegexp;
 import static util.RegexTestCase.assertHasRegexp;
+import static util.RegexTestCase.assertNotSubString;
+import static util.RegexTestCase.assertSubString;
 
 public class TestHistoryResponderTest {
   private File resultsDirectory;
@@ -339,5 +342,27 @@ public class TestHistoryResponderTest {
     request.addInput("format", "xML");
     response = (SimpleResponse) responder.makeResponse(context, request);
     assertHasRegexp("text/xml", response.getContentType());
+  }
+  
+  @Test
+  public void shouldShowDefaultPurgeTimes() throws Exception {
+    MockRequest request = new MockRequest();
+    SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=7\" onclick=\"purgeConfirmation(event)\">Purge &gt; 7 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=30\" onclick=\"purgeConfirmation(event)\">Purge &gt; 30 days</a>", html);
+  }
+
+  @Test
+  public void shouldShowConfiguredPurgeTimes() throws Exception {
+    MockRequest request = new MockRequest();
+    context.getProperties().setProperty(ConfigurationParameter.PURGE_TIME.getKey(), "30,60,90");
+    SimpleResponse response = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = response.getContent();
+    assertNotSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=0\" onclick=\"purgeConfirmation(event)\">Purge all</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=30\" onclick=\"purgeConfirmation(event)\">Purge &gt; 30 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=60\" onclick=\"purgeConfirmation(event)\">Purge &gt; 60 days</a>", html);
+    assertSubString("<a class=\"button\" href=\"?responder=purgeHistory&days=90\" onclick=\"purgeConfirmation(event)\">Purge &gt; 90 days</a>", html);
   }
 }


### PR DESCRIPTION
Added the possibility to configure the purge options in the plugins.properties.
The new property can look like TestHistory.purgeTime=0,30,60,90 and changes the buttons on the Test History page. Will default to 0,7,30 when nothing else is configured.
Also changed the purge behaviour to only delete the current page. But also with an option to still purge globally by checking the Purge Global button.

Depending on the configured purge times, the GUI for the Test Histories would look like this:
![image](https://github.com/unclebob/fitnesse/assets/135694182/602578c6-87b5-425b-a150-f0afb0cb2e4d)
