### PR TITLE
Reworking the refactor page

### DIFF
--- a/plugins.properties
+++ b/plugins.properties
@@ -143,3 +143,12 @@ TestHistory.days=1
 # Having the configuration TestHistory.maxCount enabled at the same time, will limit the range for
 # possible options and automatically set the max value.
 #TestHistory.historyOptions=3,5,10,20
+
+##
+# The Path to start on for the tree selection when refactoring a page.
+# The configured start path is selectable unless the default root path is used.
+# When left empty, starts at the root path.
+# Example values:
+#  Refactor.StartPath=FrontPage
+#  Refactor.StartPath=FitnesseRoot.FitNesse
+#Refactor.StartPath=FitnesseRoot

--- a/src/fitnesse/resources/css/fitnesse_pages.css
+++ b/src/fitnesse/resources/css/fitnesse_pages.css
@@ -342,3 +342,59 @@ span.error {
     display: inline-block;
     padding: 0;
 }
+
+/* Page Tree for Copy and Move Start */
+.form-hint {
+  font-size: 0.9em;
+  color: #666;
+  margin-bottom: 6px;
+}
+
+#pageTreeContainer {
+    border: 1px solid #ccc;
+    height: 400px;
+    width: 100%;
+    overflow-y: auto;
+    overflow-x: auto;
+    padding: 6px;
+    background: #fafafa;
+}
+
+#pageTree {
+    list-style: none;
+    padding-left: 10px;
+    margin: 0;
+}
+
+#pageTree li {
+    cursor: pointer;
+    padding: 2px 4px;
+}
+
+.tree-label.selected {
+    background-color: #cce5ff;
+}
+
+.tree-icon {
+  transition: transform 0.15s ease;
+}
+
+.tree-toggle {
+    display: inline-block;
+    width: 16px;
+}
+
+.tree-toggle.expanded .tree-icon {
+  transform: rotate(90deg);
+}
+
+.tree-child {
+	list-style: none;
+	padding-left: 10px;
+}
+
+.loading {
+    color: #888;
+    font-style: italic;
+}
+/* Page Tree for Copy and Move End */

--- a/src/fitnesse/resources/javascript/refactorForm.js
+++ b/src/fitnesse/resources/javascript/refactorForm.js
@@ -1,0 +1,137 @@
+const selectedLocation = document.getElementById("selectedLocation");
+
+async function loadChildren(path, parentElement) {
+	const loading = document.createElement("div");
+    loading.className = "loading";
+    loading.textContent = "Loading...";
+    parentElement.appendChild(loading);
+	
+    const response = await fetch(
+        "?responder=lazyPageTree&path=" + encodeURIComponent(path)
+    );
+
+    const nodes = await response.json();
+	
+	parentElement.removeChild(loading);
+
+    const ul = document.createElement("ul");
+	ul.classList.add("tree-child");
+
+    nodes.forEach(node => {
+        const li = document.createElement("li");
+        li.dataset.path = node.path;
+        
+		let toggle = null;
+		if (node.hasChildren) {
+			toggle = createToggleIcon();
+			addToggleOnClickListener(toggle, li, node.path);
+		} else {
+			toggle = document.createElement("span");
+			toggle.className = "tree-toggle";
+		}
+
+		const label = document.createElement("span");
+		label.className = "tree-label";
+        label.textContent = node.name;
+
+        label.onclick = function(e) {
+            e.stopPropagation();
+            selectNode(node.path);
+        };
+
+		li.appendChild(toggle);
+        li.appendChild(label);
+
+        ul.appendChild(li);
+    });
+
+    parentElement.appendChild(ul);
+}
+
+function addToggleOnClickListener(toggle, li, path) {
+	// Adding the functionality to load the children for the node when the toggle is clicked
+	toggle.onclick = async function(e) {
+		e.stopPropagation();
+
+		const expanded = toggle.classList.toggle("expanded");
+
+		if (expanded) {
+			if (!li.dataset.loaded) {
+				await loadChildren(path, li);
+				li.dataset.loaded = true;
+			}
+
+			li.querySelector("ul").style.display = "block";
+		} else {
+			li.querySelector("ul").style.display = "none";
+		}
+	};
+}
+
+function selectNode(path) {
+	const selected = document.querySelector(`[data-path="${path}"] .tree-label`);
+	const alreadySelected = selected.classList.contains("selected");
+	
+	document.querySelectorAll(".tree-label").forEach(label =>
+        label.classList.remove("selected")
+    );
+	
+    // Select the node if it was not already selected, otherwise deselect it
+	if (selected && !alreadySelected) {
+		document.getElementById("newLocation").value = path;
+		selected.classList.add("selected");
+		selectedLocation.textContent = path;
+	} else {
+		document.getElementById("newLocation").value = "";
+		selected.classList.remove("selected");
+		selectedLocation.textContent = "";
+	}
+}
+
+function createToggleIcon() {
+	const span = document.createElement("span");
+	span.className = "tree-toggle";
+
+	span.innerHTML = `
+        <svg class="tree-icon" viewBox="0 0 16 16" width="12" height="12">
+            <path d="M4 2 L12 8 L4 14 Z"></path>
+        </svg>
+    `;
+
+    return span;
+}
+
+/**
+ * The root node is created separately since it is should always be expanded and only selectable when not the root page.
+ */
+function createRootNode(path) {
+	const li = document.createElement("li");
+	li.dataset.path = path;
+	
+	const label = document.createElement("span");
+	label.className = "tree-label";
+    label.textContent = path;
+    // We only allow the selection of non-root nodes
+    if ("ROOT" !== path) {
+	    label.onclick = function(e) {
+	        e.stopPropagation();
+	        selectNode(path);
+	    };
+    }
+    
+    li.appendChild(label);
+    
+    return li;
+}
+
+document.addEventListener("DOMContentLoaded", async function () {
+    const tree = document.getElementById("pageTree");
+    const path = document.getElementById("configPath").dataset.path;
+    
+    const rootNode = createRootNode(path);
+    tree.appendChild(rootNode);
+    
+	await loadChildren(path, rootNode);
+	
+	rootNode.dataset.loaded = true;
+});

--- a/src/fitnesse/resources/templates/refactorForm.vm
+++ b/src/fitnesse/resources/templates/refactorForm.vm
@@ -81,13 +81,17 @@
 <form method="get" action="$refactoredRootPage">
  <input type="hidden" name="responder" value="movePage"/>
  <fieldset>
-  <label for="newLocation">New Location:</label>
-  <input type="text" name="newLocation" value="" size="80" class="wikipath" list="suites" placeholder="enter first two chars of suite name here" autocomplete="off" />
-  <datalist id="suites">
-    #foreach ($suiteEntry in $suiteMap)
-        <option value="#escape($suiteEntry)"/>
-    #end
-  </datalist>
+  <div class="d-flex">
+    <label for="newLocation">New Location:</label>
+    <span id="selectedLocation" class="ml-1"></span>
+  </div>
+  <div class="form-hint">
+	Choose the destination page in the tree. Click again to deselect. Configured root path: $rootpath
+  </div>
+  <input type="hidden" name="newLocation" id="newLocation" />
+  <div id="pageTreeContainer">
+	<ul id="pageTree"></ul>
+  </div>
  </fieldset>
  <fieldset>
   <label class="checkbox" for="refactorReferences_move"><input type="checkbox" id="refactorReferences_move" name="refactorReferences"/>Find all references to this page and change them accordingly (May take several minutes)</label>
@@ -97,4 +101,6 @@
   <a class="button" href="$viewLocation">Cancel</a>
  </fieldset>
 </form>
+<div id="configPath" data-path="$rootpath"></div>
+<script type="text/javascript" src="${contextRoot}files/fitnesse/javascript/refactorForm.js"></script>
 #end

--- a/src/fitnesse/responders/ResponderFactory.java
+++ b/src/fitnesse/responders/ResponderFactory.java
@@ -22,6 +22,7 @@ import fitnesse.responders.files.RenameFileConfirmationResponder;
 import fitnesse.responders.files.RenameFileResponder;
 import fitnesse.responders.files.UploadResponder;
 import fitnesse.responders.refactoring.DeletePageResponder;
+import fitnesse.responders.refactoring.LazyPageTreeResponder;
 import fitnesse.responders.refactoring.MovePageResponder;
 import fitnesse.responders.refactoring.RefactorPageResponder;
 import fitnesse.responders.refactoring.RenamePageResponder;
@@ -87,6 +88,7 @@ public class ResponderFactory {
     addResponder("variables", ScopeVariablesResponder.class);
     addResponder("account", AccountResponder.class);
     addResponder("saveAccount", SaveAccountResponder.class);
+    addResponder("lazyPageTree", LazyPageTreeResponder.class);
     // Deprecated:
     addResponder("executeSearchProperties", SearchPropertiesResponder.class);
     addResponder("whereUsed", WhereUsedResponder.class);

--- a/src/fitnesse/responders/refactoring/LazyPageTreeResponder.java
+++ b/src/fitnesse/responders/refactoring/LazyPageTreeResponder.java
@@ -1,0 +1,92 @@
+package fitnesse.responders.refactoring;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import fitnesse.FitNesseContext;
+import fitnesse.authentication.AlwaysSecureOperation;
+import fitnesse.authentication.SecureOperation;
+import fitnesse.authentication.SecureResponder;
+import fitnesse.http.Request;
+import fitnesse.http.Response;
+import fitnesse.http.SimpleResponse;
+import fitnesse.util.StringUtils;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPage;
+import fitnesse.wiki.WikiPagePath;
+
+public class LazyPageTreeResponder implements SecureResponder {
+
+  @Override
+  public Response makeResponse(FitNesseContext context, Request request)
+      throws Exception {
+    String path = request.getInput("path");
+
+    WikiPage page = getPage(context, path);
+
+    List<PageNode> children = buildChildren(page);
+    sortChildren(children);
+
+    StringBuilder json = new StringBuilder("[");
+    children.forEach(pageNode -> {
+      if (json.length() > 1) {
+        json.append(",");
+      }
+      json.append(pageNode.toJsonObject());
+    });
+    json.append("]");
+
+    SimpleResponse response = new SimpleResponse();
+    response.setContentType("application/json");
+    response.setContent(json.toString());
+
+    return response;
+  }
+
+  @Override
+  public SecureOperation getSecureOperation() {
+    return new AlwaysSecureOperation();
+  }
+
+  private static WikiPage getPage(FitNesseContext context, String path) {
+    WikiPage root = context.getRootPage();
+
+    if (StringUtils.isBlank(path) || "ROOT".equalsIgnoreCase(path)) {
+      return root;
+    }
+
+    WikiPagePath wikiPath = PathParser.parse(path);
+    return root.getPageCrawler().getPage(wikiPath);
+  }
+
+  private static List<PageNode> buildChildren(WikiPage page) {
+    List<PageNode> result = new ArrayList<>();
+    
+    if (page == null) {
+      return result;
+    }
+
+    for (WikiPage child : page.getChildren()) {
+      if (child.isSymbolicPage()) {
+        continue;
+      }
+      String fullPath = child.getFullPath().toString();
+      // If every child is a symbolic link we assume the page to not have any
+      // children
+      boolean hasChildren = !child.getChildren().stream()
+          .allMatch(p -> p.isSymbolicPage());
+
+      result.add(new PageNode(child.getName(), fullPath, hasChildren));
+    }
+
+    return result;
+  }
+
+  private static void sortChildren(List<PageNode> children) {
+    children.sort(
+        Comparator.comparing((PageNode n) -> Boolean.valueOf(!n.hasChildren))
+            .thenComparing(n -> n.name.toLowerCase(Locale.getDefault())));
+  }
+}

--- a/src/fitnesse/responders/refactoring/PageNode.java
+++ b/src/fitnesse/responders/refactoring/PageNode.java
@@ -1,0 +1,25 @@
+package fitnesse.responders.refactoring;
+
+public class PageNode {
+  protected String name;
+  protected String path;
+  protected boolean hasChildren;
+
+  public PageNode(String name, String path, boolean hasChildren) {
+    this.name = name;
+    this.path = path;
+    this.hasChildren = hasChildren;
+  }
+
+  public String toJsonObject() {
+    StringBuilder json = new StringBuilder();
+
+    json.append("{");
+    json.append("\"name\":\"").append(name).append("\",");
+    json.append("\"path\":\"").append(path).append("\",");
+    json.append("\"hasChildren\":").append(hasChildren);
+    json.append("}");
+
+    return json.toString();
+  }
+}

--- a/src/fitnesse/responders/refactoring/RefactorPageResponder.java
+++ b/src/fitnesse/responders/refactoring/RefactorPageResponder.java
@@ -6,21 +6,17 @@ import fitnesse.FitNesseContext;
 import fitnesse.authentication.AlwaysSecureOperation;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureResponder;
-import fitnesse.components.TraversalListener;
 import fitnesse.html.template.HtmlPage;
 import fitnesse.html.template.PageTitle;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
-import fitnesse.wiki.NoPruningStrategy;
+import fitnesse.util.StringUtils;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageProperty;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class RefactorPageResponder implements SecureResponder {
 
@@ -49,30 +45,12 @@ public class RefactorPageResponder implements SecureResponder {
     page.put("type", type);
     page.put("viewLocation", request.getResource());
     if ("move".equals(type)) {
-      page.put("suiteMap", collectPageNames(wikiPage, context.getRootPage()));
+      String rootPath = context.getProperty("Refactor.StartPath");
+      page.put("rootpath", StringUtils.isBlank(rootPath) ? "ROOT" : rootPath);
     }
     SimpleResponse response = new SimpleResponse();
     response.setContent(page.html(request));
     return response;
-  }
-
-  List<String> collectPageNames(final WikiPage thisPage, WikiPage rootPage) {
-    final List<String> pageNames = new ArrayList<>();
-    if (thisPage != null) {
-      final WikiPagePath thisPagePath = thisPage.getFullPath();
-      rootPage.getPageCrawler().traverse(new TraversalListener<WikiPage>() {
-
-        @Override
-        public void process(WikiPage page) {
-          WikiPagePath pagePath = page.getFullPath();
-          pagePath.makeAbsolute();
-          if (!thisPagePath.equals(pagePath) && !pagePath.isEmpty()) {
-            pageNames.add(pagePath.toString());
-          }
-        }
-      }, new NoPruningStrategy());
-    }
-    return pageNames;
   }
 
   @Override

--- a/test/fitnesse/responders/refactoring/LazyPageTreeResponderTest.java
+++ b/test/fitnesse/responders/refactoring/LazyPageTreeResponderTest.java
@@ -1,0 +1,88 @@
+package fitnesse.responders.refactoring;
+
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+import fitnesse.Responder;
+import fitnesse.authentication.AlwaysSecureOperation;
+import fitnesse.http.SimpleResponse;
+import fitnesse.responders.ResponderTestCase;
+import fitnesse.wiki.PathParser;
+import fitnesse.wiki.WikiPageUtil;
+import org.junit.Test;
+
+public class LazyPageTreeResponderTest extends ResponderTestCase {
+
+    @Override
+    protected Responder responderInstance() {
+        return new LazyPageTreeResponder();
+    }
+
+    @Test
+    public void testMakeResponseWithRootPath() throws Exception {
+        WikiPageUtil.addPage(root, PathParser.parse("ChildA"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("ChildB"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("ChildB.SubChild"), "content");
+
+        request.addInput("path", "ROOT");
+
+        SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+        // Assert pages with children first, then without children
+        assertThat(response.getContent(), jsonEquals("[{\"name\":\"ChildB\",\"path\":\"ChildB\",\"hasChildren\":true},{\"name\":\"ChildA\",\"path\":\"ChildA\",\"hasChildren\":false}]"));
+    }
+
+    @Test
+    public void testMakeResponseWithSpecificPath() throws Exception {
+        WikiPageUtil.addPage(root, PathParser.parse("SomePage"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("SomePage.SubChild"), "content");
+
+        request.addInput("path", "SomePage");
+
+        SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+        assertThat(response.getContent(), jsonEquals("[{\"name\":\"SubChild\",\"path\":\"SomePage.SubChild\",\"hasChildren\":false}]"));
+    }
+
+    @Test
+    public void testMakeResponseWithoutPath() throws Exception {
+        WikiPageUtil.addPage(root, PathParser.parse("SomePage"), "content");
+
+        request.addInput("path", "");
+
+        SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+        assertThat(response.getContent(), jsonEquals("[{\"name\":\"SomePage\",\"path\":\"SomePage\",\"hasChildren\":false}]"));
+    }
+
+    @Test
+    public void testMakeResponseSorting() throws Exception {
+        WikiPageUtil.addPage(root, PathParser.parse("ZChild"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("ZChild.Sub"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("AChild"), "content");
+        WikiPageUtil.addPage(root, PathParser.parse("BChild"), "content");
+
+        request.addInput("path", "ROOT");
+
+        SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+        // Assert ZChild with children first, then AChild, BChild alphabetically
+        assertThat(response.getContent(), jsonEquals("[{\"name\":\"ZChild\",\"path\":\"ZChild\",\"hasChildren\":true},{\"name\":\"AChild\",\"path\":\"AChild\",\"hasChildren\":false},{\"name\":\"BChild\",\"path\":\"BChild\",\"hasChildren\":false}]"));
+    }
+
+    @Test
+    public void testMakeResponseNonExistentPath() throws Exception {
+        request.addInput("path", "NonExistent");
+
+        SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+        assertThat(response.getContent(), jsonEquals("[]"));
+    }
+
+    @Test
+    public void testGetSecureOperation() {
+        LazyPageTreeResponder responder = new LazyPageTreeResponder();
+        assertThat(responder.getSecureOperation(), instanceOf(AlwaysSecureOperation.class));
+    }
+}

--- a/test/fitnesse/responders/refactoring/RefactorPageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/RefactorPageResponderTest.java
@@ -42,15 +42,22 @@ public class RefactorPageResponderTest extends ResponderTestCase {
   }
 
   @Test
-  public void autoCompleteForMove() throws Exception {
-    WikiPageUtil.addPage(root, PathParser.parse("OtherPage"), "content");
-    WikiPageUtil.addPage(root, PathParser.parse("OtherPage.SubPage"), "content");
+  public void testMoveWithoutStartPath() throws Exception {
+    request.addInput("type", "move");
+    SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
+
+    String content = response.getContent();
+    assertSubString("<div id=\"configPath\" data-path=\"ROOT\"></div>", content);
+  }
+
+  @Test
+  public void testMoveWithStartPath() throws Exception {
+    context.getProperties().put("Refactor.StartPath", "SomeStartPath");
 
     request.addInput("type", "move");
     SimpleResponse response = (SimpleResponse) responder.makeResponse(context, request);
 
     String content = response.getContent();
-    assertSubString("<option value=\".OtherPage\"/>", content);
-    assertSubString("<option value=\".OtherPage.SubPage\"/>", content);
+    assertSubString("<div id=\"configPath\" data-path=\"SomeStartPath\"></div>", content);
   }
 }


### PR DESCRIPTION
I changed the way how a new location is being chosen when moving a page.
The reason for this change was that we had systems with so much test pages, that it took extremely long to open the refactor page since every page will be loaded for the autocomplete.
So a Solution to this was to create a tree structure where the children will be loaded lazily.
Since selecting the new location by clicking on a tree item, this would also prevent any User to select a non existing page.
The starting path for this refactoring is also configurable. For now I set the default to start at ROOT. If it would make sense to start at a different path, I can change that.
Also the starting point is selectable as well, unless it is ROOT.
<img width="1277" height="947" alt="image" src="https://github.com/user-attachments/assets/df3d6de6-e5f8-4e8b-84c7-8a666eac8b8e" />
