### PR TITLE
Added some plugins.properties documentation

### DIFF
--- a/plugins.properties
+++ b/plugins.properties
@@ -1,4 +1,67 @@
 ##
+# LogLevel
+#
+# Possible values are: verbose, normal
+# Defaults to 'normal' if not configured.
+#
+#LogLevel=verbose
+
+##
+# Port
+#
+# Defines the port on which FitNesse will run.
+# Defaults to '80' if not configured.
+#
+#Port=8001
+
+##
+# RootPath
+#
+# Working directory.
+# Defaults to '.' if not configured.
+#
+#RootPath=.
+
+##
+# FitNesseRoot
+#
+# Page root directory.
+# Defaults to 'FitNesseRoot' if not configured.
+#
+#FitNesseRoot=FitNesseRoot
+
+##
+# LogDirectory
+#
+# Log directory {no logging}
+# Defaults to 'log' if not configured.
+#
+#LogDirectory=log
+
+##
+# OmittingUpdates
+#
+# Omit Updates
+# Can be either true or false. Defaults to false if not configured.
+#
+#OmittingUpdates=true
+
+##
+#LocalhostOnly
+#
+# Only bind to loopback interface (localhost only access)
+# Can be either true or false. Defaults to false if not configured.
+#
+#LocalhostOnly=true
+
+##
+# MaximumWorkers
+#
+# The maximum number of workers to use to handle incoming requests (must be at least 5).
+# Defaults to '100' if not configured.
+#MaximumWorkers=100
+
+##
 # Theme
 #
 # Themes can be used to customize the look and feel of the wiki.


### PR DESCRIPTION
It is possible to configure FitNesse using only the plugins.properties. So I just added some documentary to the plugins.properties that are mostly used as start parameters.