### PR TITLE
ignore UnsupportedOperationException thrown by jdk>18 when trying to setup the SystemExitSecurityManager

### DIFF
--- a/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
+++ b/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
@@ -36,9 +36,9 @@ public class SystemExitSecurityManager extends SecurityManager {
     } catch (SecurityException e) {
       System.err.println("Security manager could not be updated");
     } catch (UnsupportedOperationException e) {
-      System.err.println("Security manager could not be updated. If you are usin a JDK version >=18, you need to set " +
-        "-Djava.security.manager=allow to allow this. Or use -Dprevent.system.exit=false to disable this feature inside " +
-        "fitnesse. Exception was :" + e.getMessage());
+      System.err.println("Security manager could not be updated. If you are using a JDK version >=18, you need to set " +
+        "-Djava.security.manager=allow to allow this. Or use -Dprevent.system.exit=false to disable the FitNesse feature" +
+        " blocking System.exit() calls and prevent this message.");
     }
   }
 

--- a/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
+++ b/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
@@ -35,6 +35,10 @@ public class SystemExitSecurityManager extends SecurityManager {
       System.setSecurityManager(securityManager);
     } catch (SecurityException e) {
       System.err.println("Security manager could not be updated");
+    } catch (UnsupportedOperationException e) {
+      System.err.println("Security manager could not be updated. If you are usin a JDK version >=18, you need to set " +
+        "-Djava.security.manager=allow to allow this. Or use -Dprevent.system.exit=false to disable this feature inside " +
+        "fitnesse. Exception was :" + e.getMessage());
     }
   }
 


### PR DESCRIPTION
fixes #1455

I added a catch clause for UnsupportedOperationException showing an error message instead of failing.

I do not know how to add tests for something like this!