### PR TITLE
Enhance !contents to support filtering by Suites tag using -tag / -t option

### DIFF
--- a/src/fitnesse/wikitext/parser/Contents.java
+++ b/src/fitnesse/wikitext/parser/Contents.java
@@ -16,43 +16,52 @@ public class Contents extends SymbolType implements Rule, Translation {
 
     @Override
     public Maybe<Symbol> parse(Symbol current, Parser parser) {
-        Symbol body = parser.parseToEnd(SymbolType.Newline);
-        for (Symbol child: body.getChildren()) {
-            if (child.isType(SymbolType.Whitespace)) continue;
-            String option = child.getContent();
-            if (!option.startsWith("-")) return Symbol.nothing;
-            if (option.equals("-R")) {
-              current.putProperty(option, String.valueOf(Integer.MAX_VALUE));
+      Symbol body = parser.parseToEnd(SymbolType.Newline);
+
+      for (int i = 0; i < body.getChildren().size(); i++) {
+        Symbol child = body.getChildren().get(i);
+
+        if (child.isType(SymbolType.Whitespace)) continue;
+        String option = child.getContent();
+        if (!option.startsWith("-")) return Symbol.nothing;
+        if (option.equals("-R")) {
+          current.putProperty(option, String.valueOf(Integer.MAX_VALUE));
+        } else if (option.startsWith("-R")) {
+          current.putProperty("-R", option.substring(2));
+        } else if (option.equalsIgnoreCase("-t") || option.equalsIgnoreCase("-tag")) {
+          if (i + 1 < body.getChildren().size()) {
+            Symbol tagValueSymbol = body.getChildren().get(i + 1);
+            if (!tagValueSymbol.isType(SymbolType.Whitespace)) {
+              current.putProperty("-tag", tagValueSymbol.getContent());
+              i++;
             }
-            else if (option.startsWith("-R")) {
-              current.putProperty("-R", option.substring(2));
-            }
-            else {
-              current.putProperty(option, "");
-            }
+          }
+        } else {
+          current.putProperty(option, "");
         }
+      }
 
-        current.copyVariables(new String[] {
-                  Names.HELP_TOC,
-                  Names.HELP_INSTEAD_OF_TITLE_TOC,
-                  Names.REGRACE_TOC,
-                  Names.PROPERTY_TOC,
-                  Names.FILTER_TOC,
-                  Names.MORE_SUFFIX_TOC,
-                  Names.PROPERTY_CHARACTERS,
-                  Names.TEST_PAGE_COUNT_TOC},
-                parser.getVariableSource());
+      current.copyVariables(new String[]{
+        Names.HELP_TOC,
+        Names.HELP_INSTEAD_OF_TITLE_TOC,
+        Names.REGRACE_TOC,
+        Names.PROPERTY_TOC,
+        Names.FILTER_TOC,
+        Names.MORE_SUFFIX_TOC,
+        Names.PROPERTY_CHARACTERS,
+        Names.TEST_PAGE_COUNT_TOC
+      }, parser.getVariableSource());
 
-        return new Maybe<>(current);
+      return new Maybe<>(current);
     }
-    @Override
-    public String toTarget(Translator translator, Symbol symbol) {
-        ContentsItemBuilder itemBuilder
-                = new ContentsItemBuilder(symbol, 1, translator.getPage());
-        HtmlTag contentsDiv = new HtmlTag("div");
-        contentsDiv.addAttribute("class", "contents");
-        contentsDiv.add(HtmlUtil.makeBold("Contents:"));
-        contentsDiv.add(itemBuilder.buildLevel(translator.getPage()));
-        return contentsDiv.html();
-    }
+
+  public String toTarget(Translator translator, Symbol symbol) {
+    ContentsItemBuilder itemBuilder
+      = new ContentsItemBuilder(symbol, 1, translator.getPage());
+    HtmlTag contentsDiv = new HtmlTag("div");
+    contentsDiv.addAttribute("class", "contents");
+    contentsDiv.add(HtmlUtil.makeBold("Contents:"));
+    contentsDiv.add(itemBuilder.buildLevel(translator.getPage()));
+    return contentsDiv.html();
+  }
 }

--- a/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
+++ b/src/fitnesse/wikitext/shared/ContentsItemBuilder.java
@@ -9,171 +9,189 @@ import fitnesse.wiki.WikiSourcePage;
 import fitnesse.wikitext.SourcePage;
 import util.GracefulNamer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ContentsItemBuilder {
-    private final PropertySource contents;
-    private final int level;
-    private final SourcePage page;
+  private final PropertySource contents;
+  private final int level;
+  private final SourcePage page;
 
-    public ContentsItemBuilder(PropertySource contents, int level) {
-        this(contents, level, null);
-    }
+  public ContentsItemBuilder(PropertySource contents, int level) {
+    this(contents, level, null);
+  }
 
-    public ContentsItemBuilder(PropertySource contents, int level, SourcePage page) {
-        this.contents = contents;
-        this.level = level;
-        this.page = page;
-    }
+  public ContentsItemBuilder(PropertySource contents, int level, SourcePage page) {
+    this.contents = contents;
+    this.level = level;
+    this.page = page;
+  }
 
-    public HtmlTag buildLevel(SourcePage page) {
-        HtmlTag list = new HtmlTag("ul");
-        list.addAttribute("class", "toc" + level);
-        for (SourcePage child: getSortedChildren(page)) {
-            list.add(buildListItem(child));
-        }
-        return list;
-    }
-
-    private HtmlTag buildListItem(SourcePage child) {
-        HtmlTag listItem = buildItem(child);
-        if (!child.getChildren().isEmpty()) {
-            if (level < getRecursionLimit()) {
-                listItem.add(new ContentsItemBuilder(contents, level + 1, child).buildLevel(child));
-            }
-            else if (getRecursionLimit() > 0){
-                listItem.add(contents.findProperty(Names.MORE_SUFFIX_TOC, Names.MORE_SUFFIX_DEFAULT));
-            }
-        }
-        return listItem;
-    }
-
-    private Collection<SourcePage> getSortedChildren(SourcePage parent) {
-        ArrayList<SourcePage> result = new ArrayList<>(parent.getChildren());
-        Collections.sort(result);
-        return result;
-    }
-
-    public HtmlTag buildItem(SourcePage page) {
-        HtmlTag listItem = new HtmlTag("li");
-        HtmlTag link = new HtmlTag("a", buildBody(page));
-        link.addAttribute("href", buildReference(page));
-        link.addAttribute("class", getBooleanPropertiesClasses(page));
-        listItem.add(link);
-        String help = page.getProperty(WikiPageProperty.HELP);
-        if (!help.isEmpty()) {
-            if (hasOption("-h", Names.HELP_TOC)) {
-                listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + help));
-            }
-            else if (hasOption("-H", Names.HELP_INSTEAD_OF_TITLE_TOC)) {
-                link.use(help);
-            }
-            else {
-                link.addAttribute("title", help);
-            }
-        }
-        return listItem;
-    }
-    private boolean isSpecialPageToBeCountedAsTest(SourcePage page){
-      String pageName = page.getName();
-      return pageName.contains("SuiteSetUp") || pageName.contains("SuiteTearDown");
-    }
-
-    private int getTotalTestPagesInASuite(SourcePage page) {
-      if (page.hasProperty(PageType.TEST.toString()) || isSpecialPageToBeCountedAsTest(page)){
-        return 1;
-      }
-      int counter = 0;
-      if (page.hasProperty(PageType.SUITE.toString())) {
-        Iterator<SourcePage> pages = page.getChildren().iterator();
-        while (pages.hasNext()) {
-          SourcePage sourcePage = pages.next();
-          counter += getTotalTestPagesInASuite(sourcePage);
-        }
-      }
-      return counter;
-    }
-
-    private String buildBody(SourcePage page) {
-        String itemText = page.getName();
-        //Will show count of test pages under this suite
-        if (hasOption("-c", Names.TEST_PAGE_COUNT_TOC)) {
-          if (page.hasProperty(PageType.SUITE.toString()))
-            itemText += " ( " + getTotalTestPagesInASuite(page) + " )";
-        }
-
-        if (hasOption("-g", Names.REGRACE_TOC)) {
-            //todo: DRY? see wikiwordbuilder
-            itemText = GracefulNamer.regrace(itemText);
-        }
-
-        if (hasOption("-p", Names.PROPERTY_TOC)) {
-            String properties = getBooleanProperties(page);
-            if (!properties.isEmpty()) itemText += " " + properties;
-        }
-
-        if (hasOption("-f", Names.FILTER_TOC)) {
-            String filters = page.getProperty(WikiPageProperty.SUITES);
-            if (!filters.isEmpty()) itemText += " (" + filters + ")";
-        }
-
-        return itemText;
-    }
-
-    private String buildReference(SourcePage sourcePage) {
-        return sourcePage.getFullName();
-    }
-
-    private int getRecursionLimit() {
-      String level = contents.findProperty("-R", "0");
-      try {
-        return Integer.parseInt(level);
-      } catch (NumberFormatException e) {
-        return 0;
+  public HtmlTag buildLevel(SourcePage page) {
+    HtmlTag list = new HtmlTag("ul");
+    list.addAttribute("class", "toc" + level);
+    Optional<String> tagFilter = contents.findProperty("-tag");
+    for (SourcePage child : getSortedChildren(page)) {
+      if (!tagFilter.isPresent() || pageContainsTag(child, tagFilter.get())) {
+        list.add(buildListItem(child));
       }
     }
+    return list;
+  }
 
-    private boolean hasOption(String option, String variableName) {
-      return contents.hasProperty(option) ||
-        (!variableName.isEmpty()
-          && contents.findProperty(variableName, "").equals("true"));
+
+  private HtmlTag buildListItem(SourcePage child) {
+    HtmlTag listItem = buildItem(child);
+    if (!child.getChildren().isEmpty()) {
+      if (level < getRecursionLimit()) {
+        listItem.add(new ContentsItemBuilder(contents, level + 1, child).buildLevel(child));
+      } else if (getRecursionLimit() > 0) {
+        listItem.add(contents.findProperty(Names.MORE_SUFFIX_TOC, Names.MORE_SUFFIX_DEFAULT));
+      }
+    }
+    return listItem;
+  }
+
+  private Collection<SourcePage> getSortedChildren(SourcePage parent) {
+    ArrayList<SourcePage> result = new ArrayList<>(parent.getChildren());
+    Collections.sort(result);
+    return result;
+  }
+
+  public HtmlTag buildItem(SourcePage page) {
+    HtmlTag listItem = new HtmlTag("li");
+    HtmlTag link = new HtmlTag("a", buildBody(page));
+    link.addAttribute("href", buildReference(page));
+    link.addAttribute("class", getBooleanPropertiesClasses(page));
+    listItem.add(link);
+    String help = page.getProperty(WikiPageProperty.HELP);
+    if (!help.isEmpty()) {
+      if (hasOption("-h", Names.HELP_TOC)) {
+        listItem.add(HtmlUtil.makeSpanTag("pageHelp", ": " + help));
+      } else if (hasOption("-H", Names.HELP_INSTEAD_OF_TITLE_TOC)) {
+        link.use(help);
+      } else {
+        link.addAttribute("title", help);
+      }
+    }
+    return listItem;
+  }
+
+  private boolean isSpecialPageToBeCountedAsTest(SourcePage page) {
+    String pageName = page.getName();
+    return pageName.contains("SuiteSetUp") || pageName.contains("SuiteTearDown");
+  }
+
+  private int getTotalTestPagesInASuite(SourcePage page) {
+    if (page.hasProperty(PageType.TEST.toString()) || isSpecialPageToBeCountedAsTest(page)) {
+      return 1;
+    }
+    int counter = 0;
+    if (page.hasProperty(PageType.SUITE.toString())) {
+      Iterator<SourcePage> pages = page.getChildren().iterator();
+      while (pages.hasNext()) {
+        SourcePage sourcePage = pages.next();
+        counter += getTotalTestPagesInASuite(sourcePage);
+      }
+    }
+    return counter;
+  }
+
+  private String buildBody(SourcePage page) {
+    String itemText = page.getName();
+    //Will show count of test pages under this suite
+    if (hasOption("-c", Names.TEST_PAGE_COUNT_TOC)) {
+      if (page.hasProperty(PageType.SUITE.toString()))
+        itemText += " ( " + getTotalTestPagesInASuite(page) + " )";
     }
 
-    private String getBooleanProperties(SourcePage sourcePage) {
-        String propChars = contents.findProperty(Names.PROPERTY_CHARACTERS,
-                PROPERTY_CHARACTERS_DEFAULT).trim();
-        if(propChars.length() != PROPERTY_CHARACTERS_DEFAULT.length() ){
-            propChars = PROPERTY_CHARACTERS_DEFAULT;
-        }
-
-        String result = "";
-        if (sourcePage.hasProperty(PageType.SUITE.toString())) result += propChars.charAt(0);
-        if (sourcePage.hasProperty(PageType.TEST.toString())) result += propChars.charAt(1);
-        if (sourcePage.hasProperty(WikiImportProperty.PROPERTY_NAME)) result += propChars.charAt(2);
-        if (page != null && page instanceof WikiSourcePage){
-            if (((WikiSourcePage)page).hasSymbolicLinkChild(sourcePage.getName())) result += propChars.charAt(3);
-        }
-        if (sourcePage.hasProperty(WikiPageProperty.PRUNE)) result += propChars.charAt(4);
-        return result;
-    }
-    private String getBooleanPropertiesClasses(SourcePage sourcePage) {
-        String result = "";
-        if (sourcePage.hasProperty(PageType.SUITE.toString())) {
-        		result += "suite";
-        	}
-        else if (sourcePage.hasProperty(PageType.TEST.toString())) {
-        	result += "test";
-        	}
-        else {
-        	result += "static";
-        }
-        if (sourcePage.hasProperty(WikiImportProperty.PROPERTY_NAME)) result += " linked";
-        if (sourcePage.hasProperty(WikiPageProperty.PRUNE)) result += " pruned";
-        return result;
+    if (hasOption("-g", Names.REGRACE_TOC)) {
+      //todo: DRY? see wikiwordbuilder
+      itemText = GracefulNamer.regrace(itemText);
     }
 
-    private static final String PROPERTY_CHARACTERS_DEFAULT = "*+@>-";
+    if (hasOption("-p", Names.PROPERTY_TOC)) {
+      String properties = getBooleanProperties(page);
+      if (!properties.isEmpty()) itemText += " " + properties;
+    }
+
+    if (hasOption("-f", Names.FILTER_TOC)) {
+      String filters = page.getProperty(WikiPageProperty.SUITES);
+      if (!filters.isEmpty()) itemText += " (" + filters + ")";
+    }
+
+    return itemText;
+  }
+
+  private String buildReference(SourcePage sourcePage) {
+    return sourcePage.getFullName();
+  }
+
+  private int getRecursionLimit() {
+    String level = contents.findProperty("-R", "0");
+    try {
+      return Integer.parseInt(level);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private boolean hasOption(String option, String variableName) {
+    return contents.hasProperty(option) ||
+      (!variableName.isEmpty()
+        && contents.findProperty(variableName, "").equals("true"));
+  }
+
+  private String getBooleanProperties(SourcePage sourcePage) {
+    String propChars = contents.findProperty(Names.PROPERTY_CHARACTERS,
+      PROPERTY_CHARACTERS_DEFAULT).trim();
+    if (propChars.length() != PROPERTY_CHARACTERS_DEFAULT.length()) {
+      propChars = PROPERTY_CHARACTERS_DEFAULT;
+    }
+
+    String result = "";
+    if (sourcePage.hasProperty(PageType.SUITE.toString())) result += propChars.charAt(0);
+    if (sourcePage.hasProperty(PageType.TEST.toString())) result += propChars.charAt(1);
+    if (sourcePage.hasProperty(WikiImportProperty.PROPERTY_NAME)) result += propChars.charAt(2);
+    if (page != null && page instanceof WikiSourcePage) {
+      if (((WikiSourcePage) page).hasSymbolicLinkChild(sourcePage.getName())) result += propChars.charAt(3);
+    }
+    if (sourcePage.hasProperty(WikiPageProperty.PRUNE)) result += propChars.charAt(4);
+    return result;
+  }
+
+  private String getBooleanPropertiesClasses(SourcePage sourcePage) {
+    String result = "";
+    if (sourcePage.hasProperty(PageType.SUITE.toString())) {
+      result += "suite";
+    } else if (sourcePage.hasProperty(PageType.TEST.toString())) {
+      result += "test";
+    } else {
+      result += "static";
+    }
+    if (sourcePage.hasProperty(WikiImportProperty.PROPERTY_NAME)) result += " linked";
+    if (sourcePage.hasProperty(WikiPageProperty.PRUNE)) result += " pruned";
+    return result;
+  }
+
+  private boolean pageContainsTag(SourcePage page, String tagValue) {
+    if (page.hasProperty("Suites")) {
+      String suitesProperty = page.getProperty("Suites");
+      if (suitesProperty != null && !suitesProperty.isEmpty()) {
+        Set<String> tagsOnPage = Arrays.stream(suitesProperty.split(","))
+          .map(String::trim)
+          .map(String::toLowerCase)
+          .collect(Collectors.toSet());
+        String[] tagsToMatch = tagValue.split(",");
+        for (String tag : tagsToMatch) {
+          if (tagsOnPage.contains(tag.trim().toLowerCase())) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static final String PROPERTY_CHARACTERS_DEFAULT = "*+@>-";
 }


### PR DESCRIPTION
### Summary

This pull request enhances the existing `!contents` directive by adding a new optional argument: `-t`, allowing users to **filter listed pages based on the `Suites` property**.

---

### Motivation
In many projects, the same suite structure is reused across multiple contexts or products (e.g. Product A, Product B). However, some pages are only relevant to a specific product. Until now, there was no way to filter the `!contents` listing dynamically by tag.

This change adds that capability.

---

### New behavior:  `-t` option
You can now use `!contents` like this:

```wiki
!contents -R2 -tProductA