### PR TITLE
Also build and test on Java 17

### DIFF
--- a/.github/workflows/build-fitnesse.yml
+++ b/.github/workflows/build-fitnesse.yml
@@ -6,6 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ '11', '17' ]
+
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -13,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
       - name: Build with Gradle

--- a/.github/workflows/build-fitnesse.yml
+++ b/.github/workflows/build-fitnesse.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ '11', '17' ]
+        java-version: [ '11', '17', '21' ]
 
     steps:
       - name: Check out Git repository
@@ -20,6 +20,9 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
+      - name: Remove Java 21 incompatible tests
+        if: ${{ matrix.java-version == '21' }}
+        run: rm -rf FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteSlimTests/SystemExitIsPrevented
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v3
         with:

--- a/.github/workflows/build-fitnesse.yml
+++ b/.github/workflows/build-fitnesse.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: libs
+          name: libs-java-${{ matrix.java-version }}
           path: build/libs
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,4 +1,5 @@
 !2 Pending Changes
+ * Support using Java 17 and 21, 11 remains supported too ([[1525][https://github.com/unclebob/fitnesse/pull/1525]])
  * IMPORTANT: !style_code[System.exit()] is no longer prevented by default ([[1524][https://github.com/unclebob/fitnesse/pull/1524]]).
  * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
 

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecutionLog/ExecutionLogOfTestPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecutionLog/ExecutionLogOfTestPage/content.txt
@@ -3,6 +3,7 @@
 !| script |
 | given page | TestPage | with content | ${SUT_PATH} !-
 !define TEST_SYSTEM {slim}
+!define SLIM_PORT {0}
 
 | import |
 | fitnesse.slim.test |

--- a/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecutionLog/ExecutionLogOfTestPage/content.txt
+++ b/FitNesseRoot/FitNesse/SuiteAcceptanceTests/SuiteTestHistory/SuiteExecutionLog/ExecutionLogOfTestPage/content.txt
@@ -3,7 +3,6 @@
 !| script |
 | given page | TestPage | with content | ${SUT_PATH} !-
 !define TEST_SYSTEM {slim}
-!define SLIM_PORT {0}
 
 | import |
 | fitnesse.slim.test |

--- a/src/fitnesse/slim/LoggingOutputStream.java
+++ b/src/fitnesse/slim/LoggingOutputStream.java
@@ -10,6 +10,8 @@ import java.io.PrintStream;
  * An OutputStream that writes contents to a Logger upon each call to flush()
  */
 class LoggingOutputStream extends ByteArrayOutputStream {
+  private static final int JAVA_VERSION = Runtime.version().feature();
+  private static final boolean EXTRA_NEWLINE_EXPECTED = JAVA_VERSION >= 17;
 
   private String lineSeparator;
 
@@ -49,6 +51,10 @@ class LoggingOutputStream extends ByteArrayOutputStream {
     if (record.length() == 0 || record.equals(lineSeparator)) {
       // avoid empty records
       return;
+    }
+    if (EXTRA_NEWLINE_EXPECTED) {
+      // extra newlines after each message, strip those
+      record = record.substring(0, record.length() - 1);
     }
     // Prefix each new line with: newline + level + DOT + ":"
     record = record.replace("\n", "\n" + level

--- a/src/fitnesse/slim/SlimPipeSocket.java
+++ b/src/fitnesse/slim/SlimPipeSocket.java
@@ -2,16 +2,17 @@
 
 package fitnesse.slim;
 
+import fitnesse.util.MockSocket;
+import util.FileUtil;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import util.FileUtil;
-import fitnesse.util.MockSocket;
 
 public class SlimPipeSocket extends ServerSocket {
   public static final String STDOUT_PREFIX = "SOUT";
@@ -42,13 +43,14 @@ public class SlimPipeSocket extends ServerSocket {
     this.stdin = System.in;
 
     // bind System.stdout/System.stderr to original stderr
-    System.setOut(new PrintStream(new LoggingOutputStream(this.stderr, STDOUT_PREFIX),
-        true, FileUtil.CHARENCODING));
-    System.setErr(new PrintStream(new LoggingOutputStream(this.stderr, STDERR_PREFIX),
-        true, FileUtil.CHARENCODING));
+    System.setOut(wrapStream(this.stderr, STDOUT_PREFIX));
+    System.setErr(wrapStream(this.stderr, STDERR_PREFIX));
 
     LOG.log(Level.FINER, "Creating Slim Server with pipe socket.");
+  }
 
+  static PrintStream wrapStream(PrintStream original, String prefix) throws UnsupportedEncodingException {
+    return new PrintStream(new LoggingOutputStream(original, prefix), true, FileUtil.CHARENCODING);
   }
 
   @Override

--- a/test/fitnesse/slim/LoggingOutputStreamTest.java
+++ b/test/fitnesse/slim/LoggingOutputStreamTest.java
@@ -1,0 +1,100 @@
+package fitnesse.slim;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+public class LoggingOutputStreamTest {
+  @Test
+  public void handlesSingleLine() throws IOException {
+    assertEquals(
+      "ABC.:Hello World\n",
+      printlnOutput("Hello World"));
+  }
+
+  @Test
+  public void handlesMultiLine() throws IOException {
+    assertEquals(
+      "ABC.:Hello World\n" +
+        "ABC :\n" +
+        "ABC :The weather is nice!\n",
+      printlnOutput("Hello World\n\nThe weather is nice!"));
+  }
+
+  @Test
+  public void handlesMultiLineWithNewlineEnd() throws IOException {
+    assertEquals(
+      "ABC.:Hello World\n" +
+        "ABC :The weather is nice!\n" +
+        "ABC :\n",
+      printlnOutput("Hello World\nThe weather is nice!\n"));
+  }
+
+  @Test
+  public void handlesMultiprintln() throws IOException {
+    assertEquals(
+      "ABC.:Hello World\n" +
+        "ABC.:The weather is nice!\n",
+      outputWith(s -> {
+        s.println("Hello World");
+        s.println("The weather is nice!");
+      }));
+  }
+
+  @Test
+  public void handlesMultiprint() throws IOException {
+    assertEquals(
+      "ABC.:Hello\n" +
+      "ABC.: \n" +
+      "ABC.:World\n",
+      outputWith(s -> {
+        s.print("Hello");
+        s.print(" ");
+        s.print("World");
+        s.print("\n");
+      }));
+  }
+
+  @Test
+  public void handlesExtraFlushes() throws IOException {
+    assertEquals(
+      "ABC.:Hello\n" +
+        "ABC.: \n" +
+        "ABC.:World\n" +
+        "ABC.:The weather is nice!\n",
+      outputWith(s -> {
+        s.print("Hello");
+        s.flush();
+        s.flush();
+        s.print(" ");
+        s.print("World");
+        s.println();
+        s.flush();
+        s.println("The weather is nice!");
+        s.flush();
+      }));
+  }
+
+  private String outputWith(Consumer<PrintStream> consumer) throws IOException {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); PrintStream myStream = new PrintStream(baos)) {
+      try (PrintStream stream = createStream(myStream)) {
+        consumer.accept(stream);
+      }
+      return baos.toString();
+    }
+  }
+
+  private String printlnOutput(String input) throws IOException {
+    return outputWith(s -> s.println(input));
+  }
+
+  private PrintStream createStream(PrintStream originalStream) throws UnsupportedEncodingException {
+    return SlimPipeSocket.wrapStream(originalStream, "ABC");
+  }
+}


### PR DESCRIPTION
Update GitHub workflow to also build FitNesse on Java 17 and run all tests

@six42 as you can see I had to update one test case to get the build to pass. It appears that `fitnesse.slim.LoggingOutputStream` does not behave the same on Java 17 as it did on earlier versions. An extra newline is added to the execution log for each `println()` call to either stdin or stout when the communication with the Slim server is not via a socket. 

I have had issues in the past with this way of communicating between FitNesse and the Slim server (character encoding trouble on an IBM JVM on windows), so in my tests I always just have Slim choose a random free port (by setting the Slim port to `0`). Changing the communication protocol to use an actual socket also fixed this test. I couldn't put my finger on why the extra newline is added, but maybe it's an obvious fix for you?
I find the name of the class (`LoggingOutputStream`) a bit strange also, it's not logging its decorating the input it receives before forwarding it to the nested stream as I understand it. Maybe it would already be much simpler (the newline handling in there) if instead of just forwarding the lines received as text the records would be Base64 encoded (then each record will just always be 1 line I think)?