### PR TITLE
 UI – add “Last N” filters & “Trim page names” toggle to testHistory.vm

### DIFF
--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -11,18 +11,18 @@ To further improve clarity and usability, the table is now displayed with altern
 !4 Details
 The ''test history database'' is kept in !style_code(!-FitNesseRoot/files/testResults-!).  Beneath this directory there is a subdirectory for each test or suite.  These directories contain the ''page history'' and are named for the page that contains the test or suite.  Beneath the page history directory is a file for each test result.
 
-The test result files are named using the following scheme !style_code(YYYYMMDDHHMMSS_R_W_I_E.xml) where YYYYMMDDHHMMSS is the date and time of the test run, and R, W, I, and E are integers representing the number of Right, Wrong, Ignored, and Exception counts for the test or suite. For tests they are assertion counts. For suites they are test counts. (Example: !style_code(20090513134259_12_20_4_2.xml))
+The test result files are named using the following scheme !style_code(YYYYMMDDHHMMSS_R_W_I_E.xml)  where YYYYMMDDHHMMSS is the date and time of the test run, and R, W, I, and E are integers representing the number of Right, Wrong, Ignored, and Exception counts for the test or suite.  For tests they are assertion counts.  For suites they are test counts.  (Example: !style_code(20090513134259_12_20_4_2.xml))
 
-The test files contain the XML that describes the test run. The format of this XML is identical to the XML packet returned by the !style_code(format=xml) flag when you run a test. (See <UserGuide.RestfulTests>.)
+The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
 
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files. You have your choice of ''all'', ''>7 days'', or ''>30 days''. If you want to purge a different number of days, you can change the ''TestHistory.purgeOptions'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge options, or you can use the RESTful URL form. (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeOptions'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge options, or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history. Additionally, you can configure the property ''TestHistory.maxCount'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to limit the number of histories to keep.
 
 !4 Comparing History
-When viewing the history for a page, you can select any two test results by clicking in their checkboxes. Then, if you click the ''Compare'' button, you will be shown the two test results side-by-side along with an indicator that tells you if the results are identical or not.
+When viewing the history for a page, you can select any two test results by clicking in their checkboxes.  Then, if you click the ''Compare'' button, you will be shown the two test results side-by-side along with an indicator that tells you if the results are identical or not.
 
-Only tests can be compared this way. Suites cannot.
+Only tests can be compared this way.  Suites cannot.
 
-Notice that the comparison is pretty smart. It tries to line up the two tests on a table-by-table basis. It can detect if tables have been inserted or deleted. The % code that you see on the left is just the match score for the tables.
+Notice that the comparison is pretty smart.  It tries to line up the two tests on a table-by-table basis.  It can detect if tables have been inserted or deleted.  The % code that you see on the left is just the match score for the tables.

--- a/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
+++ b/FitNesseRoot/FitNesse/UserGuide/WritingAcceptanceTests/TestHistory/content.txt
@@ -1,24 +1,28 @@
 Every time you run a test or a suite, the results are recorded in the ''test history database''.  You can view the history by clicking on the !style_code(Test History) button.  The reports are pretty self-explanatory.
 
-When you click on !style_code(Test History) you will be shown the directory of all tests and suites that are in the ''test history database''.  This directory also shows you the status of the last 20 results from each test or suite.  You can click on the name of the test or suite to get a detailed ''page history'', or you can click on any of the individual status elements to see the particular test result.
+When you click on !style_code(Test History) you will be shown the directory of all tests and suites that are in the ''test history database''.  This directory also shows you the status of the most recent results from each test or suite. By default, the last 20 results are shown, but you can now choose to display only the !style_code(Last 3), !style_code(Last 5), !style_code(Last 10), or !style_code(Last 20) results using the button group at the top of the page. This makes it easier to focus on recent trends or reduce clutter from older test runs.
 
-The detailed ''page history'' shows you a directory of all the test results for that test or suite.  The bar chart shows how how the number of tests (for suites) or assertions (for tests) has grown over time, and the pass/fail ratio.  Clicking on an entry takes you to that specific test result.
+Each row in the table shows a test or suite name, the number of passed and failed runs, the date of the latest run, and a bar graph with the recent outcomes (!style_code(+) for pass, !style_code(-) for fail). You can click on the name of the test or suite to get a detailed ''page history'', or you can click on any of the individual status symbols to view the specific test result.
+
+If a shared prefix exists in test or suite names (e.g., !style_code(FitNesse.SuiteAcceptanceTests.)), a checkbox labeled !style_code(Trim page names) will appear. When selected, this option trims the redundant prefix from the displayed names, improving readability of deeply nested pages.
+
+To further improve clarity and usability, the table is now displayed with alternating row stripes. Column headers also include small info icons with tooltips, offering helpful explanations such as "Number of tests passed", "Latest test run", or "Recent result status" when hovered over.
 
 !4 Details
 The ''test history database'' is kept in !style_code(!-FitNesseRoot/files/testResults-!).  Beneath this directory there is a subdirectory for each test or suite.  These directories contain the ''page history'' and are named for the page that contains the test or suite.  Beneath the page history directory is a file for each test result.
 
-The test result files are named using the following scheme !style_code(YYYYMMDDHHMMSS_R_W_I_E.xml)  where YYYYMMDDHHMMSS is the date and time of the test run, and R, W, I, and E are integers representing the number of Right, Wrong, Ignored, and Exception counts for the test or suite.  For tests they are assertion counts.  For suites they are test counts.  (Example: !style_code(20090513134259_12_20_4_2.xml))
+The test result files are named using the following scheme !style_code(YYYYMMDDHHMMSS_R_W_I_E.xml) where YYYYMMDDHHMMSS is the date and time of the test run, and R, W, I, and E are integers representing the number of Right, Wrong, Ignored, and Exception counts for the test or suite. For tests they are assertion counts. For suites they are test counts. (Example: !style_code(20090513134259_12_20_4_2.xml))
 
-The test files contain the XML that describes the test run.  The format of this XML is identical to the XML packet returned by the format=xml flag when you run a test.  (See <UserGuide.RestfulTests).
+The test files contain the XML that describes the test run. The format of this XML is identical to the XML packet returned by the !style_code(format=xml) flag when you run a test. (See <UserGuide.RestfulTests>.)
 
 !4 Purging
-There are buttons at the top of the ''Test History'' page that allow you to purge old history files.  You have your choice of ''all'', ''>7 days'', or ''>30 days''.  If you want to purge a different number of days, you can change the ''TestHistory.purgeOptions'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge options, or you can use the RESTful URL form.  (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
+There are buttons at the top of the ''Test History'' page that allow you to purge old history files. You have your choice of ''all'', ''>7 days'', or ''>30 days''. If you want to purge a different number of days, you can change the ''TestHistory.purgeOptions'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to allow additional purge options, or you can use the RESTful URL form. (See [[!-RestfulServices-!][<UserGuide.AdministeringFitNesse.RestfulServices]]).
 
 You can also clean up the test history right after a test execution. To do so, configure a property ''test.history.days'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] or as a [[page variable][<UserGuide.FitNesseWiki.MarkupLanguageReference.MarkupVariables]] and assign it the number of days you want to keep history. Additionally, you can configure the property ''TestHistory.maxCount'' in the [[configuration file][<UserGuide.AdministeringFitNesse.ConfigurationFile]] to limit the number of histories to keep.
 
 !4 Comparing History
-When viewing the history for a page, you can select any two test results by clicking in their checkboxes.  Then, if you click the ''Compare'' button, you will be shown the two test results side-by-side along with an indicator that tells you if the results are identical or not.
+When viewing the history for a page, you can select any two test results by clicking in their checkboxes. Then, if you click the ''Compare'' button, you will be shown the two test results side-by-side along with an indicator that tells you if the results are identical or not.
 
-Only tests can be compared this way.  Suites cannot.
+Only tests can be compared this way. Suites cannot.
 
-Notice that the comparison is pretty smart.  It tries to line up the two tests on a table-by-table basis.  It can detect if tables have been inserted or deleted.  The % code that you see on the left is just the match score for the tables.
+Notice that the comparison is pretty smart. It tries to line up the two tests on a table-by-table basis. It can detect if tables have been inserted or deleted. The % code that you see on the left is just the match score for the tables.

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -1,4 +1,7 @@
 <h1>Test history</h1>
+<head>
+  <link rel="stylesheet" href="../scss/customize.scss">
+</head>
 #set($resultsToShow = 20)
 #if($request.hasInput("results"))
  #set($resultsToShow = $request.getInput("results"))
@@ -11,16 +14,20 @@
 <div class="d-flex align-items-center mb-2">
  <a class="btn btn-outline-secondary mr-2" href="?responder=overview">View as Overview</a>
  <a class="btn btn-outline-secondary mr-4" href="$viewLocation">Cancel</a>
- <label for="hidePassedTests" class="mb-0 text-nowrap">
-  <input type="checkbox" id="hidePassedTests" class="mr-1"/>Hide passed tests
- </label>
+ <nobr>
+  <label for="hidePassedTests">
+   <input type="checkbox" id="hidePassedTests" class="mr-1"/>Hide passed tests
+  </label>
+ <nobr>
 </div>
 <div>
  #if(!$purgeOptions.isEmpty())
   #foreach($purgeOption in $purgeOptions)
    <a class="btn btn-outline-secondary" href="?responder=purgeHistory&days=$purgeOption" onclick="purgeConfirmation(event)">Purge#if ($purgeOption == 0) all#else &gt; $purgeOption days#end</a>
   #end
-  <label for="purgeGlobal" class="mb-0 text-nowrap"><input type="checkbox" id="purgeGlobal" />Purge global</label>
+  <nobr>
+   <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
+  </nobr>
  #end
 </div>
 <div class="d-flex align-items-center my-2">
@@ -48,17 +55,19 @@
  <form class="mb-0" method="get">
   <input type="hidden" name="responder" value="testHistory"/>
   <input type="hidden" name="results"   value="$resultsToShow"/>
-  <label for="trimPath" class="mb-0 text-nowrap">
-   <input type="checkbox"
-          id="trimPath"
-          class="mr-1"
-          name="trim"
-          value="$trimPrefixSuggestion"
-          #if($trimPrefixSuggestion=="")disabled#end
-          #if($trimPrefix!="")checked#end
-          onchange="this.form.submit()"/>
-   Trim page names
-  </label>
+  <nobr>
+   <label for="trimPath">
+    <input type="checkbox"
+           id="trimPath"
+           class="mr-1"
+           name="trim"
+           value="$trimPrefixSuggestion"
+           #if($trimPrefixSuggestion=="")disabled#end
+           #if($trimPrefix!="")checked#end
+           onchange="this.form.submit()"/>
+    Trim page names
+   </label>
+  </nobr>
  </form>
 </div>
 <table class="table-striped">

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -10,7 +10,7 @@
 #set($noHistory = true)
 <div class="d-flex align-items-center mb-2">
  <a class="btn btn-outline-secondary mr-2" href="?responder=overview">View as Overview</a>
- <a class="btn btn-outline-secondary mr-2" href="$viewLocation">Cancel</a>
+ <a class="btn btn-outline-secondary mr-4" href="$viewLocation">Cancel</a>
  <label for="hidePassedTests" class="mb-0 text-nowrap">
   <input type="checkbox" id="hidePassedTests" class="mr-1"/>Hide passed tests
  </label>
@@ -20,7 +20,7 @@
   #foreach($purgeOption in $purgeOptions)
    <a class="btn btn-outline-secondary" href="?responder=purgeHistory&days=$purgeOption" onclick="purgeConfirmation(event)">Purge#if ($purgeOption == 0) all#else &gt; $purgeOption days#end</a>
   #end
-  <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
+  <label for="purgeGlobal" class="mb-0 text-nowrap"><input type="checkbox" id="purgeGlobal" />Purge global</label>
  #end
 </div>
 <div class="btn-group mt-2" role="group" aria-label="Show last N results">
@@ -30,28 +30,39 @@
  <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end" href="?responder=testHistory&results=20#if($trimPrefix!='')&trim=$trimPrefix#end">Last 20</a>
 </div>
 
-<form class="form-inline my-2" method="get">
- <input type="hidden" name="responder" value="testHistory"/>
- #if($request.hasInput("results"))
-  <input type="hidden" name="results" value="$resultsToShow"/>
+#set($trimPrefixSuggestion = "")
+#foreach($p in $testHistory.pageNames)
+ #set($firstPage = $p)
+ #break
+#end
+#if($firstPage)
+ #set($parts = $firstPage.split("\."))
+ #if($parts.size() > 2)
+  #set($trimPrefixSuggestion = "${parts[0]}.${parts[1]}.")
  #end
- <label class="mr-1" for="trimPrefix">Trim path:</label>
- <input type="text" class="form-control form-control-sm" id="trimPrefix" name="trim" value="$!trimPrefix" placeholder="Common prefix"/>
- <span class="ml-1 mr-2 text-muted align-self-center" style="cursor:help" data-toggle="tooltip" title="Enter the full common prefix to remove from each page name">&#9432;</span>
- <button type="submit" class="btn btn-secondary btn-sm">Apply</button>
-</form>
+#end
+<div class="my-2">
+#if($trimPrefix == "")
+ <a class="btn btn-outline-secondary mr-2#if($trimPrefixSuggestion=='') disabled#end"
+  href="?responder=testHistory&results=$resultsToShow#if($trimPrefixSuggestion!='')&trim=$trimPrefixSuggestion#end">
+  Trim Page Names
+ </a>
+#else
+ <a class="btn btn-outline-secondary mr-2 active"
+  href="?responder=testHistory&results=$resultsToShow">
+  Show Full Page Names
+ </a>
+#end
+</div>
 
 <table class="table-striped">
-  <tr>
-    <th>Page <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Test page name">&#9432;</span></th>
-    <th>Pass <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests passed">&#9432;</span></th>
-    <th>Fail <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests failed">&#9432;</span></th>
-    <th>Latest <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Latest test run date and time">&#9432;</span></th>
-    <th colspan="$resultsToShow">
-      Last $resultsToShow Results
-      <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="‘+’ = passed, ‘–’ = failed. Most-recent result is on the left">&#9432;</span>
-    </th>
-  </tr>
+<tr>
+  <th class="text-nowrap">Page <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Test page name">&#9432;</span></th>
+  <th class="text-nowrap">Pass <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests passed">&#9432;</span></th>
+  <th class="text-nowrap">Fail <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests failed">&#9432;</span></th>
+  <th class="text-nowrap">Latest <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Latest test run date and time">&#9432;</span></th>
+  <th colspan="$resultsToShow">Last $resultsToShow Results <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="‘+’ = passed, ‘–’ = failed. Most-recent result is on the left">&#9432;</span></th>
+</tr>
 
   #foreach ($page in $testHistory.pageNames)
   #set ($pageHistory = $testHistory.getPageHistory($page))
@@ -60,15 +71,12 @@
 
   <tr>
     #set ($barGraph = $pageHistory.getBarGraph())
-
     #if($pageHistory.passes==0) #set ($passClass = "ignore")
     #else #set ($passClass = "pass")
     #end
-
     #if($pageHistory.failures==0) #set ($failClass = "ignore")
     #else #set ($failClass = "fail")
     #end
-
     #set($displayPage = $page)
     #if($trimPrefix != "" && $page.startsWith($trimPrefix))
       #set($displayPage = $page.substring($trimPrefix.length()))

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -1,4 +1,12 @@
 <h1>Test history</h1>
+#set($resultsToShow = 20)
+#if($request.hasInput("results"))
+ #set($resultsToShow = $request.getInput("results"))
+#end
+#set($trimPrefix = "")
+#if($request.hasInput("trim"))
+ #set($trimPrefix = $request.getInput("trim"))
+#end
 #set($noHistory = true)
 <div>
  <a class="btn btn-outline-secondary" href="?responder=overview">View as Overview</a>
@@ -13,15 +21,36 @@
   <label for="purgeGlobal"><input type="checkbox" id="purgeGlobal" />Purge global</label>
  #end
 </div>
+<div class="btn-group mt-2" role="group" aria-label="Show last N results">
+ <a class="btn btn-outline-secondary#if($resultsToShow==3) active#end"  href="?responder=testHistory&results=3">Last 3</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==5) active#end"  href="?responder=testHistory&results=5">Last 5</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==10) active#end" href="?responder=testHistory&results=10">Last 10</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end" href="?responder=testHistory&results=20">Last 20</a>
+</div>
 
-<table>
- <tr>
-  <th>Page</th>
-  <th>Pass</th>
-  <th>Fail</th>
-  <th>Latest</th>
-  <th colspan="20">Last 20 Results</th>
- </tr>
+<form class="form-inline mt-2" method="get">
+ <input type="hidden" name="responder" value="testHistory"/>
+ #if($request.hasInput("results"))
+  <input type="hidden" name="results" value="$resultsToShow"/>
+ #end
+ <label class="mr-1" for="trimPrefix">Trim path:</label>
+ <input type="text" class="form-control form-control-sm" id="trimPrefix" name="trim" value="$!trimPrefix" placeholder="Common prefix"/>
+ <span class="ml-1 mr-2 text-muted align-self-center" style="cursor:help" data-toggle="tooltip" title="Enter the full common prefix to remove from each page name">&#9432;</span>
+ <button type="submit" class="btn btn-secondary btn-sm">Apply</button>
+</form>
+
+<table class="table-striped">
+  <tr>
+    <th>Page <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Test page name">&#9432;</span></th>
+    <th>Pass <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests passed">&#9432;</span></th>
+    <th>Fail <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Number of tests failed">&#9432;</span></th>
+    <th>Latest <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Latest test run date and time">&#9432;</span></th>
+    <th colspan="$resultsToShow">
+      Last $resultsToShow Results
+      <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="‘+’ = passed, ‘–’ = failed. Most-recent result is on the left">&#9432;</span>
+    </th>
+  </tr>
+
   #foreach ($page in $testHistory.pageNames)
   #set ($pageHistory = $testHistory.getPageHistory($page))
   #if($pageHistory)
@@ -38,12 +67,19 @@
     #else #set ($failClass = "fail")
     #end
 
-    <td><a href="${contextRoot}$page?pageHistory">$page</a></td>
+    #set($displayPage = $page)
+    #if($trimPrefix != "" && $page.startsWith($trimPrefix))
+      #set($displayPage = $page.substring($trimPrefix.length()))
+      #if($displayPage.startsWith(".")) #set($displayPage = $displayPage.substring(1)) #end
+    #end
+    <td><a href="${contextRoot}$page?pageHistory">$displayPage</a></td>
     <td class="$passClass">$pageHistory.passes</td>
     <td class="$failClass">$pageHistory.failures</td>
     <td>$barGraph.formatEndingDate("dd MMM yy, HH:mm")</td>
+    #set($i = 0)
     #foreach($passFail in $barGraph.passFailArray())
-    <td class="$passFail.result"><a href="$page?pageHistory&resultDate=$passFail.Date">#if($passFail.pass)+#else-#end</a></td>
+      #if($i < $resultsToShow)<td class="$passFail.result"><a href="$page?pageHistory&resultDate=$passFail.Date">#if($passFail.pass)+#else-#end</a></td>#end
+      #set($i = $i + 1)
     #end
 
   </tr>

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -8,10 +8,12 @@
  #set($trimPrefix = $request.getInput("trim"))
 #end
 #set($noHistory = true)
-<div>
- <a class="btn btn-outline-secondary" href="?responder=overview">View as Overview</a>
- <a class="btn btn-outline-secondary" href="$viewLocation">Cancel</a>
- <label for="hidePassedTests"><input type="checkbox" id="hidePassedTests"/>Hide passed tests</label>
+<div class="d-flex align-items-center mb-2">
+ <a class="btn btn-outline-secondary mr-2" href="?responder=overview">View as Overview</a>
+ <a class="btn btn-outline-secondary mr-2" href="$viewLocation">Cancel</a>
+ <label for="hidePassedTests" class="mb-0 text-nowrap">
+  <input type="checkbox" id="hidePassedTests" class="mr-1"/>Hide passed tests
+ </label>
 </div>
 <div>
  #if(!$purgeOptions.isEmpty())
@@ -22,13 +24,13 @@
  #end
 </div>
 <div class="btn-group mt-2" role="group" aria-label="Show last N results">
- <a class="btn btn-outline-secondary#if($resultsToShow==3) active#end"  href="?responder=testHistory&results=3">Last 3</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==5) active#end"  href="?responder=testHistory&results=5">Last 5</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==10) active#end" href="?responder=testHistory&results=10">Last 10</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end" href="?responder=testHistory&results=20">Last 20</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==3) active#end" href="?responder=testHistory&results=3#if($trimPrefix!='')&trim=$trimPrefix#end">Last 3</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==5) active#end" href="?responder=testHistory&results=5#if($trimPrefix!='')&trim=$trimPrefix#end">Last 5</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==10) active#end" href="?responder=testHistory&results=10#if($trimPrefix!='')&trim=$trimPrefix#end">Last 10</a>
+ <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end" href="?responder=testHistory&results=20#if($trimPrefix!='')&trim=$trimPrefix#end">Last 20</a>
 </div>
 
-<form class="form-inline mt-2" method="get">
+<form class="form-inline my-2" method="get">
  <input type="hidden" name="responder" value="testHistory"/>
  #if($request.hasInput("results"))
   <input type="hidden" name="results" value="$resultsToShow"/>

--- a/src/fitnesse/resources/templates/testHistory.vm
+++ b/src/fitnesse/resources/templates/testHistory.vm
@@ -23,38 +23,44 @@
   <label for="purgeGlobal" class="mb-0 text-nowrap"><input type="checkbox" id="purgeGlobal" />Purge global</label>
  #end
 </div>
-<div class="btn-group mt-2" role="group" aria-label="Show last N results">
- <a class="btn btn-outline-secondary#if($resultsToShow==3) active#end" href="?responder=testHistory&results=3#if($trimPrefix!='')&trim=$trimPrefix#end">Last 3</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==5) active#end" href="?responder=testHistory&results=5#if($trimPrefix!='')&trim=$trimPrefix#end">Last 5</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==10) active#end" href="?responder=testHistory&results=10#if($trimPrefix!='')&trim=$trimPrefix#end">Last 10</a>
- <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end" href="?responder=testHistory&results=20#if($trimPrefix!='')&trim=$trimPrefix#end">Last 20</a>
-</div>
-
-#set($trimPrefixSuggestion = "")
-#foreach($p in $testHistory.pageNames)
- #set($firstPage = $p)
- #break
-#end
-#if($firstPage)
- #set($parts = $firstPage.split("\."))
- #if($parts.size() > 2)
-  #set($trimPrefixSuggestion = "${parts[0]}.${parts[1]}.")
+<div class="d-flex align-items-center my-2">
+ <div class="btn-group mr-4" role="group" aria-label="Show last N results">
+  <a class="btn btn-outline-secondary#if($resultsToShow==3) active#end"
+     href="?responder=testHistory&results=3#if($trimPrefix!='')&trim=$trimPrefix#end">Last 3</a>
+  <a class="btn btn-outline-secondary#if($resultsToShow==5) active#end"
+     href="?responder=testHistory&results=5#if($trimPrefix!='')&trim=$trimPrefix#end">Last 5</a>
+  <a class="btn btn-outline-secondary#if($resultsToShow==10) active#end"
+     href="?responder=testHistory&results=10#if($trimPrefix!='')&trim=$trimPrefix#end">Last 10</a>
+  <a class="btn btn-outline-secondary#if($resultsToShow==20) active#end"
+     href="?responder=testHistory&results=20#if($trimPrefix!='')&trim=$trimPrefix#end">Last 20</a>
+ </div>
+ #set($trimPrefixSuggestion = "")
+ #foreach($p in $testHistory.pageNames)
+  #set($firstPage = $p)
+  #break
  #end
-#end
-<div class="my-2">
-#if($trimPrefix == "")
- <a class="btn btn-outline-secondary mr-2#if($trimPrefixSuggestion=='') disabled#end"
-  href="?responder=testHistory&results=$resultsToShow#if($trimPrefixSuggestion!='')&trim=$trimPrefixSuggestion#end">
-  Trim Page Names
- </a>
-#else
- <a class="btn btn-outline-secondary mr-2 active"
-  href="?responder=testHistory&results=$resultsToShow">
-  Show Full Page Names
- </a>
-#end
+ #if($firstPage)
+  #set($parts = $firstPage.split("\."))
+  #if($parts.size() > 2)
+   #set($trimPrefixSuggestion = "${parts[0]}.${parts[1]}.")
+  #end
+ #end
+ <form class="mb-0" method="get">
+  <input type="hidden" name="responder" value="testHistory"/>
+  <input type="hidden" name="results"   value="$resultsToShow"/>
+  <label for="trimPath" class="mb-0 text-nowrap">
+   <input type="checkbox"
+          id="trimPath"
+          class="mr-1"
+          name="trim"
+          value="$trimPrefixSuggestion"
+          #if($trimPrefixSuggestion=="")disabled#end
+          #if($trimPrefix!="")checked#end
+          onchange="this.form.submit()"/>
+   Trim page names
+  </label>
+ </form>
 </div>
-
 <table class="table-striped">
 <tr>
   <th class="text-nowrap">Page <span class="ml-1 text-muted" style="cursor:help" data-toggle="tooltip" title="Test page name">&#9432;</span></th>

--- a/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
+++ b/test/fitnesse/responders/testHistory/TestHistoryResponderTest.java
@@ -378,4 +378,37 @@ public class TestHistoryResponderTest {
     assertNotSubString("<a class=\"btn btn-outline-secondary\" href=\"?responder=purgeHistory&days=7\" onclick=\"purgeConfirmation(event)\">Purge &gt; 7 days</a>", html);
     assertNotSubString("<label for=\"purgeGlobal\"><input type=\"checkbox\" id=\"purgeGlobal\" />Purge global</label>", html);
   }
+
+  @Test
+  public void shouldShowLastNResultButtons() throws Exception {
+    MockRequest request = new MockRequest();
+    SimpleResponse resp  = (SimpleResponse) new TestHistoryResponder().makeResponse(context, request);
+    String html = resp.getContent();
+    assertSubString("?responder=testHistory&results=3", html);
+    assertSubString(">Last 3<", html);
+    assertSubString("?responder=testHistory&results=5", html);
+    assertSubString("?responder=testHistory&results=10", html);
+    assertSubString("?responder=testHistory&results=20", html);
+  }
+
+  @Test
+  public void shouldOfferTrimCheckboxWhenSuggestionExists() throws Exception {
+    addPageDirectoryWithOneResult("FitNesse.SuiteAcceptanceTests.DummyPage", "20090418123103_1_0_0_0");
+    makeResponse();                               
+    String html = response.getContent();
+    assertSubString("id=\"trimPath\"", html);
+    assertDoesntHaveRegexp("id=\"trimPath\"[^\n]+checked", html);
+    assertSubString("Trim page names", html);
+  }
+
+  @Test
+  public void shouldRenderTrimCheckboxCheckedWhenTrimIsApplied() throws Exception {
+    addPageDirectoryWithOneResult("FitNesse.SuiteAcceptanceTests.DummyPage", "20090418123103_1_0_0_0");
+    MockRequest req = new MockRequest();
+    req.addInput("trim", "FitNesse.SuiteAcceptanceTests.");
+    SimpleResponse resp = (SimpleResponse) new TestHistoryResponder().makeResponse(context, req);
+    String html = resp.getContent();
+    assertSubString("id=\"trimPath\"", html);
+    assertHasRegexp("id=\"trimPath\"[\\s\\S]*?checked", html);
+  }
 }


### PR DESCRIPTION
Added button group (Last 3/5/10/20) that passes results= query param.
Added “Trim page names” checkbox that toggles trim= prefix in the query string.
Added tooltip for each header element of test history table.
Minor layout tweaks (<nobr> wrappers) so labels don’t wrap and striped table.
