### PR TITLE
javascript injection using tags inside the search result page

### DIFF
--- a/src/fitnesse/resources/templates/searchResults.vm
+++ b/src/fitnesse/resources/templates/searchResults.vm
@@ -35,7 +35,7 @@
    </td>
    <td style="text-align: right;">
    #set ( $tags = $result.getData().getAttribute("Suites") )
-	<label>#if ($tags && !$tags.equals("null"))$tags#end</label>
+	<label>#if ($tags && !$tags.equals("null"))#escape($tags)#end</label>
    </td>
    <td>$result.getData().getProperties().getLastModificationTime()
    </td>

--- a/test/fitnesse/responders/search/SearchResponderTest.java
+++ b/test/fitnesse/responders/search/SearchResponderTest.java
@@ -8,9 +8,7 @@ import fitnesse.http.MockResponseSender;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.testutil.FitNesseUtil;
-import fitnesse.wiki.PathParser;
-import fitnesse.wiki.WikiPage;
-import fitnesse.wiki.WikiPageUtil;
+import fitnesse.wiki.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +25,7 @@ public class SearchResponderTest {
   public void setUp() throws Exception {
     context = FitNesseUtil.makeTestContext();
     WikiPage somePage = WikiPageUtil.addPage(context.getRootPage(), PathParser.parse("SomePage"), "has something in it");
+
     WikiPageUtil.addPage(somePage, PathParser.parse("SomeTest"), "test page content");
     WikiPageUtil.addPage(somePage, PathParser.parse("SomeSuite"), "suite page content");
     request = new MockRequest();
@@ -217,5 +216,15 @@ public class SearchResponderTest {
     String searchPageContent = getResponseContentUsingSearchString("suite page");
 
     assertSubString("<a href=\"SomePage.SomeSuite?suite\">Suite</a>", searchPageContent);
+  }
+  @Test
+  public void tagsShouldBeEscaped() throws Exception {
+    WikiPage somePage = context.getRootPage().getChildPage("SomePage");
+    PageData data = somePage.getData();
+    data.setAttribute(WikiPageProperty.SUITES, " <script>TEST</script> ");
+    somePage.commit(data);
+    String searchPageContent = getResponseContentUsingSearchString("something");
+
+    assertSubString("&lt;script&gt;TEST&lt;/script&gt;", searchPageContent);
   }
 }


### PR DESCRIPTION
Hi,

We found a small bug in the way the page "tags" are used in the search result page: They are not escaped there so if you set something like <script>alert('hello')</script> as the tag, the javascript will be executed when the page is included in  the search results.

This MR adds the missing `#escape` call in the template