### PR TITLE
Update Apache Commons Lang 3.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   implementation "org.htmlparser:htmlparser:2.1"
   implementation "org.htmlparser:htmllexer:2.1"
   implementation "org.apache.velocity:velocity-engine-core:2.4.1"
-  implementation "org.apache.commons:commons-lang3:3.17.0"
+  implementation "org.apache.commons:commons-lang3:3.18.0"
   implementation "org.slf4j:slf4j-api:2.0.17"
   implementation "org.slf4j:slf4j-jdk14:2.0.17"
   implementation "org.json:json:20250517"


### PR DESCRIPTION
Update Apache Commons Lang to 3.18.0 due to CVE-2025-48924