### PR TITLE
Fixed Ignore exception issue whereby it was still executing every sta…

### DIFF
--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,5 +1,6 @@
 !2 Pending Changes
  * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
+ * Fix Ignore exception issue whereby it still executes every statement in the script table even though it will ignore the result
 
 !2 20240707
  * Allow usage of JDK > 18 ([[1513][https://github.com/unclebob/fitnesse/pull/1513]]).

--- a/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
+++ b/FitNesseRoot/FitNesse/ReleaseNotes/content.txt
@@ -1,6 +1,6 @@
 !2 Pending Changes
  * Fix SLF4J logging ([[1522][https://github.com/unclebob/fitnesse/pull/1522]])
- * Fix Ignore exception issue whereby it still executes every statement in the script table even though it will ignore the result
+ * Fix IgnoreAllTests exception and IgnoreScriptTest exception issue whereby if either exception is thrown it would still execute subsequent statements in the script table
 
 !2 20240707
  * Allow usage of JDK > 18 ([[1513][https://github.com/unclebob/fitnesse/pull/1513]]).

--- a/src/fitnesse/slim/StatementExecutor.java
+++ b/src/fitnesse/slim/StatementExecutor.java
@@ -191,7 +191,7 @@ public class StatementExecutor implements StatementExecutorInterface {
 
 
   private void checkExceptionForStop(Throwable exception) {
-    if (isStopTestException(exception) || isStopSuiteException(exception)) {
+    if (isStopTestException(exception) || isStopSuiteException(exception) || isIgnoreAllTestsException(exception) || isIgnoreScriptTestException(exception)) {
       stopRequested = true;
     }
   }

--- a/src/fitnesse/slim/test/TestSlim.java
+++ b/src/fitnesse/slim/test/TestSlim.java
@@ -2,6 +2,9 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.slim.test;
 
+import fitnesse.slim.SlimIgnoreAllTestsException;
+import fitnesse.slim.SlimIgnoreScriptTestException;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -38,7 +41,7 @@ public class TestSlim implements TestSlimInterface {
     this.constructorArg = constructorArg;
     stringArg = other.getStringArg();
   }
-  
+
   public TestSlim createTestSlimWithString(String string) {
     TestSlim testSlim = new TestSlim();
     testSlim.setString(string);
@@ -49,7 +52,7 @@ public class TestSlim implements TestSlimInterface {
   public String toString() {
     return "TestSlim: " + constructorArg + ", " + stringArg;
   }
-  
+
   public void nilad() {
     niladWasCalled = true;
   }
@@ -113,7 +116,7 @@ public class TestSlim implements TestSlimInterface {
   public Date getDateArg() {
     return new Date(dateArg.getTime());
   }
-  
+
   public void oneInt(int arg) {
     intArg = arg;
   }
@@ -236,11 +239,11 @@ public class TestSlim implements TestSlimInterface {
   public boolean isSame(Object other) {
     return this == other;
   }
-  
+
   public String getStringFromOther(TestSlim other) {
     return other.getStringArg();
   }
-  
+
   public Zork oneZork(Zork zork) {
     this.zork = zork;
     return zork;
@@ -253,22 +256,30 @@ public class TestSlim implements TestSlimInterface {
 
   class NoSuchConverter {
   }
-  
+
   public boolean throwNormal() throws Exception {
     throw  new Exception("This is my exception");
   }
-  
+
   public boolean throwStopping() throws Exception {
     throw new StopTestException("This is a stop test exception");
   }
-  
+
+  public boolean throwIgnoreAllStopping() throws Exception {
+    throw new SlimIgnoreAllTestsException("This is an ignore all script test exception");
+  }
+
+  public boolean throwIgnoreScriptStopping() throws Exception {
+    throw new SlimIgnoreScriptTestException("This is an ignore script test exception");
+  }
+
   public boolean throwExceptionWithMessage() throws Exception {
     throw new Exception("message:<<Test message>>");
   }
-  
+
   public boolean throwStopTestExceptionWithMessage() throws Exception {
     throw new StopTestException("message:<<Stop Test>>");
-  }  
+  }
 
   public String concatenateThreeArgs(String first, String second, String third) {
     return first + " " + second + " " + third;
@@ -281,7 +292,7 @@ public class TestSlim implements TestSlimInterface {
   public Map<String, String> getMap() {
     return  map;
   }
-  
+
   @SuppressWarnings("serial")
   class StopTestException extends Exception {
     public StopTestException(String description) {

--- a/test/fitnesse/slim/SlimServiceTestBase.java
+++ b/test/fitnesse/slim/SlimServiceTestBase.java
@@ -244,6 +244,26 @@ public abstract class SlimServiceTestBase {
   }
 
   @Test
+  public void IgnoreAllTestExceptionThrownAndNextStatementResultIsNull() throws Exception {
+    addImportAndMake();
+    statements.add(new CallInstruction("id", "testSlim", "throwIgnoreAllStopping"));
+    statements.add(new CallInstruction("id2", "testSlim", "echoString", new Object[] { "hello" }));
+    Map<String, Object> results = slimClient.invokeAndGetResponse(statements);
+    assertContainsException("__EXCEPTION__:IGNORE_ALL_TESTS:", "id", results);
+    assertNull(results.get("id2"));
+  }
+
+  @Test
+  public void IgnoreScriptTestExceptionThrownAndNextStatementResultIsNull() throws Exception {
+    addImportAndMake();
+    statements.add(new CallInstruction("id", "testSlim", "throwIgnoreScriptStopping"));
+    statements.add(new CallInstruction("id2", "testSlim", "echoString", new Object[] { "hello" }));
+    Map<String, Object> results = slimClient.invokeAndGetResponse(statements);
+    assertContainsException("__EXCEPTION__:IGNORE_SCRIPT_TEST:", "id", results);
+    assertNull(results.get("id2"));
+  }
+
+  @Test
   public void canSpecifyAnInteractionClass() {
     final SlimService.Options options = SlimService.parseCommandLine(new String[]{"-i", "fitnesse.slim.fixtureInteraction.DefaultInteraction"});
     assertNotNull("should parse correctly", options);
@@ -273,5 +293,4 @@ public abstract class SlimServiceTestBase {
     assertTrue("should be verbose", options.verbose);
     assertEquals("should have set port", 7890, options.port);
   }
-
 }

--- a/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
+++ b/test/fitnesse/testsystems/slim/SlimTestSystemTableProcessingTest.java
@@ -59,8 +59,9 @@ public class SlimTestSystemTableProcessingTest {
     String exceptionId = SlimServer.EXCEPTION_IGNORE_SCRIPT_TEST_TAG + "table1 with random ignore exception";
     slimTestSystem.processTable(table(exceptionId), false);
     slimTestSystem.processTable(table("Table2"), false);
+    slimTestSystem.processTable(table("Table3"), false);
 
-    assertTestRecords(ignore(exceptionId), pass("Table2"));
+    assertTestRecords(ignore(exceptionId), pass("Table2"), pass("Table3"));
   }
 
   @Test
@@ -68,8 +69,9 @@ public class SlimTestSystemTableProcessingTest {
     String exceptionId = SlimServer.EXCEPTION_IGNORE_ALL_TESTS_TAG + "table1 with random ignore exception";
     slimTestSystem.processTable(table(exceptionId), false);
     slimTestSystem.processTable(table("Table2"), false);
+    slimTestSystem.processTable(table("Table3"), false);
 
-    assertTestRecords(ignore(exceptionId), ignore("Table2"));
+    assertTestRecords(ignore(exceptionId), ignore("Table2"), ignore("Table3"));
   }
 
   @Test


### PR DESCRIPTION
Fixed Ignore exception issue whereby it was still executing every statement in the script table even though it will ignore the result

Example below shows IGNORE_ALL_TESTS exception but what I found was it would still execute the lines below even though it would ignore the result. This fix resolves that issue which also help speed up the overall test
![image](https://github.com/user-attachments/assets/5c3a7364-a149-4900-b46d-81e7561c2b4a)
