### PR TITLE
Allow default slf4j provider to be found via service locator

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 Pending Changes
+ * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
 
 !2 20240707
  * Allow usage of JDK > 18 ([[1513][https://github.com/unclebob/fitnesse/pull/1513]]).

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ sourceSets {
   main {
     java.srcDir 'src'
     resources.srcDir 'src'
-    output.resourcesDir java.classesDirectory 
+    output.resourcesDir java.classesDirectory
   }
   test {
     java.srcDir 'test'
@@ -189,7 +189,10 @@ task standaloneJar(type: Jar) {
   from {
     configurations.runtimeClasspath.collect { zipTree(it) }
   } {
-    exclude 'META-INF/**'
+    exclude { FileTreeElement details ->
+      details.relativePath.pathString.startsWith('META-INF/') &&
+        !details.relativePath.pathString.equals('META-INF/services/org.slf4j.spi.SLF4JServiceProvider')
+    }
   }
   from jar.outputs.files.collect {
     zipTree(it)


### PR DESCRIPTION
Ensure slf4j logging is not lost but is sent to 'java.util.logging' (using 'slf4j-jdk14'), an explicit other provider can be used via the system property `slf4j.provider`, see [SLF4J Manual](https://www.slf4j.org/manual.html#swapping).

Fixes #1520 