### PR TITLE
Watch closer what SLIM is doing

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/SliM/content.txt
@@ -16,21 +16,21 @@ If you want a test page to be run under SLIM, you simply set the TEST_SYSTEM var
 !3 The Slim Tables
 The first cell of a slim table tells you what kind of table it is. Here are the table types so far:
 
-| [[Decision Table][>DecisionTable]] | Supplies the inputs and outputs for decisions. This is similar to the Fit Column Fixture |
-| [[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]|Almost identical to a >DecisionTable but more readable for very big tables with many columns as only the changed values from one line to the baseline must be specified. The fixture implementation is identical to >DecisionTable.|
-| [[Dynamic Decision Table][>DynamicDecisionTable]]                                               |Has the same syntax as a >DecisionTable, but differs in the fixture implementation. It passes the column headers as parameters to the fixture.                                                                                     |
-| [[Hybrid Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.HybridDecisionTable]]    |Combines the advantages in the fixture implementation of a Decision and a Dynamic Decision Table. Also supported by a [[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]             |
-| [[Query Table][>QueryTable]] | Supplies the expected results of a query. This is similar to the Fit Row Fixture |
-| [[Subset Query Table][>SubsetQueryTable]] | Supplies a subset of the expected results of a query. |
-| [[Ordered query Table][>OrderedQueryTable]] | Supplies the expected results of a query. The rows are expected to be in order. This is similar to the Fit Row Fixture |
-| [[Script Table][>ScriptTable]] | A series of actions and checks. Similar to Do Fixture. |
-| [[Table Table][>TableTable]] | Whatever you want it to be! |
-| [[Import][>ImportTable]] | Add a path to the fixture search path. |
-| [[Comment][>CommentTable]] | A table that does nothing. |
-| [[Scenario Table][>ScenarioTable]] | A table that can be called from other tables. |
-| [[Library Table][>LibraryTable]] | A table that installs fixtures available for all test pages |
-| [[Define Table Type][>DefineTableType]] | A helper table that defines the default table type for named fixtures. |
-| [[Define Alias][>DefineAlias]] | A helper table that defines alias names for fixtures. |
+|[[Decision Table][>DecisionTable]]                                                              |Supplies the inputs and outputs for decisions. This is similar to the Fit Column Fixture                                                                                                                                           |
+|[[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]|Almost identical to a >DecisionTable but more readable for very big tables with many columns as only the changed values from one line to the baseline must be specified. The fixture implementation is identical to >DecisionTable.|
+|[[Dynamic Decision Table][>DynamicDecisionTable]]                                               |Has the same syntax as a >DecisionTable, but differs in the fixture implementation. It passes the column headers as parameters to the fixture.                                                                                     |
+|[[Hybrid Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.HybridDecisionTable]]    |Combines the advantages in the fixture implementation of a Decision and a Dynamic Decision Table. Also supported by a [[Baseline Decision Table][.FitNesse.SuiteAcceptanceTests.SuiteSlimTests.BaseLineDecisionTable]]             |
+|[[Query Table][>QueryTable]]                                                                    |Supplies the expected results of a query. This is similar to the Fit Row Fixture                                                                                                                                                   |
+|[[Subset Query Table][>SubsetQueryTable]]                                                       |Supplies a subset of the expected results of a query.                                                                                                                                                                              |
+|[[Ordered query Table][>OrderedQueryTable]]                                                     |Supplies the expected results of a query. The rows are expected to be in order. This is similar to the Fit Row Fixture                                                                                                             |
+|[[Script Table][>ScriptTable]]                                                                  |A series of actions and checks. Similar to Do Fixture.                                                                                                                                                                             |
+|[[Table Table][>TableTable]]                                                                    |Whatever you want it to be!                                                                                                                                                                                                        |
+|[[Import][>ImportTable]]                                                                        |Add a path to the fixture search path.                                                                                                                                                                                             |
+|[[Comment][>CommentTable]]                                                                      |A table that does nothing.                                                                                                                                                                                                         |
+|[[Scenario Table][>ScenarioTable]]                                                              |A table that can be called from other tables.                                                                                                                                                                                      |
+|[[Library Table][>LibraryTable]]                                                                |A table that installs fixtures available for all test pages                                                                                                                                                                        |
+|[[Define Table Type][>DefineTableType]]                                                         |A helper table that defines the default table type for named fixtures.                                                                                                                                                             |
+|[[Define Alias][>DefineAlias]]                                                                  |A helper table that defines alias names for fixtures.                                                                                                                                                                              |
 
 !4 Data Types.
 The data in your tables is all Strings. However your fixtures don't want to be constrained to Strings. So Slim comes with several standard data type converters that will automatically convert the strings in the tables into the data types expected by your fixtures.
@@ -41,28 +41,60 @@ You can also create your own custom type converters if you like.
 !see >CustomTypes
 Content returned from the SUT will be escaped by default, so your fixture can return a piece of output without the need to transform it to HTML compatible output. On the other hand, if you're returning HTML content (e.g. a <table>..</table>), FitNesse will try to detect that (based on a valid HTML start and end tag) and will render the HTML in-line.
 
+!anchor watchlink
+
+
+!4 Watch closer what SLIM is doing
+When a SLIM test is run the the webpage will update each time a table has been fully processed.!-
+-!If you want to get quicker an undate you have to set the property: ''slim.show''
+
+At the top of the test page you will then see 2 additional outputs
+1. A list of the last 10 instructions the SLIM server is sending to the SLIM Client and the results of the same. Limitation: An instruction is shown only after it has been executed. So you don't see the currently executing instruction.
+2. The current table and how its cells are updated after each instruction executed.
+
+
+In addition you can use the following two properties to customize this further. They are explained in the next section: 
+slim.show.size
+slim.show.sleep
+
+Try it if you run a local installation: 
+http://localhost:${FITNESSE_PORT}/FitNesse.UserGuide.TwoMinuteExample?test&slim.show&slim.show.sleep=90&slim.show.size=15
+
+Note instuctions are also saved in the [[Test Result XML file][.FitNesse.UserGuide.WritingAcceptanceTests.RestfulTests]]. 
+You have to open the XML file in an editor to see them.
+ 
+
 !4 Configure SLIM
 The Slim test system can be configured using the following properties:
 
-| slim.port | 8085 | Base port for SLIM. |
-| slim.pool.size | 10 | The size of the pool of ports to cycle through. By default the ports 8085 up to 8095 are used (''slim.port'' + ''slim.pool.size''). |
-| slim.host | localhost | The host the SLIM server will be running on. This is mostly useful if you're running a remote SLIM server. |
-| slim.flags | | Extra flags to provide to the SLIM server. Arguments supported by the slim service are: !-
+|property      |default  |description                                                                                                                        |
+|slim.port     |8085     |Base port for SLIM.                                                                                                                |
+|slim.pool.size|10       |The size of the pool of ports to cycle through. By default the ports 8085 up to 8095 are used (''slim.port'' + ''slim.pool.size'').|
+|slim.host     |localhost|The host the SLIM server will be running on. This is mostly useful if you're running a remote SLIM server.                         |
+|slim.flags    |                                                                                                                                             |Extra flags to provide to the SLIM server. Arguments supported by the slim service are: !-
 -![-v] [-i interactionClass] [-s statementTimeout] [-d] [-ssl parameterClass] |
-| slim.timeout | 10 seconds | Connection timeout starting and finishing a test run. |
-| slim.debug.timeout | ''slim.timeout'' | Same as ''slim.timeout'', used when the debug property is set (falls back to ''slim.timeout''). |
-| manually.start.test.runner.on.debug | false | Do not launch a SLIM server if the test is ran in debug mode. |
+|slim.timeout                       |10 seconds      |Connection timeout starting and finishing a test run.                                          |
+|slim.debug.timeout                 |''slim.timeout''|Same as ''slim.timeout'', used when the debug property is set (falls back to ''slim.timeout'').|
+|manually.start.test.runner.on.debug|false           |Do not launch a SLIM server if the test is ran in debug mode.                                  |
+|slim.mode                          |BULK                                                                                                            |BULK mode - By default the SLIM server sends a full table to the SLIM client and gets the results for the full table back. !-
+-! SINGLE mode - Instructions are send one by one to the SLIM Client. This is required for ''slim.show'' and will be set automatically if ''slim.show'' is set !-
+
+-!There is no performance difference between these two modes. The SINGLE mode should make it simpler to write new ports of SLIM in the future. As a normal slim user you don't have to care about this setting.|
+|slim_show||See above under: Whatch closer what Slim is doing .#watchlink !-
+-!Note that slim.show will also set the ''slim.mode'' to SINGLE.|
+|slim.show.size |10|Number of instructions to show                                                                                                                                                              |
+|slim.show.sleep|0 |Waits for X milliseconds between each instruction call. This is for making nice videos of a test run. Otherwise I don't think there is a usecase for slowing down the execution of your test|
 
 Those properties can be either provided by a wiki page, on the command line (e.g. ''-Dslim.port=9000'') or in the plugins.properties file.
 
 !4 Extra Goodies that are consistent throughout all Slim tables and ports.
-| [[''Exception Handling''][>ExceptionHandling]] |
-| [[''Symbols in tables''][>SymbolsInTables]] |
-| [[''Expressions in tables''][>ExpressionsInTables]] |
-| [[''Constructor arguments''][>ConstructorArguments]] |
-| [[''Value comparisons''][>ValueComparisons]] |
-| [[''Graceful names''][>GracefulNames]] |
+|[[''Exception Handling''][>ExceptionHandling]]      |
+|[[''Symbols in tables''][>SymbolsInTables]]         |
+|[[''Expressions in tables''][>ExpressionsInTables]] |
+|[[''Constructor arguments''][>ConstructorArguments]]|
+|[[''Value comparisons''][>ValueComparisons]]        |
+|[[''Graceful names''][>GracefulNames]]              |
 
 !4 Java goodies
-| [[''System Under Test''][>SystemUnderTest]] |
-| [[''Interaction Aware Fixture''][>InteractionAwareFixture]] |
+|[[''System Under Test''][>SystemUnderTest]]                |
+|[[''Interaction Aware Fixture''][>InteractionAwareFixture]]|

--- a/src/fitnesse/reporting/JavascriptUtil.java
+++ b/src/fitnesse/reporting/JavascriptUtil.java
@@ -41,6 +41,13 @@ public class JavascriptUtil {
     return scriptTag;
   }
 
+  public static HtmlTag expandCurrentRow(String idElement) {
+    HtmlTag scriptTag = new HtmlTag("script");
+    String escapedIdElement = escapeHtmlForJavaScript(idElement);
+    scriptTag.add("$( '#" + escapedIdElement + "' ).find( '.closed-detail' ).css( 'display', 'initial' );");
+    return scriptTag;
+  }
+
   public static HtmlTag makeInitErrorMetadataScript() {
     HtmlTag scriptTag = new HtmlTag("script");
     scriptTag.add("initErrorMetadata();");

--- a/src/fitnesse/reporting/SuiteHtmlFormatter.java
+++ b/src/fitnesse/reporting/SuiteHtmlFormatter.java
@@ -4,10 +4,15 @@ package fitnesse.reporting;
 
 import fitnesse.html.HtmlTag;
 import fitnesse.html.HtmlUtil;
+import fitnesse.testsystems.Assertion;
+import fitnesse.testsystems.ExceptionResult;
+import fitnesse.testsystems.ExecutionLogListener;
 import fitnesse.testsystems.ExecutionResult;
 import fitnesse.testsystems.TestPage;
+import fitnesse.testsystems.TestResult;
 import fitnesse.testsystems.TestSummary;
 import fitnesse.testsystems.TestSystem;
+import fitnesse.testsystems.slim.HtmlTable;
 import fitnesse.util.TimeMeasurement;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
@@ -18,7 +23,7 @@ import java.io.Writer;
 
 import static fitnesse.testsystems.ExecutionResult.getExecutionResult;
 
-public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeable {
+public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeable, ExecutionLogListener  {
   private static final String TEST_SUMMARIES_ID = "test-summaries";
 
   private TestSummary pageCounts = new TestSummary();
@@ -177,6 +182,37 @@ public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeabl
       writeData(insertScript.html());
     }
   }
+  
+  @Override
+  public void testAssertionVerified(Assertion assertion, TestResult testResult) {
+    String sbys = getPage().getVariable("slim.sbys");
+    if("SHOWINSTRUCTIONS".equals(sbys)){
+      String html ="";
+      //html = ((HtmlTable) table.getTable()).getTableNode().toHtml().toString();
+      String instructionText;
+      try {
+        instructionText = assertion.getInstruction().toString();
+        if (testResult != null){
+          instructionText = instructionText + "-->" + testResult.toString();
+        } else {
+          instructionText = instructionText + "--> VOID";
+        }
+        instructionText = HtmlUtil.escapeHTML(instructionText);
+        html = "<h2>"+instructionText+"</h2>" + html;
+        String insertScript = JavascriptUtil.makeReplaceElementScript("step-by-step-Id2", html).html();
+        writeData(insertScript);
+        if ("SLEEP".equals(getPage().getVariable("slim.sbys.sleep")))
+        Thread.sleep(500);
+      } catch (Exception e){
+        html = e.getMessage();
+    }
+    }
+  }
+
+  @Override
+  public void testExceptionOccurred(Assertion assertion, ExceptionResult exceptionResult) {
+  }
+
 
   @Override
   protected String makeSummaryContent() {
@@ -189,8 +225,39 @@ public class SuiteHtmlFormatter extends InteractiveFormatter implements Closeabl
     return summaryContent;
   }
 
+
   protected boolean hasTestSummaries() {
     return testSummariesPresent;
+  }
+
+  @Override
+  public void commandStarted(ExecutionContext context) {
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'commandStarted'");
+  }
+
+  @Override
+  public void stdOut(String output) {
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'stdOut'");
+  }
+
+  @Override
+  public void stdErr(String output) {
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'stdErr'");
+  }
+
+  @Override
+  public void exitCode(int exitCode) {
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'exitCode'");
+  }
+
+  @Override
+  public void exceptionOccurred(Throwable e) {
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'exceptionOccurred'");
   }
 }
 

--- a/src/fitnesse/resources/templates/testPage.vm
+++ b/src/fitnesse/resources/templates/testPage.vm
@@ -16,6 +16,13 @@ $!headerContent.render()
 ## Filled with stop/output buttons
 </div>
 
+<div id="step-by-step-Id2">
+## Current Instruction updates here
+</div>
+<div id="step-by-step-Id">
+## Current Table updates here
+</div>
+
 #if ($multipleTestsRun)
 <div id="test-summaries">
     <h2>Test Summaries</h2>

--- a/src/fitnesse/testsystems/TableCell.java
+++ b/src/fitnesse/testsystems/TableCell.java
@@ -1,5 +1,7 @@
 package fitnesse.testsystems;
 
+import fitnesse.testsystems.slim.Table;
+
 /**
  * This interface can be implemented by Expectation's to provide extra information for reporting.
  */
@@ -8,4 +10,6 @@ public interface TableCell {
   int getCol();
 
   int getRow();
+
+  Table getTable();
 }

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import fitnesse.html.HtmlUtil;
+import fitnesse.reporting.JavascriptUtil;
 import fitnesse.slim.instructions.AssignInstruction;
 import fitnesse.slim.instructions.Instruction;
 import fitnesse.testsystems.*;
@@ -118,11 +120,13 @@ public abstract class SlimTestSystem implements TestSystem {
 
   protected void processTable(SlimTable table, boolean isSuiteTearDownPage) throws TestExecutionException {
     List<SlimAssertion> assertions = table.getAssertions();
-    final Map<String, Object> instructionResults;
+     Map<String, Object> instructionResults;
     if (stopTestCalled && !table.isTearDown()) {
       instructionResults = Collections.emptyMap();
+      evaluateTables(assertions, instructionResults);
     } else if (ignoreAllTestsCalled && !table.isTearDown()){
       instructionResults = Collections.emptyMap();
+      evaluateTables(assertions, instructionResults);
     } else {
       boolean tearDownOfAlreadyStartedTest = stopTestCalled && table.isTearDown();
       if(ignoreAllTestsCalled && table.isTearDown()){
@@ -130,71 +134,111 @@ public abstract class SlimTestSystem implements TestSystem {
       }
       if (stopSuiteCalled && !isSuiteTearDownPage && !tearDownOfAlreadyStartedTest) {
         instructionResults = Collections.emptyMap();
+        evaluateTables(assertions, instructionResults);
       } else {
-        instructionResults = slimClient.invokeAndGetResponse(SlimAssertion.getInstructions(assertions));
+        String sbys = getTestContext().getPageToTest().getVariable("slim.sbys");
+        if (sbys != null){
+          boolean IgnoreTestTable = false;
+          for (SlimAssertion a : assertions) {
+            List<SlimAssertion> oneA = new ArrayList<>();
+            oneA.add(a);
+            instructionResults = slimClient.invokeAndGetResponse(SlimAssertion.getInstructions(oneA));
+            final String key = a.getInstruction().getId();
+            Object instructionResult = instructionResults.get(key);
+            IgnoreTestTable = evaluateAssertion(instructionResult,IgnoreTestTable, a, key);
+            //evaluateTables(oneA, instructionResults);
+            if(sbys.equals("SHOWTABLE")){
+              try{
+              String html = ((HtmlTable) table.getTable()).getTableNode().toHtml().toString();
+              String instructionText = a.getInstruction().toString();
+              if(instructionResult != null){
+                instructionText = instructionText + "-->" + instructionResult.toString().substring(0, Math.min(instructionResult.toString().length(),10));
+              }
+              instructionText = HtmlUtil.escapeHTML(instructionText);
+              html = "<h2>"+instructionText+"</h2>" + html;
+              String insertScript = JavascriptUtil.makeReplaceElementScript("step-by-step-Id", html).html();
+              testOutputChunk(null, insertScript);
+              if ("SLEEP".equals(getTestContext().getPageToTest().getVariable("slim.sbys.sleep")))
+                Thread.sleep(500);
+              } catch (Exception e){
+                String em = e.getMessage();
+              }
+            }
+          }
+        } else {
+            instructionResults = slimClient.invokeAndGetResponse(SlimAssertion.getInstructions(assertions));
+            evaluateTables(assertions, instructionResults);
+        }
       }
     }
 
-    evaluateTables(assertions, instructionResults);
+    
   }
 
   protected void evaluateTables(List<SlimAssertion> assertions, Map<String, Object> instructionResults) throws SlimCommunicationException {
     boolean IgnoreTestTable = false;
     for (SlimAssertion a : assertions) {
       final String key = a.getInstruction().getId();
-      Object returnValue = instructionResults.get(key);
+      Object instructionResult = instructionResults.get(key);
+      IgnoreTestTable = evaluateAssertion(instructionResult, IgnoreTestTable, a, key);
+    }
+  }
 
-      //Ignore management
-      if(!ignoreAllTestsCalled) {
-        if (returnValue != null && returnValue.toString().contains(EXCEPTION_IGNORE_ALL_TESTS_TAG)) {
-          ignoreAllTestsCalled = IgnoreTestTable = true;
-        } else if (returnValue != null && returnValue.toString().contains(EXCEPTION_IGNORE_SCRIPT_TEST_TAG)) {
-          IgnoreTestTable = true;
-        } else if (IgnoreTestTable) {
-          returnValue = "IGNORE_SCRIPT_TEST";
-        }
-      } else {
-        returnValue = "IGNORE_SCRIPT_TEST";
+  private boolean evaluateAssertion(Object InstructionResult, boolean IgnoreTestTable, SlimAssertion a, String key)
+     throws SlimCommunicationException {
+    
+
+    //Ignore management
+    if(!ignoreAllTestsCalled) {
+      if (InstructionResult != null && InstructionResult.toString().contains(EXCEPTION_IGNORE_ALL_TESTS_TAG)) {
+        ignoreAllTestsCalled = IgnoreTestTable = true;
+      } else if (InstructionResult != null && InstructionResult.toString().contains(EXCEPTION_IGNORE_SCRIPT_TEST_TAG)) {
+        IgnoreTestTable = true;
+      } else if (IgnoreTestTable) {
+        InstructionResult = "IGNORE_SCRIPT_TEST";
       }
-      //Exception management
-      if (returnValue != null && returnValue instanceof String && ((String) returnValue).startsWith(EXCEPTION_TAG)) {
-        SlimExceptionResult exceptionResult = new SlimExceptionResult(key, (String) returnValue);
-        if (exceptionResult.isStopTestException()) {
-          stopTestCalled = true;
-          stopSuiteCalled = PageData.SUITE_SETUP_NAME.equals(testContext.getPageToTest().getName());
-        }
-        if (exceptionResult.isStopSuiteException()) {
-          stopTestCalled = stopSuiteCalled = true;
-        }
-        exceptionResult = a.getExpectation().evaluateException(exceptionResult);
-        if (exceptionResult != null) {
-          if (!exceptionResult.isCatchException())
-            testExceptionOccurred(a, exceptionResult);
-          else
-            testAssertionVerified(a, exceptionResult.catchTestResult());
-        }
-      } else {
-        //Normal results
-        TestResult testResult = a.getExpectation().evaluateExpectation(returnValue);
-        testAssertionVerified(a, testResult);
+    } else {
+      InstructionResult = "IGNORE_SCRIPT_TEST";
+    }
+    //Exception management
+    if (InstructionResult != null && InstructionResult instanceof String && ((String) InstructionResult).startsWith(EXCEPTION_TAG)) {
+      SlimExceptionResult exceptionResult = new SlimExceptionResult(key, (String) InstructionResult);
+      if (exceptionResult.isStopTestException()) {
+        IgnoreTestTable = stopTestCalled = true;
+        stopSuiteCalled = PageData.SUITE_SETUP_NAME.equals(testContext.getPageToTest().getName());
+      }
+      if (exceptionResult.isStopSuiteException()) {
+        IgnoreTestTable = stopTestCalled = stopSuiteCalled = true;
+      }
+      exceptionResult = a.getExpectation().evaluateException(exceptionResult);
+      if (exceptionResult != null) {
+        if (!exceptionResult.isCatchException())
+          testExceptionOccurred(a, exceptionResult);
+        else
+          testAssertionVerified(a, exceptionResult.catchTestResult());
+      }
+    } else {
+      //Normal results
+      TestResult testResult = a.getExpectation().evaluateExpectation(InstructionResult);
+      testAssertionVerified(a, testResult);
 
-        //Retrieve variables set during expectation step
-        if (testResult != null) {
-          Map<String, ?> variables = testResult.getVariablesToStore();
-          if (variables != null) {
-            List<Instruction> instructions = new ArrayList<>(variables.size());
-            int i = 0;
-            for (Entry<String, ?> variable : variables.entrySet()) {
-              instructions.add(new AssignInstruction("assign_" + i++, variable.getKey(), variable.getValue()));
-            }
-            //Store variables in context
-            if (i > 0) {
-              slimClient.invokeAndGetResponse(instructions);
-            }
+      //Retrieve variables set during expectation step
+      if (testResult != null) {
+        Map<String, ?> variables = testResult.getVariablesToStore();
+        if (variables != null) {
+          List<Instruction> instructions = new ArrayList<>(variables.size());
+          int i = 0;
+          for (Entry<String, ?> variable : variables.entrySet()) {
+            instructions.add(new AssignInstruction("assign_" + i++, variable.getKey(), variable.getValue()));
+          }
+          //Store variables in context
+          if (i > 0) {
+            slimClient.invokeAndGetResponse(instructions);
           }
         }
       }
     }
+    return IgnoreTestTable;
   }
 
   protected void testOutputChunk(TestPage testPage, String output) {

--- a/src/fitnesse/testsystems/slim/SlimTestSystem.java
+++ b/src/fitnesse/testsystems/slim/SlimTestSystem.java
@@ -155,9 +155,11 @@ public abstract class SlimTestSystem implements TestSystem {
                 instructionText = instructionText + "-->" + instructionResult.toString().substring(0, Math.min(instructionResult.toString().length(),10));
               }
               instructionText = HtmlUtil.escapeHTML(instructionText);
-              html = "<h2>"+instructionText+"</h2>" + html;
+              html = "<h4>"+instructionText+"</h4>" + html;
               String insertScript = JavascriptUtil.makeReplaceElementScript("step-by-step-Id", html).html();
               testOutputChunk(null, insertScript);
+              String expandScript = JavascriptUtil.expandCurrentRow("step-by-step-Id").html();
+              testOutputChunk(null, expandScript);
               if ("SLEEP".equals(getTestContext().getPageToTest().getVariable("slim.sbys.sleep")))
                 Thread.sleep(500);
               } catch (Exception e){
@@ -204,11 +206,13 @@ public abstract class SlimTestSystem implements TestSystem {
     if (InstructionResult != null && InstructionResult instanceof String && ((String) InstructionResult).startsWith(EXCEPTION_TAG)) {
       SlimExceptionResult exceptionResult = new SlimExceptionResult(key, (String) InstructionResult);
       if (exceptionResult.isStopTestException()) {
-        IgnoreTestTable = stopTestCalled = true;
+        //IgnoreTestTable = stopTestCalled = true;
+        stopTestCalled = true;
         stopSuiteCalled = PageData.SUITE_SETUP_NAME.equals(testContext.getPageToTest().getName());
       }
       if (exceptionResult.isStopSuiteException()) {
-        IgnoreTestTable = stopTestCalled = stopSuiteCalled = true;
+        //IgnoreTestTable = stopTestCalled = stopSuiteCalled = true;
+        stopTestCalled = stopSuiteCalled = true;
       }
       exceptionResult = a.getExpectation().evaluateException(exceptionResult);
       if (exceptionResult != null) {

--- a/src/fitnesse/testsystems/slim/tables/SlimTable.java
+++ b/src/fitnesse/testsystems/slim/tables/SlimTable.java
@@ -302,6 +302,10 @@ public abstract class SlimTable {
     public int getRow() {
       return row;
     }
+    @Override
+    public Table getTable() {
+      return table;
+    }
 
     // Used only by TestXmlFormatter.SlimTestXmlFormatter
     public String getExpected() {


### PR DESCRIPTION
This is an alternative implementation to #1469  from @pvbemmelen62
As it is fully implemented in the Slim Server it will work for all Slim ports and not only for the Java Slim Client as the other mentioned PR.

It adds a new feature to see the instructions SLIM is creating step by step and also see how a SLIM table changes with each execution. 
To achieve this result the Slim Test System needed a change to suport processing of SINGLE instructions.
The existing SLIM implementation always sends a full table to the SLIM client for execution, which I call BULK mode. In the past there may have been performence concernces for the network communication to do it in this bulk way. Nowdays this is not an issue. 
Modern protocols like the [Language Server Protocol](https://en.wikipedia.org/wiki/Language_Server_Protocol) or [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol//) work also in a step by step approach to get the best interactive experience. Nevertheless this new SINGLE mode is not active by default. Default is still the BULK mode. Only when more interaction is requested the SLIM test system will switch to this mode.


### Usage Guide - From the updated Wiki page
When a SLIM test is run the the webpage will update each time a table has been fully processed.
If you want to get quicker an undate you have to set the property: ''slim.show''

At the top of the test page you will then see 2 additional outputs

1. A list of the last 10 instructions the SLIM server is sending to the SLIM Client and the results of the same. Limitation: An instruction is shown only after it has been executed. So you don't see the currently executing instruction.
2. The current table and how its cells are updated after each instruction executed.


In addition you can use the following two properties to customize this further: 

- slim.show.size - default 10 - Number of instructions to show

- slim.show.sleep - default 0 - Waits for X milliseconds between each instruction call. This is for making nice videos of a test run. Otherwise I don't think there is a usecase for slowing down the execution of your test

Those properties can be either provided by a wiki page, on the command line (e.g. ''-Dslim.port=9000'') or in the plugins.properties file.

Watch the video:

https://github.com/unclebob/fitnesse/assets/5906592/a11fb7dc-b9e4-425a-ac85-a596f9d0b921


Sample Invocation:
http://localhost:80/FitNesse.UserGuide.TwoMinuteExample?test&slim.show&slim.show.sleep=90&slim.show.size=15


