### PR TITLE
No longer prevent `System.exit()` by default

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,5 +1,5 @@
 !2 Pending Changes
- * IMPORTANT: !style_code[System.exit()] is no longer prevented by default, to allow functioning without issue on JDK > 18. On lower Java versions it can be prevented by setting the system property !style_code[prevent.system.exit] to !style_code[true].
+ * IMPORTANT: !style_code[System.exit()] is no longer prevented by default ([[1524][https://github.com/unclebob/fitnesse/pull/1524]]).
  * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
 
 !2 20240707

--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 Pending Changes
+ * IMPORTANT: !style_code[System.exit()] is no longer prevented by default, to allow functioning without issue on JDK > 18. On lower Java versions it can be prevented by setting the system property !style_code[prevent.system.exit] to !style_code[true].
  * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
 
 !2 20240707

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SystemExitIsPrevented/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SystemExitIsPrevented/content.txt
@@ -1,3 +1,5 @@
+This test should be removed or 'pruned' when running on Java 21 or higher, as preventing system exit is no longer supported there.
+
 !|script|SystemExitTableConfiguration                 |
 |set system property|prevent.system.exit|to|true|
 

--- a/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
+++ b/src/fitnesse/slim/instructions/SystemExitSecurityManager.java
@@ -54,7 +54,7 @@ public class SystemExitSecurityManager extends SecurityManager {
     if (preventSystemExitString != null) {
       return Boolean.parseBoolean(preventSystemExitString);
     } else {
-      return true;
+      return false;
     }
   }
 

--- a/test/fitnesse/slim/instructions/SystemExitSecurityManagerTest.java
+++ b/test/fitnesse/slim/instructions/SystemExitSecurityManagerTest.java
@@ -1,19 +1,13 @@
 package fitnesse.slim.instructions;
 
-import static org.junit.Assert.fail;
-import static util.RegexTestCase.assertMatches;
-
+import fitnesse.slim.instructions.SystemExitSecurityManager.SystemExitException;
 import org.junit.After;
 import org.junit.Test;
 
-import fitnesse.slim.instructions.SystemExitSecurityManager.SystemExitException;
+import static org.junit.Assert.fail;
+import static util.RegexTestCase.assertMatches;
 
 public class SystemExitSecurityManagerTest {
-
-  SecurityManager oldSecurityManager;
-
-  SecurityManager securityManager;
-
   @After
   public void teardown() {
     SystemExitSecurityManager.restoreOriginalSecurityManager();
@@ -21,24 +15,23 @@ public class SystemExitSecurityManagerTest {
 
   @Test(expected = SystemExitException.class)
   public void shouldThrowExceptionWhenSystemExitIsCalled() {
-    acticateSystemExitSecurityManager();
+    activateSystemExitSecurityManager();
     System.exit(0);
     fail("should have thrown exception");
-
   }
 
   @Test
   public void shouldIncludeExitCode() {
     try {
-      acticateSystemExitSecurityManager();
+      activateSystemExitSecurityManager();
       System.exit(42);
       fail("should have thrown exception");
     } catch (SystemExitException e) {
       assertMatches("system exit with exit code 42", e.getMessage());
     }
   }
-  
-  private void acticateSystemExitSecurityManager() {
+
+  private void activateSystemExitSecurityManager() {
     System.setSecurityManager(null);
     System.setProperty(SystemExitSecurityManager.PREVENT_SYSTEM_EXIT, "true");
     SystemExitSecurityManager.activateIfWanted();


### PR DESCRIPTION
`System.exit()` is no longer prevented by default, to allow functioning without issue on JDK > 18. 

On lower Java versions it can be prevented, restoring the previous default, by setting the system property `prevent.system.exit` to `true`. (On the test runner process not the wiki servers process, of course)
