### PR TITLE
Deleting versions on page deletion

### DIFF
--- a/src/fitnesse/resources/templates/deletePage.vm
+++ b/src/fitnesse/resources/templates/deletePage.vm
@@ -1,6 +1,11 @@
 <h2>Delete $pageName?</h2>
 <form method="POST">
  <p>Are you sure you want to delete $pageName?</p>
+ <fieldset>
+  <label for="deleteVersions">
+    <input type="checkbox" id="deleteVersions" name="deleteVersions" value="Yes">Delete Versions
+  </label>
+ </fieldset>
  #if( $deleteSubPages )<p class="warning">Warning, this page contains one or more subpages.</p>#end
  <input type="submit" name="confirmed" value="Yes"/>
  <a class="button" href="$pageName" accesskey="n">No</a>

--- a/src/fitnesse/responders/refactoring/DeletePageResponder.java
+++ b/src/fitnesse/responders/refactoring/DeletePageResponder.java
@@ -2,25 +2,32 @@
 // Released under the terms of the CPL Common Public License version 1.0.
 package fitnesse.responders.refactoring;
 
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import fitnesse.FitNesseContext;
 import fitnesse.authentication.AlwaysSecureOperation;
 import fitnesse.authentication.SecureOperation;
 import fitnesse.authentication.SecureResponder;
+import fitnesse.html.template.HtmlPage;
+import fitnesse.html.template.PageTitle;
 import fitnesse.http.Request;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
-import fitnesse.html.template.HtmlPage;
-import fitnesse.html.template.PageTitle;
 import fitnesse.wiki.PageCrawler;
 import fitnesse.wiki.PageData;
 import fitnesse.wiki.PathParser;
+import fitnesse.wiki.VersionInfo;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageProperty;
 import fitnesse.wiki.WikiPageUtil;
-
-import java.io.UnsupportedEncodingException;
-import java.util.List;
+import fitnesse.wiki.fs.WikiFilePage;
+import fitnesse.wiki.fs.ZipFileVersionsController;
 
 public class DeletePageResponder implements SecureResponder {
   private SimpleResponse response;
@@ -48,10 +55,24 @@ public class DeletePageResponder implements SecureResponder {
     } else {
       WikiPage parentOfPageToBeDeleted = context.getRootPage().getPageCrawler().getPage(path);
       if (parentOfPageToBeDeleted != null) {
+        // Versions need to be deleted before the page gets removed
+        String deleteVersions = request.getInput("deleteVersions");
+        deleteVersions("yes".equalsIgnoreCase(deleteVersions), parentOfPageToBeDeleted);
         parentOfPageToBeDeleted.remove();
       }
       path.removeNameFromEnd();
       redirect(path, response);
+    }
+  }
+
+  private void deleteVersions(boolean deleteVersions, WikiPage pageToBeDeleted) {
+    if (deleteVersions && pageToBeDeleted instanceof WikiFilePage) {
+      ZipFileVersionsController versionsController = new ZipFileVersionsController();
+      File fileSystemPath = ((WikiFilePage) pageToBeDeleted).getFileSystemPath();
+      Collection<VersionInfo> history = versionsController.history(
+          Paths.get(fileSystemPath.getPath() + WikiFilePage.FILE_EXTENSION)
+              .toFile());
+      versionsController.deleteVersions(history.stream().collect(Collectors.toList()));
     }
   }
 

--- a/src/fitnesse/wiki/fs/ZipFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/ZipFileVersionsController.java
@@ -258,6 +258,13 @@ public class ZipFileVersionsController implements VersionsController {
       }
     }
   }
+  
+  public void deleteVersions(List<VersionInfo> deletionList) {
+    // When the list is filled everything in it will be deleted
+    for (VersionInfo version : deletionList) {
+      ((ZipFileVersionInfo) version).getFile().delete();
+    }
+  }
 
   private List<VersionInfo> makeSortedVersionList(Collection<VersionInfo> versions) {
     List<VersionInfo> versionsList = new ArrayList<>(versions);

--- a/src/fitnesse/wiki/fs/ZipFileVersionsController.java
+++ b/src/fitnesse/wiki/fs/ZipFileVersionsController.java
@@ -260,7 +260,6 @@ public class ZipFileVersionsController implements VersionsController {
   }
   
   public void deleteVersions(List<VersionInfo> deletionList) {
-    // When the list is filled everything in it will be deleted
     for (VersionInfo version : deletionList) {
       ((ZipFileVersionInfo) version).getFile().delete();
     }

--- a/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
@@ -137,7 +137,7 @@ public class DeletePageResponderTest extends ResponderTestCase {
       MockRequest request = new MockRequest();
       request.setResource("PageToDelete");
       request.addInput("confirmed", "yes");
-      // deleteVersions is not set → Versions should be kept
+      // deleteVersions is not set so Versions should be kept
       new DeletePageResponder().makeResponse(fileSystemContext, request);
 
       // Verify that the version still exists after deletion

--- a/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
+++ b/test/fitnesse/responders/refactoring/DeletePageResponderTest.java
@@ -4,21 +4,29 @@ package fitnesse.responders.refactoring;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static util.RegexTestCase.assertNotSubString;
 import static util.RegexTestCase.assertSubString;
 
+import java.io.File;
 import java.util.List;
 
+import fitnesse.FitNesseContext;
 import fitnesse.Responder;
 import fitnesse.http.MockRequest;
 import fitnesse.http.Response;
 import fitnesse.http.SimpleResponse;
 import fitnesse.responders.ResponderTestCase;
+import fitnesse.testutil.FitNesseUtil;
 import fitnesse.wiki.PathParser;
 import fitnesse.wiki.WikiPage;
 import fitnesse.wiki.WikiPagePath;
 import fitnesse.wiki.WikiPageUtil;
+import fitnesse.wiki.fs.DiskFileSystem;
+import fitnesse.wiki.fs.FileSystemPageFactory;
+import fitnesse.wiki.fs.WikiFilePage;
+import fitnesse.wiki.fs.ZipFileVersionsController;
 import org.junit.Test;
 
 public class DeletePageResponderTest extends ResponderTestCase {
@@ -70,6 +78,75 @@ public class DeletePageResponderTest extends ResponderTestCase {
     Response response = this.responder.makeResponse(context, this.request);
     assertEquals(303, response.getStatus());
     assertEquals("/FrontPage", response.getHeader("Location"));
+  }
+
+  @Test
+  public void testDeletePageWithDeleteVersionsYesDeletesZipFiles() throws Exception {
+    File rootPath = FitNesseUtil.createTemporaryFolder();
+    ZipFileVersionsController versionsController = new ZipFileVersionsController();
+    FileSystemPageFactory fileSystemPageFactory = new FileSystemPageFactory(new DiskFileSystem(), versionsController);
+    FitNesseContext fileSystemContext = FitNesseUtil.makeTestContext(fileSystemPageFactory, rootPath.getPath(), FitNesseUtil.base, FitNesseUtil.PORT);
+
+    try {
+      WikiPage fsRoot = fileSystemContext.getRootPage();
+      WikiFilePage pageToDelete = (WikiFilePage) WikiPageUtil.addPage(fsRoot, PathParser.parse("PageToDelete"), "content");
+      // Create a version of the page
+      pageToDelete.commit(pageToDelete.getData());
+
+      // Verify that the version exists before deletion
+      File pageWikiFile = new File(pageToDelete.getFileSystemPath().getPath() + WikiFilePage.FILE_EXTENSION);
+      File zipDir = pageWikiFile.getParentFile();
+      File[] zipsBefore = zipDir.listFiles(f -> f.getName().endsWith(".zip"));
+      assertTrue("Versions should exist before page deletion", zipsBefore != null && zipsBefore.length > 0);
+
+      MockRequest request = new MockRequest();
+      request.setResource("PageToDelete");
+      request.addInput("confirmed", "yes");
+      request.addInput("deleteVersions", "yes");
+      new DeletePageResponder().makeResponse(fileSystemContext, request);
+
+      // Verify that the version does not exist after deletion
+      File[] zipsAfter = zipDir.listFiles(f -> f.getName().endsWith(".zip"));
+      assertTrue("Versions should not exist anymore after page deletion",
+          zipsAfter == null || zipsAfter.length == 0);
+    } finally {
+      FitNesseUtil.destroyTestContext(fileSystemContext);
+    }
+  }
+
+  @Test
+  public void testDeletePageWithoutDeleteVersionsKeepsZipFiles() throws Exception {
+    File rootPath = FitNesseUtil.createTemporaryFolder();
+    ZipFileVersionsController versionsController = new ZipFileVersionsController();
+    FileSystemPageFactory fileSystemPageFactory = new FileSystemPageFactory(new DiskFileSystem(), versionsController);
+    FitNesseContext fileSystemContext = FitNesseUtil.makeTestContext(fileSystemPageFactory, rootPath.getPath(), FitNesseUtil.base, FitNesseUtil.PORT);
+
+    try {
+      WikiPage fsRoot = fileSystemContext.getRootPage();
+      WikiFilePage pageToDelete = (WikiFilePage) WikiPageUtil.addPage(fsRoot, PathParser.parse("PageToDelete"), "content");
+      // Create a version of the page
+      pageToDelete.commit(pageToDelete.getData());
+
+      // Verify that the version exists before deletion
+      File pageWikiFile = new File(pageToDelete.getFileSystemPath().getPath() + WikiFilePage.FILE_EXTENSION);
+      File zipDir = pageWikiFile.getParentFile();
+      File[] zipsBefore = zipDir.listFiles(f -> f.getName().endsWith(".zip"));
+      assertTrue("Versions should exist before page deletion", zipsBefore != null && zipsBefore.length > 0);
+      int zipCountBefore = zipsBefore.length;
+
+      MockRequest request = new MockRequest();
+      request.setResource("PageToDelete");
+      request.addInput("confirmed", "yes");
+      // deleteVersions is not set → Versions should be kept
+      new DeletePageResponder().makeResponse(fileSystemContext, request);
+
+      // Verify that the version still exists after deletion
+      File[] zipsAfter = zipDir.listFiles(f -> f.getName().endsWith(".zip"));
+      assertNotNull("Versions should still exist after page deletion", zipsAfter);
+      assertEquals("Number of ZIP version files should remain unchanged", zipCountBefore, zipsAfter.length);
+    } finally {
+      FitNesseUtil.destroyTestContext(fileSystemContext);
+    }
   }
 
   @Override


### PR DESCRIPTION
When a page gets deleted, it does not delete the corresponding versions. That could lead to a lot of unnecessary versions.
So I added a Checkbox to select if versions should be deleted.